### PR TITLE
fix devdb templates path in datasync action

### DIFF
--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           # name of the dataset
           name: ${{ matrix.dataset }}
-          path: db-developments/templates/${{ matrix.dataset }}.yml
+          path: products/db-developments/templates/${{ matrix.dataset }}.yml
           s3: true
           latest: true
           compress: true

--- a/products/db-developments/bash/config.sh
+++ b/products/db-developments/bash/config.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-FILE_DIR=$(dirname "$(readlink -f "$0")")
-ROOT_DIR="${FILE_DIR}/../../.."
+source ../../bash/utils.sh
 
-source $ROOT_DIR/bash/utils.sh
-
-set_env $ROOT_DIR/.env version.env
+set_env .env version.env
 set_error_traps
 
 


### PR DESCRIPTION
per [failed scheduled action run](https://github.com/NYCPlanning/data-engineering/actions/runs/5779538228/job/15661960781#step:4:181), the path to [`products/db-developments/templates/`](https://github.com/NYCPlanning/data-engineering/tree/main/products/db-developments/templates) was missing the `products/` part

per [failed action run](https://github.com/NYCPlanning/data-engineering/actions/runs/5786521830/job/15682000508#step:5:14), the path to the shared bash utils at `bash/utils.sh` could not be found at the top of `products/db-developments/bash/config.sh`

[successful action run using this branch](https://github.com/NYCPlanning/data-engineering/actions/runs/5787507408)