### PR TITLE
build pluto 23v2

### DIFF
--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -15,7 +15,7 @@ on:
         default: false
 jobs:
   version:
-    name: get version
+    name: check version
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get Version
+      - name: Check Version
         id: get_version
         working-directory: ./db-pluto/pluto_build
         run: |
@@ -35,9 +35,9 @@ jobs:
         working-directory: ./db-pluto/pluto_build
         run: |
           source version.env
-          SUBSTRING='.'
+          SUBSTRING="."
 
-          if grep -q "$SUBSTRING" <<< "$VERSION"
+          if [[ "$VERSION" =~ .*"$SUBSTRING".* ]];
           then
             is_minor_version=true
             echo "$VERSION is a minor version"
@@ -53,7 +53,7 @@ jobs:
       run:
         shell: bash
         working-directory: ./db-pluto/pluto_build
-    container: 
+    container:
       image: nycplanning/build-base:latest
     env:
       BUILD_ENGINE: postgresql://postgres:postgres@postgis:5432/postgres
@@ -71,7 +71,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-          --shm-size=2gb
+          --shm-size=4gb
         ports:
           - 5432:5432
     steps:
@@ -81,6 +81,13 @@ jobs:
         run: |
           echo "is_minor: ${{ needs.version.outputs.is_minor_version }}"
           ../../bash/docker_container_setup.sh
+
+      - name: clean out shared libs
+        run: |
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+          rm -rf "/usr/local/share/boost"
+          rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: dataloading (major) ..
         run: ./01_dataloading.sh

--- a/db-pluto/pluto_build/06_export.sh
+++ b/db-pluto/pluto_build/06_export.sh
@@ -2,6 +2,10 @@
 source ./bash/config.sh
 set_error_traps
 
+echo "Vacuuming build DB"
+# NOTE in the future may need to drop big tables (dof_dtm, pluto_input_cama_dof, pluto_input_geocodes)
+run_sql_command "VACUUM (FULL, ANALYZE, VERBOSE)"
+
 mkdir -p output
 cd output
     
@@ -19,6 +23,8 @@ csv_export source_data_versions
 
 echo "Exporting gdbs and shapefiles"
 
+# DEV section start: low disk space
+
 # mappluto.gdb
 fgdb_export_pluto mappluto_gdb &
 
@@ -30,6 +36,8 @@ shp_export_pluto mappluto MULTIPOLYGON &
 
 # mappluto_unclipped
 shp_export_pluto mappluto_unclipped MULTIPOLYGON &
+
+# DEV section end: low disk space
 
 wait
 echo "Exporting pluto csv"

--- a/db-pluto/pluto_build/version.env
+++ b/db-pluto/pluto_build/version.env
@@ -1,13 +1,15 @@
 # PLUTO versions for latest release
-VERSION=23v1.2
-VERSION_PREV=23v1.1
+VERSION=23v2
+VERSION_PREV=23v1.2
 
-# input data versions for latests minor release
+# input data versions for all release types
+GEOSUPPORT_CITYCOUNCIL=22c
+
+# input data versions for minor release only
 DOF_WEEKLY_DATA_VERSION=20230320
 DOF_CAMA_DATA_VERSION=20230315
 
 GEOSUPPORT_VERSION=23a
-GEOSUPPORT_CITYCOUNCIL=22c
 FEMA_FIRPS_VERSION=20181219
 DOITT_DATA_VERSION=20180910
 DOF_DATA_VERSION=20230321


### PR DESCRIPTION
resolves https://github.com/NYCPlanning/edm-overview/issues/935

## changes
- update `version.env`
- fix build action to minor vs major release version is determined
- ensure build action doesn't run out of disk space

## notes
- [latest successful build](https://github.com/NYCPlanning/data-engineering/actions/runs/5647240804)
- the build action seems to run out of space space during `06_export.sh` while exporting GDB and SHP files
  - may have fixed this by deleting unused github action runner files ([reference](https://github.com/actions/runner-images/issues/2840#issuecomment-790492173)) and running `VACUUM (FULL, ANALYZE, VERBOSE)` at the start of `06_export.sh`