### PR TITLE
ensure all products can build in monorepo

### DIFF
--- a/.github/workflows/knownprojects_build.yml
+++ b/.github/workflows/knownprojects_build.yml
@@ -1,29 +1,27 @@
-name: z(TODO) KPDB - Build
+name: KPDB - 🏗️ Build
 
 on:
-  #push: todo - add branch paths if we want this. More likely want to normalize across projects
   workflow_dispatch:
     inputs:
-      update_submodule:
-        description: 'Would you like to use the latest db-knownprojects-data? (yes/no)'
-        required: false
-        default: 'no'
-      export:
-        description: 'Would you like to export outputs to db-knownprojects-data? (yes/no)'
-        required: false
-        default: 'no'
-      comments:
-        description: 'Provide any additional comments below'
-        required: false
-        default: ''
+      will_export:
+        description: 'Export outputs to a private S3 bucket?'
+        type: boolean
+        required: true
+        default: false
 
 jobs:
   build:
-    name: Building in Github database
-    runs-on: ubuntu-20.04
+    name: build
+    runs-on: ubuntu-22.04
+    container:
+      image: nycplanning/build-base:latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./products/db-knownprojects
     services:
-      postgres:
-        image: postgis/postgis:11-3.0-alpine
+      postgis:
+        image: postgis/postgis:14-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -34,57 +32,26 @@ jobs:
         ports:
           - 5432:5432
     env:
-      BUILD_ENGINE: postgresql://postgres:postgres@localhost:5432/postgres
+      BUILD_ENGINE: postgresql://postgres:postgres@postgis:5432/postgres
       EDM_DATA: ${{ secrets.EDM_DATA }}
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
-      ARD_PAT: ${{ secrets.ARD_PAT }}
-      AUTHOR: Data Engineering
     steps:
-      - uses: actions/checkout@v2
-        with: 
-            submodules: true
-            token: ${{ secrets.ARD_PAT }}
-            persist-credentials: true
+      - uses: actions/checkout@v3
 
-      - name: Update Submodule
-        if: github.event.inputs.update_submodule == 'yes'
-        run: git submodule update --remote
-         
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: install dependencies ...
-        run: |
-          sudo apt install -y gdal-bin
-          curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
-          chmod +x mc
-          sudo mv ./mc /usr/bin
-          mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
-          python3 -m pip install -r requirements.txt
+      - name: Setup build environment
+        working-directory: ./
+        run: ./bash/docker_container_setup.sh
 
       - name: 1. dataloading ..
-        run: ./kpdb.sh dataloading
+        run: ./bash/01_dataloading.sh
 
       - name: 2. build ...
-        run: ./kpdb.sh build
-
-      - name: 3. export ...
-        id: export
-        if: github.event.inputs.export == 'yes'
-        run: ./kpdb.sh export ${{ github.event.sender.login }}
-
-      - name: 4. comment on PR
-        uses: actions/github-script@v3
-        if: github.event.inputs.export == 'yes' && github.event.inputs.comments != ''
-        with: 
-          github-token: ${{ secrets.ARD_PAT }}
-          script: |
-            github.issues.createComment({
-              issue_number: ${{ steps.export.outputs.issue_number }},
-              owner: 'NYCPlanning',
-              repo: 'db-knownprojects-data',
-              body: `${{ github.event.inputs.comments }}`
-            })
+        run: ./bash/02_build.sh
+      
+      # TODO upload outputs to a private S3 bucket
+      # - name: 3. export ...
+      #   id: export
+      #   if: inputs.will_export
+      #   run: ./kpdb.sh export ${{ github.event.sender.login }}

--- a/.github/workflows/zoningtaxlots_build.yml
+++ b/.github/workflows/zoningtaxlots_build.yml
@@ -1,21 +1,19 @@
 name: Zoning Tax Lots - 🏗️ Build
 
 on:
-  #push:
-  #  branches:
-  #    - main
   workflow_dispatch:
 
 jobs:
   build:
-    if: >-
-      contains(github.event.head_commit.message, '[build]') ||
-      github.event_name == 'workflow_dispatch'
     name: Building ...
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./db-zoningtaxlots
     services:
       db:
