### PR TITLE
PFF tweaks for decennial manual update

### DIFF
--- a/dcpy/utils/json.py
+++ b/dcpy/utils/json.py
@@ -1,0 +1,8 @@
+import json
+import pandas as pd
+
+
+def df_to_json(df: pd.DataFrame):
+    """Converts pandas dataframe to pretty json
+    Prints as json array rather than standard to_json"""
+    return json.dumps(json.loads(df.to_json(orient="records")), indent=4)

--- a/products/db-factfinder/factfinder/data/decennial/2010/metadata.json
+++ b/products/db-factfinder/factfinder/data/decennial/2010/metadata.json
@@ -1,204 +1,827 @@
 [
     {
-        "pff_variable": "decennial_pop",
-        "base_variable": "decennial_pop",
-        "census_variable": [
-            "P001001"
-        ],
-        "domain": "community_profiles",
-        "rounding": 0,
-        "category": "decennial"
+        "pff_variable": "GeogType",
+        "base_variable": null,
+        "category": null
     },
     {
-        "pff_variable": "pop1",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Year",
+        "base_variable": null,
+        "category": null
     },
     {
-        "pff_variable": "popinhh",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "GeoID",
+        "base_variable": null,
+        "category": null
     },
     {
-        "pff_variable": "ingrpqtrs",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Pop1",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "institlzd",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Male ",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "avghhsz",
-        "census_variable": [],
-        "base_variable": "mean",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Fem",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "popperacre",
-        "census_variable": [],
+        "pff_variable": "PopU5",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop5t9",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop10t14",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop15t19",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop20t24",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop25t29",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop30t34",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop35t39",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop40t44",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop45t49",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop50t54",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop55t59",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop60t64",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop65t69",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop70t74",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop75t79",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop80t84",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop85pl",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "MdAge",
+        "base_variable": "median",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "PopU18",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop65pl",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "AgDpdRt",
+        "base_variable": "rate",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "OdAgDpdRt",
+        "base_variable": "rate",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "ChldDpdRt",
+        "base_variable": "rate",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "PopAcre",
         "base_variable": "ratio",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "pop2",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "male ",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "fem",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18_1",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18_2",
-        "census_variable": [],
-        "base_variable": "popu18_2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18m",
-        "census_variable": [],
-        "base_variable": "popu18_2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18f",
-        "census_variable": [],
-        "base_variable": "popu18_2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "pop3",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "Pop2",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "hsp1",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "Hsp1",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "wnh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "WNH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "bnh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "BNH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "anh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "ANH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "onh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "ONH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "twoplnh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "TwoPlNH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "hunits",
-        "census_variable": [],
-        "base_variable": "hunits",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "Pop3",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "PopInHH_1",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "HHldr",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "InGrpQtrs",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "Institlzd",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQCrctl",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQJuv",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQNrsng",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQOInst",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "NoInstlzd",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQClgHsg",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQMltry",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQONInst",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "HH_1",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "NFmLvgAln",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "NFLvA65pl",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HH_2",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HHwU18",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HHw65pl",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HUnits",
+        "base_variable": "HUnits",
         "category": "HOUSING OCCUPANCY"
     },
     {
-        "pff_variable": "ochu_1",
-        "census_variable": [],
-        "base_variable": "hunits",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "OcHU_1",
+        "base_variable": "HUnits",
         "category": "HOUSING OCCUPANCY"
     },
     {
-        "pff_variable": "vachus",
-        "census_variable": [],
-        "base_variable": "hunits",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "VacHUs",
+        "base_variable": "HUnits",
         "category": "HOUSING OCCUPANCY"
     },
     {
-        "pff_variable": "landacres",
-        "census_variable": [],
-        "base_variable": "popperacre",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "For Persons per Acre"
+        "pff_variable": "VHUFRnt",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHURNOc",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUFSlO",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUSNOc",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUFSRoOU",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUMigWrk",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUOthVc",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "HmOwnVcRt",
+        "base_variable": "rate",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "RntVcRt",
+        "base_variable": "rate",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "OcHU_2",
+        "base_variable": "OcHU_2",
+        "category": "HOUSING TENURE"
+    },
+    {
+        "pff_variable": "OOcHU_1",
+        "base_variable": "OcHU_2",
+        "category": "HOUSING TENURE"
+    },
+    {
+        "pff_variable": "ROcHU_1",
+        "base_variable": "OcHU_2",
+        "category": "HOUSING TENURE"
+    },
+    {
+        "pff_variable": "OcHU_3",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH1person",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH2ppl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH3ppl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH4ppl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH5plPpl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "AvgHHSz",
+        "base_variable": "mean",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHU_2",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH1",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH2",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH3",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH4",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH5pl",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHU_2",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH1",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH2",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH3",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH4",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH5pl",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "Pop4",
+        "base_variable": "PopAcre",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "LandAcres",
+        "base_variable": "PopAcre",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "PopInHH_2",
+        "base_variable": "AvgHHSz",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "HH_3",
+        "base_variable": "AvgHHSz",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "AgeU5",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age5t9",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age10t14",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age15t17",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age18t19",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age20",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age21",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age22t24",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age25t29",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age30t34",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age35t39",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age40t44",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age45t49",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age50t54",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age55t59",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age60t61",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age62t64",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age65t66",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age67t69",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age70t74",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age75t79",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age80t84",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age85pl",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "AgU1865pl",
+        "base_variable": "AgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Ag18t64",
+        "base_variable": "AgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "OdAg65pl",
+        "base_variable": "OdAgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "OdAg18t64",
+        "base_variable": "OdAgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "CDpdU18",
+        "base_variable": "ChldDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "CDpd18t64",
+        "base_variable": "ChldDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "HOVacU",
+        "base_variable": "HmOwnrVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "VacSale",
+        "base_variable": "HmOwnrVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "RntVacU",
+        "base_variable": "RntVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "VacRnt",
+        "base_variable": "RntVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Pop5",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop0t5",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop5t9",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop10t14",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop15t19",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop20t24",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop25t29",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop30t34",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop35t39",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop40t44",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop45t49",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop50t54",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop55t59",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop60t64",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop65t69",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop70t74",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop75t79",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop80t84",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop85pl",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop0t5",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop5t9",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop10t14",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop15t19",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop20t24",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop25t29",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop30t34",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop35t39",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop40t44",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop45t49",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop50t54",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop55t59",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop60t64",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop65t69",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop70t74",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop75t79",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop80t84",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop85pl",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
     }
 ]

