### PR TITLE
fix pluto cli path

### DIFF
--- a/db-pluto/pluto_build/pluto
+++ b/db-pluto/pluto_build/pluto
@@ -16,7 +16,7 @@ fi
 
 # resolve path to this file (following symlinks) and load libs
 BASEDIR=$( dirname $( ${CMD_READLINK} -f "${BASH_SOURCE[0]}" ) )
-for f in ${BASEDIR}/bin/cli.sh ${BASEDIR}/bin/* ; do source $f; done
+for f in ${BASEDIR}/bash/cli.sh ${BASEDIR}/bash/* ; do source $f; done
 
 # cli runner
 cli "$@"


### PR DESCRIPTION
## issues
- all 3 scheduled Pluto github actions are failing ([Number of Buildings](https://github.com/NYCPlanning/data-engineering/actions/runs/5508483115), [CAMA](https://github.com/NYCPlanning/data-engineering/actions/runs/5508478717), [PTS](https://github.com/NYCPlanning/data-engineering/actions/runs/5508450835))
- `data-engineering/db-pluto/pluto_build/bin/cli.sh: No such file or directory`

## changes
- fix hard-coded path in `db-pluto/pluto_build/puto`

## tests
- [successful run of Number of Buildings](https://github.com/NYCPlanning/data-engineering/actions/runs/5510988233) on this branch