-        image: postgis/postgis:11-3.0-alpine
+        image: postgis/postgis:14-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -33,7 +31,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install dependencies ...
         run: |
           sudo apt update
@@ -45,13 +43,10 @@ jobs:
           mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
 
       - name: 1. dataloading ...
-        working-directory: ./db-zoningtaxlots
         run: ./ztl.sh dataloading
 
       - name: 2. build ...
-        working-directory: ./db-zoningtaxlots
         run: ./ztl.sh build
 
       - name: 3. qaqc ...
-        working-directory: ./db-zoningtaxlots
         run: ./ztl.sh qaqc

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -1,15 +1,10 @@
 name: Zoning Tax lots - 📁 DataLoading
 
 on:
-  #issues:
-  #  types: [opened, edited]
   workflow_dispatch:
 
 jobs:
   dataloading:
-    if: >- 
-      contains(github.event.issue.title, '[dataloading]') ||
-      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-20.04
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
@@ -31,24 +26,11 @@ jobs:
           - dof_shoreline
           - dof_condo
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: NYCPlanning/action-library-archive@v1.1
         with:
-          path: templates/${{ matrix.dataset }}.yml 
+          path: ./db-zoningtaxlots/templates/${{ matrix.dataset }}.yml
           latest: true
           s3: true
           compress: true
           output_format: pgdump shapefile
-
-  close_issue:
-    if: github.event_name == 'issues'
-    runs-on: ubuntu-20.04
-    needs: dataloading
-    steps:
-      - name: Close Issue
-        uses: peter-evans/close-issue@v1
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          comment: |
-            # Success! 🎉
-            for more details, check https://github.com/NYCPlanning/db-zoningtaxlots/actions/runs/${{ github.run_id }}

--- a/products/db-knownprojects/.gitignore
+++ b/products/db-knownprojects/.gitignore
@@ -1,2 +1,0 @@
-*/output
-.python-version

--- a/products/db-knownprojects/.gitmodules
+++ b/products/db-knownprojects/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "data"]
-	path = data
-	url = git@github.com:NYCPlanning/db-knownprojects-data.git

--- a/products/db-knownprojects/README.md
+++ b/products/db-knownprojects/README.md
@@ -1,6 +1,8 @@
-# db-knownprojects
+# Known Projects Database (KPDB)
 