--- a/products/db-factfinder/factfinder/data/decennial/2020/metadata.json
+++ b/products/db-factfinder/factfinder/data/decennial/2020/metadata.json
@@ -1,204 +1,827 @@
 [
     {
-        "pff_variable": "decennial_pop",
-        "base_variable": "decennial_pop",
-        "census_variable": [
-            "P001001"
-        ],
-        "domain": "community_profiles",
-        "rounding": 0,
-        "source": "decennial"
+        "pff_variable": "GeogType",
+        "base_variable": null,
+        "category": null
     },
     {
-        "pff_variable": "pop1",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Year",
+        "base_variable": null,
+        "category": null
     },
     {
-        "pff_variable": "popinhh",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "GeoID",
+        "base_variable": null,
+        "category": null
     },
     {
-        "pff_variable": "ingrpqtrs",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Pop1",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "institlzd",
-        "census_variable": [],
-        "base_variable": "pop1",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Male ",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "avghhsz",
-        "census_variable": [],
-        "base_variable": "mean",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "pff_variable": "Fem",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "popperacre",
-        "census_variable": [],
+        "pff_variable": "PopU5",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop5t9",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop10t14",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop15t19",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop20t24",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop25t29",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop30t34",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop35t39",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop40t44",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop45t49",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop50t54",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop55t59",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop60t64",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop65t69",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop70t74",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop75t79",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop80t84",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop85pl",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "MdAge",
+        "base_variable": "median",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "PopU18",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "Pop65pl",
+        "base_variable": "Pop1",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "AgDpdRt",
+        "base_variable": "rate",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "OdAgDpdRt",
+        "base_variable": "rate",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "ChldDpdRt",
+        "base_variable": "rate",
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
+    },
+    {
+        "pff_variable": "PopAcre",
         "base_variable": "ratio",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "POPULATION"
+        "category": "POPULATION, SEX, AGE, AND DENSITY"
     },
     {
-        "pff_variable": "pop2",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "male ",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "fem",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18_1",
-        "census_variable": [],
-        "base_variable": "pop2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18_2",
-        "census_variable": [],
-        "base_variable": "popu18_2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18m",
-        "census_variable": [],
-        "base_variable": "popu18_2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "popu18f",
-        "census_variable": [],
-        "base_variable": "popu18_2",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "AGE AND SEX"
-    },
-    {
-        "pff_variable": "pop3",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "Pop2",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "hsp1",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "Hsp1",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "wnh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "WNH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "bnh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "BNH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "anh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "ANH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "onh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "ONH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "twoplnh",
-        "census_variable": [],
-        "base_variable": "pop3",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "TwoPlNH",
+        "base_variable": "Pop2",
         "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
     },
     {
-        "pff_variable": "hunits",
-        "census_variable": [],
-        "base_variable": "hunits",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "Pop3",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "PopInHH_1",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "HHldr",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "InGrpQtrs",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "Institlzd",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQCrctl",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQJuv",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQNrsng",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQOInst",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "NoInstlzd",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQClgHsg",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQMltry",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "GQONInst",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+    },
+    {
+        "pff_variable": "HH_1",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "NFmLvgAln",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "NFLvA65pl",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HH_2",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HHwU18",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HHw65pl",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE "
+    },
+    {
+        "pff_variable": "HUnits",
+        "base_variable": "HUnits",
         "category": "HOUSING OCCUPANCY"
     },
     {
-        "pff_variable": "ochu_1",
-        "census_variable": [],
-        "base_variable": "hunits",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "OcHU_1",
+        "base_variable": "HUnits",
         "category": "HOUSING OCCUPANCY"
     },
     {
-        "pff_variable": "vachus",
-        "census_variable": [],
-        "base_variable": "hunits",
-        "domain": "decennial",
-        "rounding": 0,
+        "pff_variable": "VacHUs",
+        "base_variable": "HUnits",
         "category": "HOUSING OCCUPANCY"
     },
     {
-        "pff_variable": "landacres",
-        "census_variable": [],
-        "base_variable": "popperacre",
-        "domain": "decennial",
-        "rounding": 0,
-        "category": "For Persons per Acre"
+        "pff_variable": "VHUFRnt",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHURNOc",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUFSlO",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUSNOc",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUFSRoOU",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUMigWrk",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "VHUOthVc",
+        "base_variable": "HUnits",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "HmOwnVcRt",
+        "base_variable": "rate",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "RntVcRt",
+        "base_variable": "rate",
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "OcHU_2",
+        "base_variable": "OcHU_2",
+        "category": "HOUSING TENURE"
+    },
+    {
+        "pff_variable": "OOcHU_1",
+        "base_variable": "OcHU_2",
+        "category": "HOUSING TENURE"
+    },
+    {
+        "pff_variable": "ROcHU_1",
+        "base_variable": "OcHU_2",
+        "category": "HOUSING TENURE"
+    },
+    {
+        "pff_variable": "OcHU_3",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH1person",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH2ppl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH3ppl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH4ppl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "HH5plPpl",
+        "base_variable": "OcHU_3",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "AvgHHSz",
+        "base_variable": "mean",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHU_2",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH1",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH2",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH3",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH4",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "OOcHH5pl",
+        "base_variable": "OOcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHU_2",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH1",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH2",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH3",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH4",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "ROcHH5pl",
+        "base_variable": "ROcHU_2",
+        "category": "HOUSEHOLD SIZE"
+    },
+    {
+        "pff_variable": "Pop4",
+        "base_variable": "PopAcre",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "LandAcres",
+        "base_variable": "PopAcre",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "PopInHH_2",
+        "base_variable": "AvgHHSz",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "HH_3",
+        "base_variable": "AvgHHSz",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "AgeU5",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age5t9",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age10t14",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age15t17",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age18t19",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age20",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age21",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age22t24",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age25t29",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age30t34",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age35t39",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age40t44",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age45t49",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age50t54",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age55t59",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age60t61",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age62t64",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age65t66",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age67t69",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age70t74",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age75t79",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age80t84",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Age85pl",
+        "base_variable": "MdAge",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "AgU1865pl",
+        "base_variable": "AgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Ag18t64",
+        "base_variable": "AgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "OdAg65pl",
+        "base_variable": "OdAgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "OdAg18t64",
+        "base_variable": "OdAgDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "CDpdU18",
+        "base_variable": "ChldDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "CDpd18t64",
+        "base_variable": "ChldDpdRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "HOVacU",
+        "base_variable": "HmOwnrVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "VacSale",
+        "base_variable": "HmOwnrVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "RntVacU",
+        "base_variable": "RntVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "VacRnt",
+        "base_variable": "RntVcRt",
+        "category": "Special Variable"
+    },
+    {
+        "pff_variable": "Pop5",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop0t5",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop5t9",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop10t14",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop15t19",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop20t24",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop25t29",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop30t34",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop35t39",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop40t44",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop45t49",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop50t54",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop55t59",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop60t64",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop65t69",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop70t74",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop75t79",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop80t84",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "MPop85pl",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop0t5",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop5t9",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop10t14",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop15t19",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop20t24",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop25t29",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop30t34",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop35t39",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop40t44",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop45t49",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop50t54",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop55t59",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop60t64",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop65t69",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop70t74",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop75t79",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop80t84",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
+    },
+    {
+        "pff_variable": "FPop85pl",
+        "base_variable": "Pop5",
+        "category": "PopPyramid Only"
     }
 ]

