### PR TITLE
delete reference to deprecated test param in db-checkbook build

### DIFF
--- a/products/db-checkbook/build_scripts/build.py
+++ b/products/db-checkbook/build_scripts/build.py
@@ -146,9 +146,7 @@ def _clean_joined_checkbook_cpdb(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     gdf['bc_category'].fillna('None', inplace=True)
     gdf['cp_category'].fillna('None', inplace=True)
     gdf.drop('_merge', axis=1, inplace=True)
-    if not test:
-        gdf = _limit_cols(gdf)
-    return gdf
+    return _limit_cols(gdf)
 
 def _limit_cols(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """


### PR DESCRIPTION
resubmitting PR after pulling changes to monorepo folder structure from main. one-line fix in _clean_joined_checkbook_cpdb() to remove reference to outdated test param (from unit tests) 