-This repo contains code for creating the Known Projects Database (KPDB). The build process has multiple automated phases, separated by manual review. For detailed information on the tables created throughout the build process, see the [build environment table descriptions](https://github.com/NYCPlanning/db-knownprojects/wiki/Build-environment-tables).
+This repo contains code for creating the Known Projects Database (KPDB). The build process has multiple automated phases, separated by manual review. 
+
+For detailed information on the tables created throughout the build process, see the [build environment table descriptions](https://github.com/NYCPlanning/db-knownprojects/wiki/Build-environment-tables).
 
 ## Instructions
 
@@ -10,17 +12,3 @@ This repo contains code for creating the Known Projects Database (KPDB). The bui
 - Load data: `./01_dataloading.sh`
 - Build database: `./02_build.sh`
 - Export: `./03_export.sh`
-
-### Development
-
-1. Pulling repo for the first time and pull files from submodule
-
-    ```bash
-    git submodule update --init --recursive
-    ```
-
-2. Updating submodule
-
-    ```bash
-    git submodule update --remote
-    ```

--- a/products/db-knownprojects/bash/01_dataloading.sh
+++ b/products/db-knownprojects/bash/01_dataloading.sh
@@ -1,12 +1,34 @@
 #!/bin/bash
+source ../../bash/utils.sh
 source bash/config.sh
+set_error_traps
 max_bg_procs 5
 
 # Load source data
+# TODO create data folder and populate it with data from S3 rather than a copy of the data repo
+rm -rf data
+mkdir -p data
+
+# download data/raw
+# download data/corrections
+python3 -m python.download
+
+# extract data/raw -> data/processed
+python3 -m python.extractors esd_projects
+python3 -m python.extractors edc_projects
+python3 -m python.extractors edc_dcp_inputs
+python3 -m python.extractors dcp_n_study
+python3 -m python.extractors dcp_n_study_future
+python3 -m python.extractors dcp_n_study_projected
+python3 -m python.extractors hpd_rfp
+python3 -m python.extractors hpd_pc
+python3 -m python.extractors dcp_planneradded
+
 for f in $(ls data/processed)
 do 
-    psql $BUILD_ENGINE -f data/processed/$f &
+    run_sql_file data/processed/$f
 done
+
 
 # Load ZAP tables
 import_private dcp_projects &
@@ -27,7 +49,7 @@ import_public dcp_school_districts
 wait
 
 # Load corrections tables
-psql $BUILD_ENGINE -f sql/create_corrections.sql
+run_sql_file sql/create_corrections.sql
 
 echo
 echo "data loading complate"

--- a/products/db-knownprojects/bash/02_build.sh
+++ b/products/db-knownprojects/bash/02_build.sh
@@ -1,42 +1,44 @@
 #!/bin/bash
+source ../../bash/utils.sh
 source bash/config.sh
+set_error_traps
 
 # Create functions and procedures
-psql $BUILD_ENGINE -1 -f sql/_functions.sql
-psql $BUILD_ENGINE -1 -f sql/_procedures.sql
+run_sql_file sql/_functions.sql
+run_sql_file sql/_procedures.sql
 
 # Map source data
-psql $BUILD_ENGINE -1 -f sql/dcp_application.sql
-psql $BUILD_ENGINE -1 -f sql/dcp_housing.sql
-psql $BUILD_ENGINE -1 -f sql/combine.sql
-psql $BUILD_ENGINE -1 -c "CALL apply_correction('combined', 'corrections_main');"
-psql $BUILD_ENGINE -c "VACUUM ANALYZE combined;"
+run_sql_file sql/dcp_application.sql
+run_sql_file sql/dcp_housing.sql
+run_sql_file sql/combine.sql
+run_sql_command "CALL apply_correction('combined', 'corrections_main');"
+run_sql_command "VACUUM ANALYZE combined;"
 
 # Find and matches between non-DOB sources
-psql $BUILD_ENGINE -1 -f sql/_project_record_ids.sql
+run_sql_file sql/_project_record_ids.sql
 
 # Apply corrections to reassign records to projects
-psql $BUILD_ENGINE -1 -f sql/correct_projects.sql
-psql $BUILD_ENGINE -c "VACUUM ANALYZE _project_record_ids;"
+run_sql_file sql/correct_projects.sql
+run_sql_command "VACUUM ANALYZE _project_record_ids;"
 
 # Output corrected projects for review
-psql $BUILD_ENGINE -1 -f sql/review_project.sql
+run_sql_file sql/review_project.sql
 
 # Find matches between DOB and non-DOB sources
-psql $BUILD_ENGINE -1 -f sql/review_dob.sql
+run_sql_file sql/review_dob.sql
 
 # Create project IDs and deduplicate units
-psql $BUILD_ENGINE -1 -f sql/project_record_ids.sql 
-psql $BUILD_ENGINE -c "VACUUM ANALYZE project_record_ids;"
+run_sql_file sql/project_record_ids.sql 
+run_sql_command "VACUUM ANALYZE project_record_ids;"
 
 # Dedup units
 python3 -m python.dedup_units
-psql $BUILD_ENGINE -1 -c "CALL apply_correction('deduped_units', 'corrections_main');"
-psql $BUILD_ENGINE -c "VACUUM ANALYZE deduped_units;"
+run_sql_command "CALL apply_correction('deduped_units', 'corrections_main');"
+run_sql_command "VACUUM ANALYZE deduped_units;"
 
 # Join to boro, clean duplicates
-psql $BUILD_ENGINE -1 -f sql/join_boroughs.sql
-psql $BUILD_ENGINE -1 -c "CALL apply_correction('combined', 'corrections_borough');"
+run_sql_file sql/join_boroughs.sql
+run_sql_command "CALL apply_correction('combined', 'corrections_borough');"
 
 # Create KPDB
-psql $BUILD_ENGINE -1 -f sql/create_kpdb.sql
+run_sql_file sql/create_kpdb.sql

--- a/products/db-knownprojects/bash/03_sca_aggregate.sh
+++ b/products/db-knownprojects/bash/03_sca_aggregate.sh
@@ -5,24 +5,24 @@ echo "Create the longfrom SCA Aggregate Tables..."
 
 echo "Preprocess column names to standardize"
 #Preprocess the tables to standardize geometry column name 
-psql $BUILD_ENGINE -1 -f sca_aggregate/preprocessing.sql
+run_sql_file sca_aggregate/preprocessing.sql
 
 echo "Create ZAP Project Many BBLs table"
 # Create the `zap_projects_many_bbls`` table
-psql $BUILD_ENGINE -1 -f sca_aggregate/create_zap_projects.sql
+run_sql_file sca_aggregate/create_zap_projects.sql
 
 # Aggregate KPDB projects to Elementary School Zones 
 echo "Build Elementary School Zones Aggregate Table"
-psql $BUILD_ENGINE -1 -f sca_aggregate/boundaries_es_zone.sql
+run_sql_file sca_aggregate/boundaries_es_zone.sql
 
 echo "Build School Districts aggregate table"
 # Aggregate KPDB projects to School District Zones
-psql $BUILD_ENGINE -1 -f sca_aggregate/boundaries_school_districts.sql
+run_sql_file sca_aggregate/boundaries_school_districts.sql
 
 echo "Build School Subdistricts aggregate tables"
 # Aggregate KPDB projects to School Subdistrict Zones
-psql $BUILD_ENGINE -1 -f sca_aggregate/boundaries_school_subdistricts.sql
+run_sql_file sca_aggregate/boundaries_school_subdistricts.sql
 
-psql $BUILD_ENGINE -c "ALTER TABLE _kpdb RENAME COLUMN geometry TO geom;"
+run_sql_command "ALTER TABLE _kpdb RENAME COLUMN geometry TO geom;"
 
 echo "SCA Longform Aggregate tables are complete"

--- a/products/db-knownprojects/bash/04_export.sh
+++ b/products/db-knownprojects/bash/04_export.sh
@@ -3,7 +3,7 @@ set -e
 source bash/config.sh
 
 echo "Generate output tables"
-psql $BUILD_ENGINE -f sql/_export.sql
+run_sql_file sql/_export.sql
 
 echo "Archive tables"
 archive public.kpdb kpdb.kpdb &
@@ -33,9 +33,9 @@ mkdir -p output
         SHP_export review_dob MULTIPOLYGON 
         wait
 
-        psql $BUILD_ENGINE  -c "ALTER TABLE review_project DROP COLUMN geom;" &
-        psql $BUILD_ENGINE  -c "ALTER TABLE review_dob DROP COLUMN geom;" &
-        psql $BUILD_ENGINE  -c "ALTER TABLE combined DROP COLUMN geom;"
+        run_sql_command "ALTER TABLE review_project DROP COLUMN geom;" &
+        run_sql_command "ALTER TABLE review_dob DROP COLUMN geom;" &
+        run_sql_command "ALTER TABLE combined DROP COLUMN geom;"
         wait 
         
         CSV_export combined &

--- a/products/db-knownprojects/bash/config.sh
+++ b/products/db-knownprojects/bash/config.sh
@@ -38,7 +38,7 @@ function import_private {
   version=$(mc cat spaces/edm-recipes/datasets/$name/$version/config.json | jq -r '.dataset.version')
   echo "$name version: $version"
   mc cp spaces/edm-recipes/datasets/$name/$version/$name.sql $name.sql
-  psql $BUILD_ENGINE -f $name.sql
+  run_sql_file $name.sql
   rm $name.sql
 }
 
@@ -48,12 +48,12 @@ function import_public {
   version=$(curl -s https://nyc3.digitaloceanspaces.com/edm-recipes/datasets/$name/$version/config.json | jq -r '.dataset.version')
   echo "$name version: $version"
   curl -O https://nyc3.digitaloceanspaces.com/edm-recipes/datasets/$name/$version/$name.sql
-  psql $BUILD_ENGINE -f $name.sql
+  run_sql_file $name.sql
   rm $name.sql
 }
 
 function CSV_export {
-  psql $BUILD_ENGINE  -c "\COPY (
+  run_sql_command "\COPY (
     SELECT * FROM $@
   ) TO STDOUT DELIMITER ',' CSV HEADER;" > $@.csv
 }

--- a/products/db-knownprojects/example.env
+++ b/products/db-knownprojects/example.env
@@ -1,3 +1,0 @@
-BUILD_ENGINE=postgresql://username:password@host:port/dbname
-EDM_DATA=postgresql://username:password@host:port/dbname
-GH_PAT=XXXXXXXXXXXXXXXXXXXXXXXX

--- a/products/db-knownprojects/python/__init__.py
+++ b/products/db-knownprojects/python/__init__.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from pathlib import Path
+from dotenv import load_dotenv
+from datetime import datetime
+
+_module_top_path = Path(__file__).resolve().parent
+_product_path = _module_top_path.parent
+_proj_root = _product_path.parent.parent
+
+# Make `dcpy` available
+sys.path.append(str(_proj_root))
+
+S3_SOURCE_BUCKET = "edm-private"
+S3_SOURCE_HOUSING_TEAM_DIR = "dcp_housing_team/db-knownprojects"
+
+DATA_PATH = _product_path / "data"
+RAW_DATA_PATH = DATA_PATH / "raw"
+PROCESSED_DATA_PATH = DATA_PATH / "processed"
+CORRECTIONS_DATA_PATH = DATA_PATH / "corrections"
+
+DCP_HOUSING_DATA_FILENAMES = {
+    "esd_projects": "2021.2.10 State Developments for Housing Pipeline.xlsx",
+    "edc_projects": "2022.11.18 EDC inputs for DCP housing projections.xlsx",
+    "edc_dcp_inputs": "edc_shapefile_20221118.zip",
+    "dcp_n_study": "nstudy_rezoning_commitments_shapefile_20221017.zip",
+    "dcp_n_study_future": "future_nstudy_shapefile_20221017.zip",
+    "dcp_n_study_projected": "PastNeighborhoodStudies_20221019.zip",
+    "hpd_rfp": "20221122_HPD_RFPs.xlsx",
+    "hpd_pc": "2022_11_23 DCP_SCA Pipeline.xlsx",
+    "dcp_planneradded": "dcp_planneradded_2023_03_21.csv",
+}
+DCP_HOUSING_CORRECTIONS_FILENAMES = {
+    "corrections_dob": "corrections_dob.csv",
+    "corrections_main": "corrections_main.csv",
+    "corrections_project": "corrections_project.csv",
+    "corrections_zap": "corrections_zap.csv",
+    "zap_record_ids": "zap_record_ids.csv",
+}
+
+
+# Today's date
+DATE = datetime.today().strftime("%Y-%m-%d")
+
+# Load environmental variables
+load_dotenv()
+BUILD_ENGINE = os.environ["BUILD_ENGINE"]
+
+# Create temporary output directories
+current_dir = os.getcwd()
+output_dir = f"{current_dir}/.output"
+
+if not os.path.isdir(output_dir):
+    os.makedirs(output_dir, exist_ok=True)

--- a/products/db-knownprojects/python/download.py
+++ b/products/db-knownprojects/python/download.py
@@ -1,0 +1,39 @@
+import os
+from dcpy.connectors.s3 import client
+
+from . import (
+    S3_SOURCE_BUCKET,
+    S3_SOURCE_HOUSING_TEAM_DIR,
+    RAW_DATA_PATH,
+    CORRECTIONS_DATA_PATH,
+    DCP_HOUSING_DATA_FILENAMES,
+    DCP_HOUSING_CORRECTIONS_FILENAMES,
+)
+
+
+def download_s3_source_file(file_name: str) -> None:
+    s3_filepath = f"{S3_SOURCE_HOUSING_TEAM_DIR}/raw/{file_name}"
+    save_file_path = f"{RAW_DATA_PATH}/{file_name}"
+    client().download_file(S3_SOURCE_BUCKET, s3_filepath, save_file_path)
+
+
+def download_s3_corrections_file(file_name: str) -> None:
+    s3_filepath = f"{S3_SOURCE_HOUSING_TEAM_DIR}/corrections/{file_name}"
+    save_file_path = f"{CORRECTIONS_DATA_PATH}/{file_name}"
+    client().download_file(S3_SOURCE_BUCKET, s3_filepath, save_file_path)
+
+
+if __name__ == "__main__":
+    print("Downloading DCP Housing team source data ...")
+
+    os.makedirs(RAW_DATA_PATH, exist_ok=True)
+    for dataset, filename in DCP_HOUSING_DATA_FILENAMES.items():
+        print(f"downloading source dataset '{dataset}' with filename '{filename}' ...")
+        download_s3_source_file(filename)
+
+    os.makedirs(CORRECTIONS_DATA_PATH, exist_ok=True)
+    for dataset, filename in DCP_HOUSING_CORRECTIONS_FILENAMES.items():
+        print(f"downloading corrections '{dataset}' with filename '{filename}' ...")
+        download_s3_corrections_file(filename)
+
+    print("Done!")

--- a/products/db-knownprojects/python/extractors.py
+++ b/products/db-knownprojects/python/extractors.py
@@ -1,0 +1,95 @@
+# This file processes the raw source data into .sql (`/processed/`) files that are then used to build KPDB.
+
+import sys
+
+import geopandas as gpd
+import pandas as pd
+import shapely
+from shapely import wkb
+
+from . import RAW_DATA_PATH
+from .utils import ETL, hash_each_row
+
+
+@ETL
+def dcp_knownprojects() -> pd.DataFrame:
+    filename = "kpdb_20211006_shapefiles.zip"
+    df = gpd.read_file(f"zip://{RAW_DATA_PATH}/{filename}")
+    df.rename(columns={"geom": "geometry"}, inplace=True)
+    df["geometry"] = df["geometry"].fillna()
+    return df
+
+
+@ETL
+def esd_projects() -> pd.DataFrame:
+    filename = "2021.2.10 State Developments for Housing Pipeline.xlsx"
+    df = pd.read_excel(f"{RAW_DATA_PATH}/{filename}", dtype=str)
+    return df
+
+
+@ETL
+def edc_projects() -> pd.DataFrame:
+    filename = "2022.11.18 EDC inputs for DCP housing projections.xlsx"
+    df = pd.read_excel(f"{RAW_DATA_PATH}/{filename}", dtype=str)
+    return df
+
+
+@ETL
+def dcp_n_study() -> pd.DataFrame:
+    filename = "nstudy_rezoning_commitments_shapefile_20221017.zip"
+    df = gpd.read_file(f"zip://{RAW_DATA_PATH}/{filename}")
+    return df
+
+
+@ETL
+def dcp_n_study_future() -> pd.DataFrame:
+    filename = "future_nstudy_shapefile_20221017.zip"
+    df = gpd.read_file(f"zip://{RAW_DATA_PATH}/{filename}")
+    return df
+
+
+@ETL
+def dcp_n_study_projected() -> gpd.geodataframe.GeoDataFrame:
+    filename = "PastNeighborhoodStudies_20221019.zip"
+    df = gpd.read_file(f"zip://{RAW_DATA_PATH}/{filename}")
+    return df
+
+
+@ETL
+def hpd_rfp() -> pd.DataFrame:
+    filename = "20221122_HPD_RFPs.xlsx"
+    df = pd.read_excel(f"{RAW_DATA_PATH}/{filename}", dtype=str)
+    return df
+
+
+@ETL
+def hpd_pc() -> pd.DataFrame:
+    filename = "2022_11_23 DCP_SCA Pipeline.xlsx"
+    df = pd.read_excel(f"{RAW_DATA_PATH}/{filename}", dtype=str)
+    return df
+
+
+@ETL
+def dcp_planneradded():
+    filename = "dcp_planneradded_2023_03_21.csv"
+    df = pd.read_csv(f"{RAW_DATA_PATH}/{filename}", dtype=str)
+    df.rename(columns={"WKT": "geometry"}, inplace=True)
+    # print(df)
+    return df
+
+
+@ETL
+def edc_dcp_inputs() -> gpd.geodataframe.GeoDataFrame:
+    filename = "edc_shapefile_20221118.zip"
+    df = gpd.read_file(f"zip://{RAW_DATA_PATH}/{filename}")
+    # print(df)
+    return df
+
+
+if __name__ == "__main__":
+    name = sys.argv[1]
+    assert name in list(locals().keys()), f"{name} is invalid"
+
+    print(f"Extracting DCP Housing team source dataset '{name}' ...")
+    locals()[name]()
+    print("Done!")

--- a/products/db-knownprojects/python/upload.py
+++ b/products/db-knownprojects/python/upload.py
@@ -61,22 +61,23 @@ if __name__ == "__main__":
     file_list = glob.glob(basepath + "/output/**", recursive=True)
     file_list = [f for f in file_list if os.path.isfile(f)]
 
-    # Create a new target branch
-    timestamp = dt.now()
-    title = timestamp.strftime("%Y-%m-%d %H:%M")
-    target_branch = timestamp.strftime("output-%Y%m%d-%H%M")
-    create_new_branch(target_branch)
+    # TODO upload outputs to a private S3 bucket
+    # # Create a new target branch
+    # timestamp = dt.now()
+    # title = timestamp.strftime("%Y-%m-%d %H:%M")
+    # target_branch = timestamp.strftime("output-%Y%m%d-%H%M")
+    # create_new_branch(target_branch)
     
-    # Upload files one by one
-    for _file in file_list:
-        upload_file(_file, target_branch)
+    # # Upload files one by one
+    # for _file in file_list:
+    #     upload_file(_file, target_branch)
 
-    # Create a PR after upload
-    md_file_list = "\n".join([f" - `{f.replace(basepath+'/', '')}`" for f in file_list])
-    body = f"## Files Commited:\n{md_file_list}\n"
+    # # Create a PR after upload
+    # md_file_list = "\n".join([f" - `{f.replace(basepath+'/', '')}`" for f in file_list])
+    # body = f"## Files Commited:\n{md_file_list}\n"
 
-    pr = create_pull_request(
-        title=f'output: {timestamp.strftime("%Y-%m-%d %H:%M")}, created by: {SENDER}',
-        body=body,
-        head=target_branch,
-    )
+    # pr = create_pull_request(
+    #     title=f'output: {timestamp.strftime("%Y-%m-%d %H:%M")}, created by: {SENDER}',
+    #     body=body,
+    #     head=target_branch,
+    # )

--- a/products/db-knownprojects/python/utils.py
+++ b/products/db-knownprojects/python/utils.py
@@ -1,8 +1,14 @@
-import csv
-from io import StringIO
 import os
-from sqlalchemy import create_engine
+from io import StringIO
+import re
+import csv
+import hashlib
+from sqlalchemy import create_engine, text
 import pandas as pd
+import geopandas as gpd
+from functools import wraps
+
+from . import BUILD_ENGINE, DATE, PROCESSED_DATA_PATH
 
 engine = create_engine(os.environ.get("BUILD_ENGINE"))
 
@@ -33,3 +39,111 @@ def psql_insert_copy(table, conn, keys, data_iter):
 
         sql = "COPY {} ({}) FROM STDIN WITH CSV".format(table_name, columns)
         cur.copy_expert(sql=sql, file=s_buf)
+
+
+def hash_each_row(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    e.g. df = hash_each_row(df)
+    this function will create a "uid" column with hashed row values
+    ----------
+    df: input dataframe
+    """
+    df["temp_column"] = df.astype(str).values.sum(axis=1)
+
+    def hash_helper(x):
+        return hashlib.md5(x.encode("utf-8")).hexdigest()
+
+    df["uid"] = df["temp_column"].apply(hash_helper)
+    del df["temp_column"]
+    cols = list(df.columns)
+    cols.remove("uid")
+    cols = ["uid"] + cols
+    return df[cols]
+
+
+def format_field_names(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Change field name to lower case
+    and replace all spaces with underscore
+    """
+
+    def format_func(x):
+        return re.sub(r"\W+", "", x.lower().strip().replace("-", "_").replace(" ", "_"))
+
+    df.columns = df.columns.map(format_func)
+    return df
+
+
+def add_version_date(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Adding today's date as the version of the file
+    -----
+    note that this function is not implemented yet
+    because we might want to get the file creation date
+    directly from the file instead of assigning a date
+    """
+    df["version"] = DATE
+    return df
+
+
+def ETL(func) -> callable:
+    """
+    Decorator for extractor functions that does the following:
+    1. extracts data
+    2. adds md5 uid field
+    3. format field names
+    4. if geopandas dataframe, convert geometry to string type
+    5. copy table to postgres
+    6. alter geometry field type to geometry with SRID 4326 if needed
+    6. save data to /processed/
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs) -> None:
+        name = func.__name__
+        print(f"ingesting\t{name} ...")
+        df = func()
+
+        # Adding uid
+        df = hash_each_row(df)
+
+        # Formating field names
+        df = format_field_names(df)
+
+        # Write to postgres database
+        # If it's a geopandas dataframe, we will have to
+        # Convert geometry column to text first
+        if isinstance(df, gpd.geodataframe.GeoDataFrame):
+            df = pd.DataFrame(df, dtype=str)
+
+        print(f"export\t{name} to postgres ...")
+        df.to_sql(
+            name,
+            con=engine,
+            if_exists="replace",
+            index=False,
+            method=psql_insert_copy,
+        )
+
+        with engine.begin() as conn:
+            if "geometry" in list(df.columns):
+                conn.execute(
+                    text(
+                        """
+                BEGIN; 
+                ALTER TABLE %(name)s 
+                ALTER COLUMN geometry type Geometry 
+                    USING ST_SetSRID(ST_GeomFromText(geometry), 4326);
+                COMMIT;
+                """
+                        % {"name": name}
+                    )
+                )
+            # df.to_csv(f"{output_dir}/{name}.csv", index=False)
+        os.system(
+            f"pg_dump {BUILD_ENGINE} -O -c --if-exists -t {name} > {PROCESSED_DATA_PATH}/{name}.sql"
+        )
+        print("🎉 done!")
+        return None
+
+    return wrapper

--- a/products/db-zoningtaxlots/bash/02_build.sh
+++ b/products/db-zoningtaxlots/bash/02_build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 source bash/config.sh
 
+echo "Run build"
+
 run_sql_file sql/create_priority.sql &
 run_sql_file sql/create.sql
 run_sql_file sql/preprocessing.sql
@@ -21,10 +23,9 @@ run_sql_file sql/correct_duplicatevalues.sql
 run_sql_file sql/correct_zoninggaps.sql
 run_sql_file sql/correct_invalidrecords.sql
 
-echo "archive final output"
+echo "Archive final output"
 
-echo "archive final output"
-pg_dump -t dcp_zoning_taxlot ${BUILD_ENGINE} | psql ${EDM_DATA}
+pg_dump -d ${BUILD_ENGINE} -t dcp_zoning_taxlot --no-owner --clean | psql ${EDM_DATA}
 psql ${EDM_DATA} -c "
   CREATE SCHEMA IF NOT EXISTS dcp_zoningtaxlots;
   ALTER TABLE dcp_zoning_taxlot SET SCHEMA dcp_zoningtaxlots;


### PR DESCRIPTION
resolves #72, resolves #3

## changes
- ZTL
  - update paths in github actions and fix the use of `pg_dump` in 02_build.sh
  - [dataloading passing](https://github.com/NYCPlanning/data-engineering/actions/workflows/zoningtaxlots_dataloading.yml)
  - [build passing](https://github.com/NYCPlanning/data-engineering/actions/runs/5649591665)
- KPDB
  - deprecate the use of the [KPDB data repo](https://github.com/NYCPlanning/db-knownprojects-data) in favor of a private S3 bucket
  - disable export step and code until use of private S3 bucket is implemented (not implemented yet due to build issues, see notes)
  - incorporate all data loading / transformation code from the KPDB repo
  - simplify build action and use common bash utils
  - [build failing](https://github.com/NYCPlanning/data-engineering/actions/runs/5753922994/job/15598117213#step:6:17) at expected point (when using `dcp_projects` columns)

## notes
- this is meant to be focused on "does it build in the mono repo?" this doesn't have to improve builds by using shared bash utils, using shared containers, or being called via the common build action (but it might)
- KPDB: many columns that are expected to be in the source dataset `dcp_projects` aren't there because we only archive the public version, which has less columns than the private version. I'll create a separate issue for this
- on related issues, I'll flag which tasks have been completed by this PR