--- a/products/db-factfinder/pipelines/utils.py
+++ b/products/db-factfinder/pipelines/utils.py
@@ -10,6 +10,9 @@ from dcpy.utils.git import git_branch
 from pipelines import PRODUCT_PATH
 
 
+DATA_PATH = PRODUCT_PATH / "factfinder" / "data"
+
+
 def parse_args() -> Tuple[str, str, bool]:
     parser = argparse.ArgumentParser()
 
@@ -43,9 +46,7 @@ def download_manual_update(update_type, version, overwrite=False):
     recipe_names = {"acs": "dcp_pop_acs", "decennial": "dcp_pop_decennial_dhc"}
     if update_type not in recipe_names:
         raise ValueError("'update_type' must either be 'acs' or 'decennial'")
-    output_folder = (
-        PRODUCT_PATH / f"factfinder/data/{update_type}_manual_updates/{version}"
-    )
+    output_folder = DATA_PATH / f"{update_type}_manual_updates" / version
     filepath = output_folder / f"{recipe_names[update_type]}.xlsx"
     if not filepath.exists() or overwrite:
         print(f"Downloading {update_type} manual update data ...")
@@ -61,7 +62,10 @@ def download_manual_update(update_type, version, overwrite=False):
 
 
 def s3_upload(file: Path, latest=True):
