### PR TITLE
Expose Jupyter Notebook default port in container

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       POSTGRES_PASSWORD: postgres
     expose: 
       - "5432"
+    ports:
+      - "8888:8888"
 
 volumes:
   postgres-data:


### PR DESCRIPTION
It's nice to run a jupyter notebook in docker to have access to pg, dockerized python deps, and gdal, etc.