### PR TITLE
PLUTO: create subfolders for zipped exports

### DIFF
--- a/db-pluto/pluto_build/06_export.sh
+++ b/db-pluto/pluto_build/06_export.sh
@@ -10,9 +10,9 @@ cd output
 echo "version: ${VERSION}" > version.txt
 echo "date: ${DATE}" >> version.txt
 # csv_export ${BUILD-ENGINE} pluto_changes
-csv_export ${BUILD-ENGINE} pluto_removed_records
-csv_export ${BUILD-ENGINE} pluto_changes_not_applied
-csv_export ${BUILD-ENGINE} pluto_changes_applied
+csv_export pluto_removed_records
+csv_export pluto_changes_not_applied
+csv_export pluto_changes_applied
 zip pluto_changes.zip *
 ls | grep -v pluto_changes.zip | xargs rm
 

--- a/db-pluto/pluto_build/06_export.sh
+++ b/db-pluto/pluto_build/06_export.sh
@@ -26,10 +26,10 @@ fgdb_export_pluto mappluto_gdb &
 fgdb_export_pluto mappluto_unclipped_gdb &
 
 # mappluto
-shp_export mappluto MULTIPOLYGON &
+shp_export_pluto mappluto MULTIPOLYGON &
 
 # mappluto_unclipped
-shp_export mappluto_unclipped MULTIPOLYGON &
+shp_export_pluto mappluto_unclipped MULTIPOLYGON &
 
 # Pluto
 mkdir -p pluto &&

--- a/db-pluto/pluto_build/bin/config.sh
+++ b/db-pluto/pluto_build/bin/config.sh
@@ -30,9 +30,10 @@ function shp_export_pluto {
 
 function fgdb_export_pluto {
     local filename=${1}
-    mkdir ${filename}
+    local foldername=${filename}.gdb
+    mkdir ${foldername}
     (
-        cd ${filename}
+        cd ${foldername}
         fgdb_export_partial ${filename} MULTIPOLYGON ${filename} ${filename}
         fgdb_export_partial ${filename} NONE NOT_MAPPED_LOTS unmapped -update
         fgdb_export_cleanup ${filename}


### PR DESCRIPTION
When I moved over to "common" functionality, changed the folder structure slightly for pluto. Reverting to original. 

See https://cloud.digitalocean.com/spaces/edm-publishing?path=db-pluto%2F23v1.2%2Flatest%2Foutput%2F (shared logic)

vs

https://cloud.digitalocean.com/spaces/edm-publishing?path=db-pluto%2F23v1.1%2Flatest%2Foutput%2F

Build successful - see outputs in latest build

<img width="284" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/a52b3999-bac0-4c8b-9aaa-659378f8e8c2">

vs last stable version before monorepo

<img width="808" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/046370bb-d1d9-416a-b1cb-184a0697188c">