### PR TITLE
use a github secret in db-template tests

### DIFF
--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -25,6 +25,8 @@ jobs:
   branch_unit_tests:
     name: Unit tests
     runs-on: ubuntu-22.04
+    env:
+      TOY_SECRET: toy_secret_value
     container:
       image: nycplanning/build-geosupport:latest
     defaults:

--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -26,7 +26,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-22.04
     env:
-      TOY_SECRET: toy_secret_value
+      TOY_SECRET: ${{ secrets.TOY_SECRET }}
     container:
       image: nycplanning/build-geosupport:latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
     needs: confirm_changes
     if: contains(needs.check_changes.outputs.path_filters, 'template')
     uses: ./.github/workflows/template_test.yml
+    secrets: inherit
   cbbr:
     needs: confirm_changes
     if: contains(needs.check_changes.outputs.path_filters, 'cbbr')

--- a/products/db-template/tests/test_utils.py
+++ b/products/db-template/tests/test_utils.py
@@ -1,10 +1,16 @@
+import os
 import geopandas as gpd
 import pandas as pd
 import pytest
 
 from python.utils import load_data_file, load_geodata_url, load_shapefile
 
+TOY_SECRET = os.environ["TOY_SECRET"]
 TEST_DATA_PATH = "tests/test_data"
+
+
+def test_use_of_github_secret():
+    assert TOY_SECRET == "toy_secret_value"
 
 
 def test_load_data_file_csv():


### PR DESCRIPTION
this was originally an exercise to troubleshoot other dev work, but this seems informative enough to squash & merge

## motivation
- when an action is triggered via `workfloa_call`, how can it be passed a github secret to use it as an environment variable?
- called actions don't have access to secrets by default?

## series of changes and results of tests in this branch
1. [a KeyError](https://github.com/NYCPlanning/data-engineering/actions/runs/5789853710/job/15691806582#step:5:33) when using an undeclared envar
2. [works](https://github.com/NYCPlanning/data-engineering/actions/runs/5789903190/job/15691952005#step:5:33) when the envar is hardcoded
3. [envar is blank](https://github.com/NYCPlanning/data-engineering/actions/runs/5789953209/job/15692094240#step:5:70) when trying to use a github secret
4. [works](https://github.com/NYCPlanning/data-engineering/actions/runs/5789987702/job/15692186716#step:5:34) when secrets are inherited from the caller action