### PR TITLE
ensure zap workflows work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,10 @@ jobs:
               - products/db-checkbook/**
             qaqc:
               - apps/qaqc/**
+            zap:
+              - .github/workflows/zap_test.yml
+              - .github/workflows/build.yml
+              - products/db-zap-opendata/**
 
   confirm_changes:
     name: Confirm changes to relevant files
@@ -78,4 +82,8 @@ jobs:
     needs: confirm_changes
     if: contains(needs.check_changes.outputs.path_filters, 'qaqc')
     uses: ./.github/workflows/qaqc_test.yml
+  zap:
+    needs: confirm_changes
+    if: contains(needs.check_changes.outputs.path_filters, 'zap')
+    uses: ./.github/workflows/zap_test.yml
     secrets: inherit

--- a/.github/workflows/zap_build_mapzap.yml
+++ b/.github/workflows/zap_build_mapzap.yml
@@ -1,4 +1,4 @@
-name: Build MapZAP
+name: ZAP - MapZAP (Placeholder)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/zap_export.yml
+++ b/.github/workflows/zap_export.yml
@@ -1,4 +1,4 @@
-name: Weekly Export from CRM to BigQuery
+name: ZAP - Weekly Export from CRM to BigQuery
 
 on:
   schedule:
@@ -8,17 +8,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: products/db-zap-opendata
     env:
-      CLIENT_ID: ${{ secrets.CLIENT_ID }}
-      SECRET: ${{ secrets.SECRET }}
-      TENANT_ID: ${{ secrets.TENANT_ID }}
-      ZAP_DOMAIN: ${{ secrets.ZAP_DOMAIN }}
-      ZAP_ENGINE: ${{ secrets.ZAP_ENGINE }}
+      ZAP_DOMAIN: ${{ secrets.ZAP_CRM_DOMAIN }}
+      TENANT_ID: ${{ secrets.ZAP_CRM_TENANT_ID }}
+      CLIENT_ID: ${{ secrets.ZAP_CRM_CLIENT_ID }}
+      SECRET: ${{ secrets.ZAP_CRM_SECRET }}
+      ZAP_ENGINE: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}/edm-zap
+      EDM_DATA_ZAP_SCHEMA: weekly_export_${{ github.event_name }}_${{ github.ref_name }}
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       AWS_S3_LIBRARY_BUCKET: edm-recipes
-      EDM_DATA_ZAP_SCHEMA: export_${{ github.event_name }}_${{ github.ref_name }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -55,12 +59,13 @@ jobs:
           DATE=$(date +%Y%m%d)
           echo "version=$DATE" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID_DATA_ENGINEERING }}
-          service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}
-          export_default_credentials: true
+      # NOTE disabling all use of BigQuery
+      # - name: Set up Cloud SDK
+      #   uses: google-github-actions/setup-gcloud@v0
+      #   with:
+      #     project_id: ${{ secrets.GCP_PROJECT_ID_DATA_ENGINEERING }}
+      #     service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}
+      #     export_default_credentials: true
 
       - name: Set up Mini IO
         run: |
@@ -69,17 +74,19 @@ jobs:
           sudo mv ./mc /usr/bin
           mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
 
-      - name: Archive to BigQuery
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: ./zap.sh upload_bq ${{ matrix.entity }} $VERSION
+      # NOTE disabling all use of BigQuery
+      # - name: Archive to BigQuery
+      #   env:
+      #     VERSION: ${{ steps.version.outputs.version }}
+      #   run: ./zap.sh upload_bq ${{ matrix.entity }} $VERSION
 
-      - name: Archive recoded data to BigQuery
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        if: ${{ matrix.open }}
-        run: |
-          ./zap.sh upload_recoded_bq ${{ matrix.entity }} $VERSION
+      # NOTE disabling all use of BigQuery
+      # - name: Archive recoded data to BigQuery
+      #   env:
+      #     VERSION: ${{ steps.version.outputs.version }}
+      #   if: ${{ matrix.open }}
+      #   run: |
+      #     ./zap.sh upload_recoded_bq ${{ matrix.entity }} $VERSION
 
       - name: Archive to data library - PGdump
         env:

--- a/.github/workflows/zap_single_visible.yml
+++ b/.github/workflows/zap_single_visible.yml
@@ -1,4 +1,4 @@
-name: Export Single Open Dataset from CRM to DO
+name: ZAP - Export Single Open Dataset from CRM to DO
 run-name: Export ${{ inputs.dataset }}
 
 on:
@@ -16,12 +16,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: products/db-zap-opendata
     env:
-      CLIENT_ID: ${{ secrets.CLIENT_ID }}
-      SECRET: ${{ secrets.SECRET }}
-      TENANT_ID: ${{ secrets.TENANT_ID }}
-      ZAP_DOMAIN: ${{ secrets.ZAP_DOMAIN }}
-      ZAP_ENGINE: ${{ secrets.ZAP_ENGINE }}
+      CLIENT_ID: ${{ secrets.ZAP_CRM_CLIENT_ID }}
+      SECRET: ${{ secrets.ZAP_CRM_SECRET }}
+      TENANT_ID: ${{ secrets.ZAP_CRM_TENANT_ID }}
+      ZAP_DOMAIN: ${{ secrets.ZAP_CRM_ZAP_DOMAIN }}
+      ZAP_ENGINE: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}/edm-zap
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}

--- a/.github/workflows/zap_test.yml
+++ b/.github/workflows/zap_test.yml
@@ -1,25 +1,25 @@
-name: Branch tests
+name: ZAP - Tests
 run-name: Tests (${{ github.event_name }})
 
 on: 
-  workflow_dispatch:
-
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  workflow_call:
 
 env:
-  ZAP_DOMAIN: ${{ secrets.ZAP_DOMAIN }}
-  TENANT_ID: ${{ secrets.TENANT_ID }}
-  CLIENT_ID: ${{ secrets.CLIENT_ID }}
-  SECRET: ${{ secrets.SECRET }}
-  ZAP_ENGINE: ${{ secrets.ZAP_ENGINE }}
+  ZAP_DOMAIN: ${{ secrets.ZAP_CRM_DOMAIN }}
+  TENANT_ID: ${{ secrets.ZAP_CRM_TENANT_ID }}
+  CLIENT_ID: ${{ secrets.ZAP_CRM_CLIENT_ID }}
+  SECRET: ${{ secrets.ZAP_CRM_SECRET }}
+  ZAP_ENGINE: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}/edm-zap
   TEST_SCHEMA_SUFFIX: pr_${{ github.event.pull_request.number || 'workflow_dispatch' }}
 
 jobs:
   branch_unit_tests:
     name: Unit tests
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: products/db-zap-opendata
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
@@ -37,6 +37,10 @@ jobs:
   branch_integration_tests:
     name: Integration tests
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: products/db-zap-opendata
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
@@ -65,6 +69,7 @@ jobs:
       - name: Build and run dev container task
         uses: devcontainers/ci@v0.3
         with:
+          subFolder: products/db-zap-opendata
           runCmd: |
             echo "Dev Container is in CI? $CI"
             gcloud version

--- a/products/db-zap-opendata/src/visible_projects.py
+++ b/products/db-zap-opendata/src/visible_projects.py
@@ -101,8 +101,7 @@ def make_staging_table(sql_engine, dataset_name) -> None:
                     %(source_table_name)s.dcp_userinputborough as unverified_borough,
                     %(source_table_name)s.dcp_userinputblock as unverified_block,
                     %(source_table_name)s.dcp_userinputlot as unverified_lot
-             from %(source_table_name)s INNER JOIN dcp_projects_recoded
-            on SUBSTRING(%(source_table_name)s.dcp_name, 0,10) = dcp_projects_recoded.project_id);
+            FROM %(source_table_name)s);
             COMMIT;
         """ % {
             "source_table_name": source_table_name,
@@ -112,7 +111,7 @@ def make_staging_table(sql_engine, dataset_name) -> None:
         statement_staging_table = """
             BEGIN;
             DROP TABLE IF EXISTS %{staging_table_name}s;
-            CREATE TABLE %{staging_table_name}s as SELECT * FROM %{source_table_name}s
+            CREATE TABLE %{staging_table_name}s as SELECT * FROM %{source_table_name}s;
             COMMIT;
         """ % {
             "source_table_name": source_table_name,

--- a/products/db-zap-opendata/tests/test_runner.py
+++ b/products/db-zap-opendata/tests/test_runner.py
@@ -28,20 +28,16 @@ test_datasets = [
     TestDataset(
         table_name="dcp_projects",
         filter_clause="""
-            where dcp_name in (
-                'P2016K0159', '2023K0228', 'P2005K0122', '2021M0260'
-                )
+            where dcp_name in ('2023K0228')
             """,
-        expected_row_count=4,
+        expected_row_count=1,
     ),
     TestDataset(
         table_name="dcp_projectbbls",
         filter_clause="""
-            where SUBSTRING(dcp_name, 0,10) in (
-                'P2016K0159', '2023K0228', 'P2005K0122', '2021M0260'
-                )
+            where SUBSTRING(dcp_name, 0,10) in ('2023K0228') and dcp_bblnumber = '3050637501'
             """,
-        expected_row_count=2210,
+        expected_row_count=8,
     ),
 ]
 
@@ -68,7 +64,6 @@ def test_runner_download(test_dataset):
         schema=test_schema_actual,
     )
     runner.download()
-    # TODO assert things
 
 
 @pytest.mark.integration()
@@ -81,7 +76,6 @@ def test_runner_combine(test_dataset):
     runner.combine()
 
     table_name = f"{test_dataset.table_name}_crm"
-
     test_data_query_parameters = {
         "dataset_name": table_name,
         "filter_clause": test_dataset.filter_clause,
@@ -95,7 +89,9 @@ def test_runner_combine(test_dataset):
         .sort_values(by="@odata.etag")
         .reset_index()
     )
-    # TODO assert things
+
+    assert len(test_data_actual) == test_dataset.expected_row_count
+    # TODO compare entire tables
     # runner_expected = Runner(name=test_dataset.table_name, schema=test_data_expected_schema)
     # test_data_expected = runner_expected.pg.execute_select_query(
     #     base_query=test_data_query,


### PR DESCRIPTION
resolves #152 and related to #143

## cause of record count anomaly issue
- there appeared to be duplicates in the raw Project and Project BBL data pulled from the CRM (e.g. Project ID `2023K0228` and BBL `3050637501`)
- these duplicates were caused by the appending of CRM records to existing SQL tables
  - each dataset is downloaded as multiple json files
  - during the `combine` stage of the `Runner`, all downloaded json files [are written to a sql table](https://github.com/NYCPlanning/data-engineering/blob/main/products/db-zap-opendata/src/runner.py#L133-L139) using `if_exists="append"`
  - all sql queries in this data product use [a DB schema arg](https://github.com/NYCPlanning/data-engineering/blob/main/products/db-zap-opendata/src/runner.py#L38) passed to the `Runner` so that data is isolated by build environment in a persistent database `edm-zap`
    - examples of DB schemas are `weekly_export_schedule_main`, `weekly_export_workflow_dispatch_zap_runnable`, `test_data_actual_pr_147`
- **[we weren't deleting the table](https://github.com/NYCPlanning/data-engineering/blob/main/products/db-zap-opendata/src/runner.py#L107-L117) if it exists before writing the first json file to sql**

## changes
- add ZAP product to centralized test workflow
- rename and fix secrets in ZAP workflows
- ensure an existing sql table is deleted before ingesting new CRM data
- remove a redundant `INNER JOIN` from an early intermittent `dcp_projectbbls` table (it's used to limit BBL records to publicly visible projects, doesn't have to happen twice)
- add an assertion to an integration test to ensure a single project and a BBL associated with it have the expected number of rows in their respective tables after `Runner.combine()`


## run notes
- most recent CRM export run on this branch: [link](https://github.com/NYCPlanning/data-engineering/actions/runs/5870648856)
- The file sizes from the 8/15 build are very close to those from the valid 7/17 build and have the following row counts:
  - Projects file: 32,428
  - Project BBLs file: 67,289

## dev notes
- inspecting integration test results helped identify the problem. the number for rows for a single project was increasing after each test (e.g. [5 rows](https://github.com/NYCPlanning/data-engineering/actions/runs/5869800018/job/15915549659#step:5:266) became [6 rows](https://github.com/NYCPlanning/data-engineering/actions/runs/5869866740/job/15915739481#step:5:266))
- ZAP devcontainer/image requires google cloud services so I held off on switching to our standard one. but we don't use the bigquery tables at all so I commented out all uses of it and we can revisit this