### PR TITLE
fix DevDB corrections

### DIFF
--- a/db-developments/bash/02_build_devdb.sh
+++ b/db-developments/bash/02_build_devdb.sh
@@ -3,11 +3,11 @@ source bash/config.sh
 
 display "Starting to build Developments DB"
 run_sql_file sql/_function.sql
-run_sql_file sql/_procedures.sql
+run_sql_file sql/_procedures.sql -v build_schema=${BUILD_ENGINE_SCHEMA}
 run_sql_file sql/bis/_init.sql
 run_sql_file sql/now/_init.sql
 run_sql_file sql/hpd/_init.sql
-run_sql_file sql/_init.sql
+run_sql_file sql/_init.sql -v build_schema=${BUILD_ENGINE_SCHEMA}
 sql_table_summary _INIT_devdb
 
 display "Assign geoms to _GEO_devdb and create GEO_devdb"
@@ -15,8 +15,7 @@ run_sql_file sql/_geo.sql
 run_sql_file sql/_geo_corrections.sql
 sql_table_summary GEO_devdb
 
-display "Fill NULLs spatial boundries in GEO_devdb through spatial joins. 
-  This is the consolidated spatial attributes table"
+display "Fill NULLs spatial boundries in GEO_devdb through spatial joins. This is the consolidated spatial attributes table"
 run_sql_file sql/_spatial.sql
 sql_table_summary SPATIAL_devdb
 run_sql_file sql/init.sql
@@ -39,7 +38,7 @@ sql_table_summary CO_devdb
 display "Creating OCC fields: 
       occ_initial, 
       occ_proposed"
-run_sql_file sql/_occ.sql
+run_sql_file sql/_occ.sql -v build_schema=${BUILD_ENGINE_SCHEMA}
 sql_table_summary OCC_devdb
 
 display "Creating UNITS fields: 
@@ -51,7 +50,7 @@ display "Creating UNITS fields:
       otherb_prop,
       classa_net,
       resid_flag"
-run_sql_file sql/_units.sql
+run_sql_file sql/_units.sql -v build_schema=${BUILD_ENGINE_SCHEMA}
 sql_table_summary UNITS_devdb
 
 display "Creating status_q fields: date_permittd,
@@ -68,7 +67,7 @@ display "Combining INIT_devdb with OCC_devdb,
       OCC_devdb, 
       UNITS_devdb,
       STATUS_Q_devdb to create _MID_devdb"
-run_sql_file sql/_mid.sql
+run_sql_file sql/_mid.sql -v build_schema=${BUILD_ENGINE_SCHEMA}
 sql_table_summary _MID_devdb
 
 display "Creating status fields: 
@@ -77,7 +76,7 @@ display "Creating status fields:
       date_permittd,
       job_inactive"
 
-run_sql_file sql/_status.sql -v CAPTURE_DATE=$CAPTURE_DATE
+run_sql_file sql/_status.sql -v CAPTURE_DATE=$CAPTURE_DATE -v build_schema=${BUILD_ENGINE_SCHEMA}
 
 display "Combining _MID_devdb with STATUS_devdb to create MID_devdb,
             Creating nonres_flag field"

--- a/db-developments/sql/_init.sql
+++ b/db-developments/sql/_init.sql
@@ -94,12 +94,12 @@ CORRECTIONS:
 	date_statusr
 	date_statusx
 */
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'stories_prop');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'bin');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'bbl');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'date_lastupdt');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'date_filed');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'date_statusd');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'date_statusp');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'date_statusr');
-CALL apply_correction('_INIT_devdb', '_manual_corrections', 'date_statusx');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'stories_prop');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'bin');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'bbl');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'date_lastupdt');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'date_filed');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'date_statusd');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'date_statusp');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'date_statusr');
+CALL apply_correction(:'build_schema', '_INIT_devdb', '_manual_corrections', 'date_statusx');

--- a/db-developments/sql/_mid.sql
+++ b/db-developments/sql/_mid.sql
@@ -168,7 +168,7 @@ ON a.job_number = b.job_number;
 CORRECTIONS: (implemeted 2021/02/22)
     date_permittd
 */
-CALL apply_correction('JOIN_date_permittd', '_manual_corrections', 'date_permittd');
+CALL apply_correction(:'build_schema', 'JOIN_date_permittd', '_manual_corrections', 'date_permittd');
 
 /*
 CONTINUE

--- a/db-developments/sql/_occ.sql
+++ b/db-developments/sql/_occ.sql
@@ -48,5 +48,5 @@ CORRECTIONS
 	occ_proposed
 */
 CREATE INDEX OCC_devdb_job_number_idx ON OCC_devdb(job_number);