-    export_type = file.stem
+    if file.suffix == ".json":
+        export_type = file.parent.parent.name
+    else:
+        export_type = file.stem
     year = file.parent.name
     upload(
         output=file,


### PR DESCRIPTION
Continuation of #67. Per convo with EM, some changes around schema. 
- don't use metadata.json as input. These files were written as part of the api-pulling code. When they were written, the decennial census had not released as much data as they did for the latest update (far fewer columns before - 20ish vs 200ish). 
  - don't filter columns based on inclusion in old metadata files
  - don't rename new column headers to align with old, but use new instead
- generate new metadata files
  - these are used by OSE/AE in their ingestion. From glancing at [their code](https://github.com/search?q=repo%3ANYCPlanning%2Flabs-factfinder-api+-%3E%3E+%27base_variable%27&amp%3Btype=code&type=code), it seems like they only need `pff_variable`, `base_variable`, `domain`, and `category`. 
 
Need to think a little bit about long-term health here. It's a little odd to both have the metadata be defined by us but also semi-auto-generated from excels from housing. It also might make sense to export these metadata files to DO and not keep in the repo at the moment, since they really are outputs now rather than metadata inputs - also, currently I believe OSE/AE is grabbing them from the repo. if we're just generating them, we can export them to DO instead and not need to commit changes as part of a build. For now I'll do both (commit changes and export to DO), but worth revisiting.