### PR TITLE
fix zap tests failing on all PRs

### DIFF
--- a/.github/workflows/zap_tests_branch.yml
+++ b/.github/workflows/zap_tests_branch.yml
@@ -1,7 +1,8 @@
 name: Branch tests
 run-name: Tests (${{ github.event_name }})
 
-on: [pull_request, workflow_dispatch]
+on:
+  workflow_call:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
follow up to #145

ZAP tests [are failing](https://github.com/NYCPlanning/data-engineering/actions/runs/5814017939) on all PRs because they haven't been changed yet to run in the monorepo

these tests shouldn't be running yet and, when they do, should only be triggered by the centralized test.yml workflow