### PR TITLE
Checkbook NYC: add placeholder build scripts

### DIFF
--- a/db-checkbook/README.md
+++ b/db-checkbook/README.md
@@ -1,12 +1,47 @@
 # Checkbook NYC Exploratory Work and Join to CPDB
 
-## To do:
-- upload relevant Checkbook NYC data to Digital Ocean
-- write the code to pull down data from Digital Ocean
-- Dea and Ali make their own branches and start working on smallest units of extractable code from our original notebooks, checking it into our projects, implementing, then submitting PR
-- put data manipulation steps into sequential files, mimicing terminology of facdb (i.e. 01_dataloading.py, 02_build.py, etc)
-- make a data product-level requirements doc if needed, and update top-level requirements doc (requirements.in) in monorepo with python modules that are generally applicable to the team's work
+## Overview
 
-## Eventually to do: 
-- (eventually) add recipe for updating Checkbook NYC data from website 
-- upload final data to `edm-publishing` on S3 at the end
+...
+
+## Data sources
+
+- NYC Office of the Comptroller Checkbook NYC
+- DCP Capital Project DB
+
+> Note: All source data is in our DigitalOcean S3 storage in the `edm-recipes` bucket
+
+## Build instructions (locally only)
+
+1. Clone the repo and create `.env`
+
+2. Open the repo in the defined devcontainer in VS code
+
+3. Intall python packages
+
+    ```bash
+    ./bash/install_python_packages.sh python
+    ```
+
+    > Note: This is only necessary if devcontainer does not have necessary packages installed already. This can be checked first via `pip list`.
+
+4. Run the following command(s) from a terminal
+
+    ```bash
+    ./db-checkbook/checkbook.sh
+    ```
+
+    > 🚧 This is a work-in-progress and doesn't build the data product yet
+
+## Todo
+
+- [ ] upload relevant Checkbook NYC source data to Digital Ocean
+- [ ] write the code to pull down data from Digital Ocean
+- [ ] Dea and Ali make their own branches and start working on smallest units of extractable code from our original notebooks, checking it into our projects, implementing, then submitting PR
+- [ ] put data manipulation steps into sequential files, mimicking terminology of facdb (i.e. 01_dataloading.py, 02_build.py, etc)
+- [ ] make a data product-level requirements doc if needed, and update top-level requirements doc (requirements.in) in monorepo with python modules that are generally applicable to the team's work
+- [ ] upload final data to `edm-publishing` on S3 at the end
+
+## Eventually todo
+
+- [ ] (eventually) add recipe for updating Checkbook NYC data from website

--- a/db-checkbook/build_scripts/01_dataloading.py
+++ b/db-checkbook/build_scripts/01_dataloading.py
@@ -4,9 +4,12 @@ from dcpy.connectors.s3 import client
 def do_stuff() -> None:
     print("doing stuff")
     s3_client = client()
-    available_buckets = [bucket["Name"] for bucket in s3_client.list_buckets()["Buckets"]]
+    available_buckets = [
+        bucket["Name"] for bucket in s3_client.list_buckets()["Buckets"]
+    ]
     print(f"This S3 client is a {type(s3_client)}")
     print(f"This S3 client has access to buckets: {available_buckets}")
+
 
 if __name__ == "__main__":
     print("started dataloading ...")

--- a/db-checkbook/build_scripts/01_dataloading.py
+++ b/db-checkbook/build_scripts/01_dataloading.py
@@ -1,0 +1,13 @@
+from dcpy.connectors.s3 import client
+
+
+def do_stuff() -> None:
+    print("doing stuff")
+    s3_client = client()
+    available_buckets = [bucket["Name"] for bucket in s3_client.list_buckets()["Buckets"]]
+    print(f"This S3 client is a {type(s3_client)}")
+    print(f"This S3 client has access to buckets: {available_buckets}")
+
+if __name__ == "__main__":
+    print("started dataloading ...")
+    do_stuff()

--- a/db-checkbook/build_scripts/02_build.py
+++ b/db-checkbook/build_scripts/02_build.py
@@ -1,0 +1,5 @@
+import pandas as pd
+
+
+if __name__ == "__main__":
+    print("started build ...")

--- a/db-checkbook/build_scripts/03_export.py
+++ b/db-checkbook/build_scripts/03_export.py
@@ -1,0 +1,5 @@
+from dcpy.connectors.s3 import client
+
+
+if __name__ == "__main__":
+    print("started export ...")

--- a/db-checkbook/checkbook.sh
+++ b/db-checkbook/checkbook.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Builds db-checkbook
+
+# import bash utils
+FILE_DIR=$(dirname "$(readlink -f "$0")")
+source $FILE_DIR/../bash/utils.sh
+# ensure script exits whent there's an error
+set_error_traps
+
+echo "started building db-checkbook ..."
+
+python3 -m db-checkbook.build_scripts.01_dataloading
+python3 -m db-checkbook.build_scripts.02_build
+python3 -m db-checkbook.build_scripts.03_export
+
+echo "done building db-checkbook!"


### PR DESCRIPTION
related to https://github.com/NYCPlanning/edm-overview/issues/819

## changes
- add placeholder build scripts for the Historical Checkbook NYC build pipeline
- expand the README

## notes
- this is to kickoff an approach to combining the existing code for loading source data, transforming it, and exporting it. that code either already exists in Jupyter notebooks or doesn't exists yet
- the bash script `checkbook.sh` was not necessary but seemed worth mimicking the approaches in most of our build pipelines
- README diffs aren't the best, so here's the preview of how the README would actually look: [link](https://github.com/NYCPlanning/data-engineering/blob/checkbook-build-scaffold/db-checkbook/README.md)