-CALL apply_correction('OCC_devdb', '_manual_corrections', 'occ_initial');
-CALL apply_correction('OCC_devdb', '_manual_corrections', 'occ_proposed');
+CALL apply_correction(:'build_schema', 'OCC_devdb', '_manual_corrections', 'occ_initial');
+CALL apply_correction(:'build_schema', 'OCC_devdb', '_manual_corrections', 'occ_proposed');

--- a/db-developments/sql/_status.sql
+++ b/db-developments/sql/_status.sql
@@ -134,4 +134,4 @@ CORRECTIONS
     job_inactive
 */
 CREATE INDEX STATUS_devdb_job_number_idx ON STATUS_devdb(job_number);
-CALL apply_correction('STATUS_devdb', '_manual_corrections', 'job_inactive');
+CALL apply_correction(:'build_schema', 'STATUS_devdb', '_manual_corrections', 'job_inactive');

--- a/db-developments/sql/_units.sql
+++ b/db-developments/sql/_units.sql
@@ -76,12 +76,12 @@ the associated classa field. As a result, these corrections
 get applied prior to the classa corrections.
 */
 CREATE INDEX _UNITS_devdb_raw_job_number_idx ON _UNITS_devdb_raw(job_number);
-CALL apply_correction('_UNITS_devdb_raw', '_manual_corrections', 'hotel_init', 'classa_init');
-CALL apply_correction('_UNITS_devdb_raw', '_manual_corrections', 'hotel_prop', 'classa_prop');
-CALL apply_correction('_UNITS_devdb_raw', '_manual_corrections', 'otherb_init', 'classa_init');
-CALL apply_correction('_UNITS_devdb_raw', '_manual_corrections', 'otherb_prop', 'classa_prop');
-CALL apply_correction('_UNITS_devdb_raw', '_manual_corrections', 'classa_init');
-CALL apply_correction('_UNITS_devdb_raw', '_manual_corrections', 'classa_prop');
+CALL apply_correction(:'build_schema', '_UNITS_devdb_raw', '_manual_corrections', 'hotel_init', 'classa_init');
+CALL apply_correction(:'build_schema', '_UNITS_devdb_raw', '_manual_corrections', 'hotel_prop', 'classa_prop');
+CALL apply_correction(:'build_schema', '_UNITS_devdb_raw', '_manual_corrections', 'otherb_init', 'classa_init');
+CALL apply_correction(:'build_schema', '_UNITS_devdb_raw', '_manual_corrections', 'otherb_prop', 'classa_prop');
+CALL apply_correction(:'build_schema', '_UNITS_devdb_raw', '_manual_corrections', 'classa_init');
+CALL apply_correction(:'build_schema', '_UNITS_devdb_raw', '_manual_corrections', 'classa_prop');
 
 /*
 Using corrected classa, hotel, and otherb unit fields, 
@@ -109,7 +109,7 @@ DROP TABLE _UNITS_devdb_raw CASCADE;
 CORRECTIONS
 	resid_flag
 */
-CALL apply_correction('_UNITS_devdb_resid_flag', '_manual_corrections', 'resid_flag');
+CALL apply_correction(:'build_schema', '_UNITS_devdb_resid_flag', '_manual_corrections', 'resid_flag');
 
 /*
 Separate A2 job types from other types of records with units 


### PR DESCRIPTION
resolves #84 

fixed by passing the build schema to `apply_corrections` (@fvankrieken got this working on [`fvk-devdb-corrections`](https://github.com/NYCPlanning/data-engineering/tree/fvk-devdb-corrections))

[successful build](https://github.com/NYCPlanning/data-engineering/actions/runs/5716162406/job/15487056722)

files sizes of corrections outputs:
<img width="523" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/3c62155d-2af9-4e34-a629-9c7d63cf3208">


## notes

the sql procedure `apply_corrections` was using the table `information_schema.columns` to:
1. determine which columns are in each table and would be valid to correct
2. not apply any if the column isn't in the list
3. raise a sql notice

```sql
...
SELECT array_agg(column_name) FROM information_schema.columns
WHERE table_schema = 'public'
AND table_name = lower(_table) INTO  _valid_fields;
...
```

since DevDB no longer uses the default DB schema `public` to build tables, this list was empty. per #50, DevDB now uses the edm-data DB and a schema which is unique to the branch + workflow trigger (e.g. `build_workflow_dispatch_fix_devdb_correction`)