### PR TITLE
Use sys.path to make `dcpy` accessible to python

### DIFF
--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -21,6 +21,7 @@ jobs:
     defaults:
       run:
         shell: bash
+        working-directory: ./db-facilities
     container:
       image: nycplanning/build-geosupport:latest
       env:
@@ -46,30 +47,30 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run Container Setup
+        working-directory: ./
         run: ./bash/docker_container_setup.sh
 
       - name: Install python deps
+        working-directory: ./
         run: pip install -r ./python/requirements.txt
 
       - name: Initialize
-        run: python -m db-facilities.facdb.cli init
+        run: python -m facdb.cli init
 
       - name: Dataloading
-        run: python -m db-facilities.facdb.cli dataloading
+        run: python -m facdb.cli dataloading
 
       - name: Run Pipelines
-        run: python -m db-facilities.facdb.cli run --all
+        run: python -m facdb.cli run --all
 
       - name: Build facdb
-        run: python -m db-facilities.facdb.cli build
+        run: python -m facdb.cli build
 
       - name: QAQC facdb
-        run: python -m db-facilities.facdb.cli qaqc
+        run: python -m facdb.cli qaqc
 
       - name: Export facdb
-        working-directory: ./db-facilities
         run: ./facdb.sh export
 
       - name: Upload Artifacts
-        working-directory: ./db-facilities
         run: ./facdb.sh upload

--- a/db-facilities/facdb/__init__.py
+++ b/db-facilities/facdb/__init__.py
@@ -1,17 +1,22 @@
 import os
+import sys
 from pathlib import Path
 from dotenv import dotenv_values
 
 
 _module_top_path = Path(__file__).resolve().parent
-_config = dotenv_values(_module_top_path.parent / "version.env")
+_product_path = _module_top_path.parent
+_proj_root = _product_path.parent
+
+# Make `dcpy` available
+sys.path.append(str(_proj_root))
+
+_config = dotenv_values(_product_path / "version.env")
 
 VERSION_PREV = _config["VERSION_PREV"]
-
 SQL_PATH = _module_top_path / "sql"
 BASH_PATH = _module_top_path / "bash"
-CACHE_PATH = _module_top_path.parent / ".cache"
-
+CACHE_PATH = _product_path / ".cache"
 BASE_URL = "https://nyc3.digitaloceanspaces.com/edm-recipes/datasets"
 
 BUILD_ENGINE = os.environ.get("BUILD_ENGINE")

--- a/db-facilities/facdb/cli.py
+++ b/db-facilities/facdb/cli.py
@@ -9,7 +9,7 @@ from dcpy.connectors import psql
 from .utility.prepare import read_datasets_yml
 from .utility.metadata import dump_metadata
 
-from . import SQL_PATH, BASH_PATH, BUILD_ENGINE, CACHE_PATH, VERSION_PREV
+from facdb import SQL_PATH, BASH_PATH, BUILD_ENGINE, CACHE_PATH, VERSION_PREV
 
 if not CACHE_PATH.exists():
     CACHE_PATH.mkdir()
@@ -105,7 +105,7 @@ def run(
         dataset = next(filter(lambda x: x["name"] == name, datasets), None)
         scripts = dataset.get("scripts", None)
         if python:
-            pipelines = importlib.import_module("db-facilities.facdb.pipelines")
+            pipelines = importlib.import_module("facdb.pipelines")
             pipeline = getattr(pipelines, name)
             pipeline()
 

--- a/db-facilities/facdb/sql/_create_reference_tables.sql
+++ b/db-facilities/facdb/sql/_create_reference_tables.sql
@@ -4,7 +4,7 @@ CREATE TABLE lookup_boro (
     boroname TEXT,
     borocode INTEGER
 );
-\COPY lookup_boro FROM 'db-facilities/facdb/data/lookup_boro.csv' DELIMITER ',' CSV HEADER;
+\COPY lookup_boro FROM 'facdb/data/lookup_boro.csv' DELIMITER ',' CSV HEADER;
 
 
 DROP TABLE IF EXISTS lookup_classification;
@@ -14,7 +14,7 @@ CREATE TABLE lookup_classification (
     facdomain TEXT,
     servarea TEXT
 );
-\COPY lookup_classification FROM 'db-facilities/facdb/data/lookup_classification.csv' DELIMITER ',' CSV HEADER;
+\COPY lookup_classification FROM 'facdb/data/lookup_classification.csv' DELIMITER ',' CSV HEADER;
 
 
 DROP TABLE IF EXISTS lookup_agency;
@@ -24,7 +24,7 @@ CREATE TABLE lookup_agency (
     overlevel TEXT,
     optype TEXT
 );
-\COPY lookup_agency FROM 'db-facilities/facdb/data/lookup_agency.csv' DELIMITER ',' CSV HEADER;
+\COPY lookup_agency FROM 'facdb/data/lookup_agency.csv' DELIMITER ',' CSV HEADER;
 
 
 DROP TABLE IF EXISTS manual_corrections;
@@ -34,4 +34,4 @@ CREATE TABLE manual_corrections (
     old_value TEXT,
     new_value TEXT
 );
-\COPY manual_corrections FROM 'db-facilities/facdb/data/manual_corrections.csv' DELIMITER ',' CSV HEADER;
+\COPY manual_corrections FROM 'facdb/data/manual_corrections.csv' DELIMITER ',' CSV HEADER;

--- a/db-facilities/facdb/utility/export.py
+++ b/db-facilities/facdb/utility/export.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from sqlalchemy import dialects
 from dcpy.connectors import psql
-from .. import BUILD_ENGINE
+from facdb import BUILD_ENGINE
 from sqlalchemy import create_engine
 
 ENGINE = create_engine(BUILD_ENGINE)

--- a/db-facilities/facdb/utility/prepare.py
+++ b/db-facilities/facdb/utility/prepare.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import yaml
 
-from .. import CACHE_PATH, BASE_URL
+from facdb import CACHE_PATH, BASE_URL
 from .metadata import add_version
 from .utils import format_field_names, hash_each_row
 


### PR DESCRIPTION
Using sys.path.append is a little dirty, but it's the easiest way to make our shared code available in the products themselves. Other products will need to implement something similar in their top-level __init__.py

Also refactors paths in db-facilities to make reflect that we're executing python from inside the product folder. Also implements absolute paths for constant imports.
