### PR TITLE
improve dataset build workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,8 @@
 				"ms-python.vscode-pylance",
 				"mtxr.sqltools",
 				"mtxr.sqltools-driver-pg",
-				"ms-toolsai.jupyter"
+				"ms-toolsai.jupyter",
+				"redhat.vscode-yaml"
 			]
 		}
 	},

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
         description: "A short note about this build (optional)"
         type: string
         required: false
-      do_export:
+      will_export:
         description: "Export build outputs"
         type: boolean
         required: true
@@ -36,7 +36,7 @@ jobs:
     with:
       logging_level: ${{ inputs.LOGGING_LEVEL }}
       build_note: ${{ inputs.BUILD_NOTE }}
-      do_export: ${{ inputs.DO_EXPORT }}
+      will_export: ${{ inputs.will_export }}
   cbbr:
     if: inputs.dataset_name == 'cbbr'
     uses: ./.github/workflows/cbbr_build.yml
@@ -44,4 +44,4 @@ jobs:
     with:
       logging_level: ${{ inputs.LOGGING_LEVEL }}
       build_note: ${{ inputs.BUILD_NOTE }}
-      do_export: ${{ inputs.DO_EXPORT }}
+      will_export: ${{ inputs.will_export }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,5 @@ jobs:
     uses: ./.github/workflows/pluto_build.yml
     secrets: inherit
     with:
-      logging_level: ${{ inputs.logging_level }}
       minor_version: true
       run_export: ${{ inputs.will_export }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
         options:
           - template
           - cbbr
+          - pluto
       logging_level:
         description: "Logging level"
         type: choice
@@ -54,3 +55,11 @@ jobs:
       logging_level: ${{ inputs.logging_level }}
       build_note: ${{ inputs.build_note }}
       will_export: ${{ inputs.will_export }}
+  pluto:
+    if: inputs.dataset_name == 'pluto'
+    uses: ./.github/workflows/pluto_build.yml
+    secrets: inherit
+    with:
+      logging_level: ${{ inputs.logging_level }}
+      minor_version: true
+      run_export: ${{ inputs.will_export }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
         required: true
         options:
           - template
+          - cbbr
       logging_level:
         description: "Logging level"
         type: choice
@@ -29,6 +30,14 @@ on:
         default: false
 
 jobs:
+  health_check:
+    name: Health Check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check inputs
+        run: |
+          echo "Githubt aciton inputs are:"
+          echo "${{ toJSON(github.event.inputs) }}"
   template:
     if: inputs.dataset_name == 'template'
     uses: ./.github/workflows/template_build.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,5 +60,4 @@ jobs:
     uses: ./.github/workflows/pluto_build.yml
     secrets: inherit
     with:
-      # minor_version: true
       run_export: ${{ inputs.will_export }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,20 +28,25 @@ on:
         type: string
         required: false
 
+env:
+  DO_EXPORT: ${{ inputs.do_export }}
+  LOGGING_LEVEL: ${{ inputs.logging_level }}
+  BUILD_NOTE: ${{ inputs.build_note }}
+
 jobs:
   template:
     if: inputs.dataset_name == 'template'
     uses: ./.github/workflows/template_build.yml
     secrets: inherit
     with:
-      do_export: ${{ inputs.do_export }}
-      logging_level: ${{ inputs.logging_level }}
-      build_note: ${{ inputs.build_note }}
+      do_export: ${{ env.DO_EXPORT }}
+      logging_level: ${{ env.LOGGING_LEVEL }}
+      build_note: ${{ env.BUILD_NOTE }}
   cbbr:
     if: inputs.dataset_name == 'cbbr'
     uses: ./.github/workflows/cbbr_build.yml
     with:
-      do_export: ${DO_EXPORT}
-      build_note: ${BUILD_NOTE}
-      logging_level: ${LOGGING_LEVEL}
+      do_export: ${{ env.DO_EXPORT }}
+      logging_level: ${{ env.LOGGING_LEVEL }}
+      build_note: ${{ env.BUILD_NOTE }}
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,14 @@ jobs:
     uses: ./.github/workflows/template_build.yml
     secrets: inherit
     with:
-      logging_level: ${{ inputs.LOGGING_LEVEL }}
-      build_note: ${{ inputs.BUILD_NOTE }}
+      logging_level: ${{ inputs.logging_level }}
+      build_note: ${{ inputs.build_note }}
       will_export: ${{ inputs.will_export }}
   cbbr:
     if: inputs.dataset_name == 'cbbr'
     uses: ./.github/workflows/cbbr_build.yml
     secrets: inherit
     with:
-      logging_level: ${{ inputs.LOGGING_LEVEL }}
-      build_note: ${{ inputs.BUILD_NOTE }}
+      logging_level: ${{ inputs.logging_level }}
+      build_note: ${{ inputs.build_note }}
       will_export: ${{ inputs.will_export }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,5 +60,5 @@ jobs:
     uses: ./.github/workflows/pluto_build.yml
     secrets: inherit
     with:
-      minor_version: true
+      # minor_version: true
       run_export: ${{ inputs.will_export }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,11 @@ on:
 jobs:
   health_check:
     name: Health Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check inputs
         run: |
-          echo "Githubt aciton inputs are:"
+          echo "Workflow inputs are:"
           echo "${{ toJSON(github.event.inputs) }}"
   template:
     if: inputs.dataset_name == 'template'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,6 @@ on:
         required: true
         options:
           - template
-      do_export:
-        description: "Export build outputs"
-        type: boolean
-        required: true
-        default: false
       logging_level:
         description: "Logging level"
         type: choice
@@ -27,6 +22,11 @@ on:
         description: "A short note about this build (optional)"
         type: string
         required: false
+      do_export:
+        description: "Export build outputs"
+        type: boolean
+        required: true
+        default: false
 
 jobs:
   template:
@@ -34,14 +34,14 @@ jobs:
     uses: ./.github/workflows/template_build.yml
     secrets: inherit
     with:
-      do_export: ${{ inputs.DO_EXPORT }}
       logging_level: ${{ inputs.LOGGING_LEVEL }}
       build_note: ${{ inputs.BUILD_NOTE }}
+      do_export: ${{ inputs.DO_EXPORT }}
   cbbr:
     if: inputs.dataset_name == 'cbbr'
     uses: ./.github/workflows/cbbr_build.yml
     secrets: inherit
     with:
-      do_export: ${{ inputs.DO_EXPORT }}
       logging_level: ${{ inputs.LOGGING_LEVEL }}
       build_note: ${{ inputs.BUILD_NOTE }}
+      do_export: ${{ inputs.DO_EXPORT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
         options:
           - template
       do_export:
-        description: "Whether to export build outputs"
+        description: "Export build outputs"
         type: boolean
         required: true
         default: false
@@ -28,25 +28,20 @@ on:
         type: string
         required: false
 
-env:
-  DO_EXPORT: ${{ inputs.do_export }}
-  LOGGING_LEVEL: ${{ inputs.logging_level }}
-  BUILD_NOTE: ${{ inputs.build_note }}
-
 jobs:
   template:
     if: inputs.dataset_name == 'template'
     uses: ./.github/workflows/template_build.yml
     secrets: inherit
     with:
-      do_export: ${{ env.DO_EXPORT }}
-      logging_level: ${{ env.LOGGING_LEVEL }}
-      build_note: ${{ env.BUILD_NOTE }}
+      do_export: ${{ inputs.DO_EXPORT }}
+      logging_level: ${{ inputs.LOGGING_LEVEL }}
+      build_note: ${{ inputs.BUILD_NOTE }}
   cbbr:
     if: inputs.dataset_name == 'cbbr'
     uses: ./.github/workflows/cbbr_build.yml
-    with:
-      do_export: ${{ env.DO_EXPORT }}
-      logging_level: ${{ env.LOGGING_LEVEL }}
-      build_note: ${{ env.BUILD_NOTE }}
     secrets: inherit
+    with:
+      do_export: ${{ inputs.DO_EXPORT }}
+      logging_level: ${{ inputs.LOGGING_LEVEL }}
+      build_note: ${{ inputs.BUILD_NOTE }}

--- a/.github/workflows/cbbr_build.yml
+++ b/.github/workflows/cbbr_build.yml
@@ -3,15 +3,15 @@ name: CBBR - 🏗️ Build
 on:
   workflow_call:
     inputs:
-      do_export:
-        type: boolean
-        required: true
       logging_level:
         type: string
         required: true
       build_note:
         type: string
         required: false
+      will_export:
+        type: boolean
+        required: true
 
 jobs:
   build:
@@ -74,9 +74,9 @@ jobs:
       - name: Export CBBR Output to DO (edm-publishing)
         working-directory: db-cbbr/cbbr_build
         run: ./04_export.sh
-        if: inputs.do_export == true
+        if: inputs.will_export == true
 
       - name: Archive CBBR to EDM-DATA
         working-directory: db-cbbr/cbbr_build
         run: ./05_archive.sh
-        if: inputs.do_export == true
+        if: inputs.will_export == true

--- a/.github/workflows/cbbr_build.yml
+++ b/.github/workflows/cbbr_build.yml
@@ -74,9 +74,9 @@ jobs:
       - name: Export CBBR Output to DO (edm-publishing)
         working-directory: db-cbbr/cbbr_build
         run: ./04_export.sh
-        if: inputs.will_export == true
+        if: inputs.will_export
 
       - name: Archive CBBR to EDM-DATA
         working-directory: db-cbbr/cbbr_build
         run: ./05_archive.sh
-        if: inputs.will_export == true
+        if: inputs.will_export

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -3,19 +3,11 @@ name: PLUTO - 🏗️ Build
 on:
   workflow_call:
     inputs:
-      # minor_version:
-      #   type: boolean
-      #   required: true
       run_export:
         type: boolean
         required: true
   workflow_dispatch:
     inputs:
-      # minor_version:
-      #   description: "Run minor version build"
-      #   type: boolean
-      #   required: true
-      #   default: false
       run_export:
         description: "Run Export Step and Upload to DO"
         type: boolean
@@ -26,20 +18,20 @@ jobs:
     name: get version
     runs-on: ubuntu-22.04
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      is_minor_version: ${{ steps.minor_version.outputs.is_minor_version }}
+      version: ${{ steps.get_version.outputs.version }}
+      is_minor_version: ${{ steps.check_minor_version.outputs.is_minor_version }}
     steps:
       - uses: actions/checkout@v3
 
       - name: Get Version
-        id: version
+        id: get_version
         working-directory: ./db-pluto/pluto_build
         run: |
           source version.env
           echo "::set-output name=version::$VERSION"
           echo "Version is $VERSION"
       - name: Check for minor version
-        id: minor_version
+        id: check_minor_version
         working-directory: ./db-pluto/pluto_build
         run: |
           source version.env

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -3,26 +3,55 @@ name: PLUTO - 🏗️ Build
 on:
   workflow_call:
     inputs:
-      minor_version:
-        type: boolean
-        required: true
+      # minor_version:
+      #   type: boolean
+      #   required: true
       run_export:
         type: boolean
         required: true
   workflow_dispatch:
     inputs:
-      minor_version:
-        description: "Run minor version build"
-        type: boolean
-        required: true
-        default: false
+      # minor_version:
+      #   description: "Run minor version build"
+      #   type: boolean
+      #   required: true
+      #   default: false
       run_export:
         description: "Run Export Step and Upload to DO"
         type: boolean
         required: true
         default: false
 jobs:
+  version:
+    name: get version
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_minor_version: ${{ steps.minor_version.outputs.is_minor_version }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get Version
+        id: version
+        run: |
+          source pluto_build/version.env
+          echo "::set-output name=version::$VERSION"
+          echo "Version is $VERSION"
+      - name: Check for minor version
+        id: minor_version
+        run: |
+          source pluto_build/version.env
+          SUBSTRING='.'
+
+          if grep -q "$SUB" <<< "$STR"
+          then
+            echo "::set-output name=is_minor_version::true"
+          else
+            echo "::set-output name=is_minor_version::false"
+          fi
+          echo "is_minor_version is $VERSION"
   build:
+    needs: [version]
     runs-on: ubuntu-22.04
     container: ghcr.io/osgeo/gdal:ubuntu-small-3.6.4
     services:
@@ -56,13 +85,13 @@ jobs:
         shell: bash
         working-directory: ./db-pluto/pluto_build
         run: ./01_dataloading.sh
-        if: inputs.minor_version == false
+        if: needs.version.outputs.is_minor_version == false
 
       - name: dataloading (minor) ..
         shell: bash
         working-directory: ./db-pluto/pluto_build
         run: ./01_dataloading_minor.sh
-        if: inputs.minor_version == true
+        if: needs.version.outputs.is_minor_version == true
 
       - name: building ...
         shell: bash

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -33,17 +33,19 @@ jobs:
 
       - name: Get Version
         id: version
+        working-directory: ./db-pluto/pluto_build
         run: |
-          source pluto_build/version.env
+          source version.env
           echo "::set-output name=version::$VERSION"
           echo "Version is $VERSION"
       - name: Check for minor version
         id: minor_version
+        working-directory: ./db-pluto/pluto_build
         run: |
-          source pluto_build/version.env
+          source version.env
           SUBSTRING='.'
 
-          if grep -q "$SUB" <<< "$STR"
+          if grep -q "$SUBSTRING" <<< "$VERSION"
           then
             echo "::set-output name=is_minor_version::true"
           else

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -48,10 +48,10 @@ jobs:
           if grep -q "$SUBSTRING" <<< "$VERSION"
           then
             echo "::set-output name=is_minor_version::true"
-            echo "$VERSION is a major version"
+            echo "$VERSION is a minor version"
           else
             echo "::set-output name=is_minor_version::false"
-            echo "$VERSION is a minor version"
+            echo "$VERSION is a major version"
           fi
   build:
     needs: [version]

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -1,6 +1,14 @@
 name: PLUTO - 🏗️ Build
 
 on:
+  workflow_call:
+    inputs:
+      minor_version:
+        type: boolean
+        required: true
+      run_export:
+        type: boolean
+        required: true
   workflow_dispatch:
     inputs:
       minor_version:

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -48,10 +48,11 @@ jobs:
           if grep -q "$SUBSTRING" <<< "$VERSION"
           then
             echo "::set-output name=is_minor_version::true"
+            echo "$VERSION is a major version"
           else
             echo "::set-output name=is_minor_version::false"
+            echo "$VERSION is a minor version"
           fi
-          echo "is_minor_version is $VERSION"
   build:
     needs: [version]
     runs-on: ubuntu-22.04
@@ -87,13 +88,13 @@ jobs:
         shell: bash
         working-directory: ./db-pluto/pluto_build
         run: ./01_dataloading.sh
-        if: needs.version.outputs.is_minor_version == false
+        if: needs.version.outputs.is_minor_version == 'false'
 
       - name: dataloading (minor) ..
         shell: bash
         working-directory: ./db-pluto/pluto_build
         run: ./01_dataloading_minor.sh
-        if: needs.version.outputs.is_minor_version == true
+        if: needs.version.outputs.is_minor_version == 'true'
 
       - name: building ...
         shell: bash

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -3,15 +3,15 @@ name: Template - Build
 on:
   workflow_call:
     inputs:
-      do_export:
-        type: boolean
-        required: true
       logging_level:
         type: string
         required: true
       build_note:
         type: string
         required: false
+      will_export:
+        type: boolean
+        required: true
 
 env:
   LOGGING_LEVEL: ${{ inputs.logging_level }}
@@ -81,6 +81,6 @@ jobs:
 
       - name: 5) Export for production
         working-directory: db-template
-        if: inputs.do_export
+        if: inputs.will_export
         run: |
           echo "PLACEHOLDER running Export for production"

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -12,6 +12,7 @@ on:
       build_note:
         type: string
         required: false
+
 env:
   LOGGING_LEVEL: ${{ inputs.logging_level }}
   BUILD_ENGINE: postgresql://postgres:postgres@localhost:5432/postgres
@@ -37,13 +38,14 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
-      - name: Inputs check
+      - name: Check inputs
         working-directory: db-template
         run: |
           python --version
           echo "Hello build note: ${{ inputs.build_note }}"
           echo "Hello logging level: ${{ inputs.logging_level }} (directly from action inputs)"
           echo "Hello logging level: $LOGGING_LEVEL (from envar from action inputs)"
+          echo "Running python.run_logging ..."
           python -m python.run_logging
 
       - name: Setup python

--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -50,7 +50,7 @@ jobs:
     name: Build test run
     uses: ./.github/workflows/template_build.yml
     with:
-      do_export: false
+      will_export: false
       logging_level: DEBUG
       build_note: a test build
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           filters: |
             template:
+              - .github/workflows/tests.yml
+              - .github/workflows/build.yml
               - db-template/**
             cbbr:
               - db-cbbr/**

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# data-engineering
-Primary repository for NYC DCP's Data Engineering team
+# Data Engineering Team
+
+This is the primary repository for NYC DCP's Data Engineering team and is used to build data products.
+
+The [Data Engineering wiki page](https://github.com/NYCPlanning/data-engineering/wiki) is the single source of truth for all of our documentation.


### PR DESCRIPTION
resolves #12 
follow-up to PR #19 

changes
- finish adding CBBR build in centralized build workflow
- add PLUTO build to centralized build workflow
- remove the "is a minor release build" input to PLUTO build
  - by using the version set in `version.env` to infer whether it's a major or minor release
- ensure changes to the centralized github action files (`build.yml`, `tests.yml`) trigger the Template Datasets tests
- add dev container extension for formatting yaml files

tests
- [pluto build](https://github.com/NYCPlanning/data-engineering/actions/runs/5327347377) w/o exporting