### PR TITLE
add utils to upload file, upload/download folder

### DIFF
--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -85,17 +85,17 @@ def download_folder(
 
 
 def upload_folder(
-    bucket:str,
-    local_folder_path:str,
-    upload_path:str,
+    bucket: str,
+    local_folder_path: str,
+    upload_path: str,
     acl: str = "public-read",
     metadata: dict = {},
-    include_foldername: bool=True,
+    include_foldername: bool = True,
 ):
     local_folder_path = Path(local_folder_path)
     if not local_folder_path.exists() or (not local_folder_path.is_dir()):
         raise NotADirectoryError(f"'{local_folder_path}' is not a folder.")
-    for path_object in local_folder_path.rglob('*'):
+    for path_object in local_folder_path.rglob("*"):
         if path_object.is_file():
             if not include_foldername:
                 key = upload_path / Path(*path_object.parts[2:])

--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -28,16 +28,16 @@ def client(
     )
 
 
-## adapted from data library
-## https://github.com/NYCPlanning/db-data-library/blob/main/library/s3.py#L37
 def upload_file(
     bucket: str,
     path: str,
     key: str,
     acl: str = "public-read",
-    metadata: dict = {},
+    metadata: dict = None,
 ) -> dict:
-    """Uploads a single file to AWS S3."""
+    """Uploads a single file to AWS S3.
+    adapted from data library
+    https://github.com/NYCPlanning/db-data-library/blob/main/library/s3.py#L37"""
     with Progress(
         SpinnerColumn(spinner_name="earth"),
         TextColumn("[progress.description]{task.description}"),

--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -53,7 +53,8 @@ def upload_file(
             f"[green]Uploading [bold]{path.name}[/bold]", total=size
         )
         extra_args = {"ACL": acl}
-        if metadata: extra_args["Metadata"] = metadata
+        if metadata:
+            extra_args["Metadata"] = metadata
         response = client().upload_file(
             path,
             bucket,
@@ -80,14 +81,9 @@ def download_folder(
     if not "Contents" in resp:
         raise NotADirectoryError(f"Folder {prefix} not found in bucket {bucket}")
     for obj in resp["Contents"]:
-        print(obj["Key"])
-        key = obj["Key"].replace(prefix, "")
-        print(key)
-        if key and (key[-1] != "/"):
+        key = obj["Key"].replace(prefix, "") if include_prefix_in_export else obj["Key"]
+        if key and (key != prefix) and (key[-1] != "/"):
             key_directory = Path(key).parent
-            print(key_directory)
-            if include_prefix_in_export:
-                export_path = export_path / prefix
             if not (export_path / key_directory).exists():
                 os.makedirs(export_path / key_directory)
             client_.download_file(bucket, obj["Key"], export_path / key)

--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -62,9 +62,9 @@ def upload_file(
 
 
 def download_folder(
-    bucket, prefix, export_path, include_prefix_in_export=False
+    bucket: str, prefix: str, export_path: str, include_prefix_in_export: bool = False
 ) -> None:
-    """given bucket, prefix filter, and export path, download contents of folder from s3 recursively"""
+    """Given bucket, prefix filter, and export path, download contents of folder from s3 recursively"""
     export_path = Path(export_path)
     if prefix[-1] != "/":
         raise NotADirectoryError("prefix must be a folder path, ending with '/'")
@@ -91,7 +91,8 @@ def upload_folder(
     acl: str = "public-read",
     metadata: dict = {},
     include_foldername: bool = True,
-):
+) -> None:
+    """Given bucket, local folder path, and upload path, uploads contents of folder to s3 recursively"""
     local_folder_path = Path(local_folder_path)
     if not local_folder_path.exists() or (not local_folder_path.is_dir()):
         raise NotADirectoryError(f"'{local_folder_path}' is not a folder.")

--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -94,7 +94,7 @@ def upload_folder(
 ):
     local_folder_path = Path(local_folder_path)
     if not local_folder_path.exists() or (not local_folder_path.is_dir()):
-        raise ValueError(f"'{local_folder_path}' is not a folder.")
+        raise NotADirectoryError(f"'{local_folder_path}' is not a folder.")
     for path_object in local_folder_path.rglob('*'):
         if path_object.is_file():
             if not include_foldername:

--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -89,7 +89,7 @@ def upload_folder(
     local_folder_path: str,
     upload_path: str,
     acl: str = "public-read",
-    metadata: dict = {},
+    metadata: dict = None,
     include_foldername: bool = True,
 ) -> None:
     """Given bucket, local folder path, and upload path, uploads contents of folder to s3 recursively"""

--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -1,5 +1,15 @@
 import os
+from pathlib import Path
 import boto3
+from botocore.client import Config
+
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
 
 
 def client(
@@ -8,9 +18,87 @@ def client(
     endpoint_url=os.environ["AWS_S3_ENDPOINT"],
 ):
     """Returns a client for AWS S3."""
+    config = Config(read_timeout=120)
     return boto3.client(
         "s3",
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         endpoint_url=endpoint_url,
+        config=config,
     )
+
+
+## adapted from data library
+## https://github.com/NYCPlanning/db-data-library/blob/main/library/s3.py#L37
+def upload_file(
+    bucket: str,
+    path: str,
+    key: str,
+    acl: str = "public-read",
+    metadata: dict = {},
+) -> dict:
+    """Uploads a single file to AWS S3."""
+    with Progress(
+        SpinnerColumn(spinner_name="earth"),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(bar_width=30),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TimeRemainingColumn(),
+        transient=True,
+    ) as progress:
+        size = os.stat(path).st_size
+        task = progress.add_task(
+            f"[green]Uploading [bold]{os.path.basename(path)}[/bold]", total=size
+        )
+
+        response = client().upload_file(
+            path,
+            bucket,
+            key,
+            ExtraArgs={"ACL": acl, "Metadata": metadata},
+            Callback=lambda complete: progress.update(task, completed=complete),
+        )
+    return response
+
+
+def download_folder(
+    bucket, prefix, export_path, include_prefix_in_export=False
+) -> None:
+    """given bucket, prefix filter, and export path, download contents of folder from s3 recursively"""
+    export_path = Path(export_path)
+    if prefix[-1] != "/":
+        raise NotADirectoryError("prefix must be a folder path, ending with '/'")
+
+    client_ = client()
+    resp = client_.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    if not "Contents" in resp:
+        raise NotADirectoryError(f"Folder {prefix} not found in bucket {bucket}")
+    for obj in resp["Contents"]:
+        key = obj["Key"].replace(prefix, "")
+        if key and (key[-1] != "/"):
+            key_directory = os.path.dirname(key)
+            if include_prefix_in_export:
+                export_path = export_path / prefix
+            if not (export_path / key_directory).exists():
+                os.makedirs(export_path / key_directory)
+            client_.download_file(bucket, obj["Key"], export_path / key)
+
+
+def upload_folder(
+    bucket:str,
+    local_folder_path:str,
+    upload_path:str,
+    acl: str = "public-read",
+    metadata: dict = {},
+    include_foldername: bool=True,
+):
+    local_folder_path = Path(local_folder_path)
+    if not local_folder_path.exists() or (not local_folder_path.is_dir()):
+        raise ValueError(f"'{local_folder_path}' is not a folder.")
+    for path_object in local_folder_path.rglob('*'):
+        if path_object.is_file():
+            if not include_foldername:
+                key = upload_path / Path(*path_object.parts[2:])
+            else:
+                key = Path(upload_path) / path_object
+            upload_file(bucket, path_object, str(key), acl=acl, metadata=metadata)

--- a/dcpy/connectors/s3.py
+++ b/dcpy/connectors/s3.py
@@ -60,7 +60,7 @@ def upload_file(
             bucket,
             key,
             ExtraArgs=extra_args,
-            Callback=lambda complete: progress.update(task, completed=complete),
+            Callback=lambda bytes: progress.update(task, advance=bytes),
         )
     return response
 

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -14,6 +14,7 @@ pytest-cov==4.0.0
 python-dotenv==0.20.0
 python-geosupport @ git+https://github.com/NYCPlanning/python-geosupport.git@3b8df06
 PyYAML>=5.4.1
+rich>=13.4.2
 sqlalchemy==2.0.15
 tabulate==0.9.0
 tqdm>=4.59.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,9 +17,9 @@ backcall==0.2.0
     # via ipython
 black==23.1.0
     # via -r ./python/requirements.in
-boto3==1.28.11
+boto3==1.28.14
     # via -r ./python/requirements.in
-botocore==1.31.11
+botocore==1.31.14
     # via
     #   boto3
     #   s3transfer
@@ -125,6 +125,8 @@ kiwisolver==1.4.4
     # via matplotlib
 mapclassify==2.5.0
     # via -r ./python/requirements.in
+markdown-it-py==3.0.0
+    # via rich
 markupsafe==2.1.3
     # via jinja2
 matplotlib==3.7.1
@@ -135,11 +137,13 @@ matplotlib-inline==0.1.6
     # via
     #   ipykernel
     #   ipython
+mdurl==0.1.2
+    # via markdown-it-py
 mercantile==1.2.1
     # via contextily
 mypy-extensions==1.0.0
     # via black
-nest-asyncio==1.5.6
+nest-asyncio==1.5.7
     # via ipykernel
 networkx==3.1
     # via mapclassify
@@ -198,7 +202,9 @@ ptyprocess==0.7.0
 pure-eval==0.2.2
     # via stack-data
 pygments==2.15.1
-    # via ipython
+    # via
+    #   ipython
+    #   rich
 pyparsing==3.1.0
     # via
     #   matplotlib
@@ -237,6 +243,8 @@ requests==2.31.0
     # via
     #   contextily
     #   folium
+rich==13.4.2
+    # via -r ./python/requirements.in
 s3transfer==0.6.1
     # via boto3
 scikit-learn==1.3.0


### PR DESCRIPTION
A couple points

- do we want to use the `rich` printing/progress I copied over from data library? Essentially all `upload_file` is is a wrapper around boto3 client built-in upload with this progress. If we like this we could do a similar thing for download
- download_folder is essentially ported over from @DeaBardhoshi and @athursland 's work in db-checkbook
- ~~should acl have default? This is what we had in data library but it seems maybe it's good to make ourselves be explicit if we're making things being pushed public rather than defaulting to it~~ going with no default - acl must be passed explicitly. We could have a small wrapper in `recipes` if we really want one that defaults to public but this will likely be used to push publishing data as well
- ~~I have a funny mish-mash of os.path stuff and pathlib.Path~~ better now I think

