### PR TITLE
Fvk pff tweaks

### DIFF
--- a/products/factfinder/factfinder/data/decennial/2010/metadata.json
+++ b/products/factfinder/factfinder/data/decennial/2010/metadata.json
@@ -1,974 +1,204 @@
 [
     {
-        "pff_variable": "Pop1",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Male",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Fem",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopU5",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop5t9",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop10t14",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop15t19",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop20t24",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop25t29",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop30t34",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop35t39",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop40t44",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop45t49",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop50t54",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop55t59",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop60t64",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop65t69",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop70t74",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop75t79",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop80t84",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop85pl",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MdAge",
-        "base_variable": "median",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopU18",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop65pl",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AgDpdRt",
-        "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OdAgDpdRt",
-        "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ChldDpdRt",
-        "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopAcre",
-        "base_variable": "ratio",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop2",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Hsp1",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "WNH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "BNH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ANH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ONH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "TwoPlNH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop3",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopInHH_1",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HHldr",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "InGrpQtrs",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Institlzd",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQCrctl",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQJuv",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQNrsng",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQOInst",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NoInstlzd",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQClgHsg",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQMltry",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQONInst",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH_1",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NFmLvgAln",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NFLvA65pl",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH_2",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HHwU18",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HHw65pl",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HUnits",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OcHU_1",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VacHUs",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUFRnt",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHURNOc",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUFSlO",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUSNOc",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUFSRoOU",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUMigWrk",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUOthVc",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HmOwnVcRt",
-        "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "RntVcRt",
-        "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OcHU_2",
-        "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OOcHU_1",
-        "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHU_1",
-        "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OcHU_3",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH1person",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH2ppl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH3ppl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH4ppl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH5plPpl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AvgHHSz",
+        "pff_variable": "decennial_pop",
+        "base_variable": "decennial_pop",
+        "census_variable": [
+            "P001001"
+        ],
+        "domain": "community_profiles",
+        "rounding": 0,
+        "category": "decennial"
+    },
+    {
+        "pff_variable": "pop1",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "popinhh",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "ingrpqtrs",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "institlzd",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "avghhsz",
+        "census_variable": [],
         "base_variable": "mean",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
     },
     {
-        "pff_variable": "OOcHU_2",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "popperacre",
+        "census_variable": [],
+        "base_variable": "ratio",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
     },
     {
-        "pff_variable": "OOcHH1",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "pop2",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH2",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "male ",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH3",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "fem",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH4",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "popu18_1",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH5pl",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "popu18_2",
+        "census_variable": [],
+        "base_variable": "popu18_2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "ROcHU_2",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH1",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH2",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH3",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH4",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH5pl",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop4",
-        "base_variable": "PopAcre",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "LandAcres",
-        "base_variable": "PopAcre",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopInHH_2",
-        "base_variable": "AvgHHSz",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH_3",
-        "base_variable": "AvgHHSz",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AgeU5",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age5t9",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age10t14",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age15t17",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age18t19",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age20",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age21",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age22t24",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age25t29",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age30t34",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age35t39",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age40t44",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age45t49",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age50t54",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age55t59",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age60t61",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age62t64",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age65t66",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age67t69",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age70t74",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age75t79",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age80t84",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age85pl",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AgU1865pl",
-        "base_variable": "AgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Ag18t64",
-        "base_variable": "AgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OdAg65pl",
-        "base_variable": "OdAgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OdAg18t64",
-        "base_variable": "OdAgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "CDpdU18",
-        "base_variable": "ChldDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "CDpd18t64",
-        "base_variable": "ChldDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HOVacU",
-        "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VacSale",
-        "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "RntVacU",
-        "base_variable": "RntVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VacRnt",
-        "base_variable": "RntVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop5",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop0t5",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop5t9",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop10t14",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop15t19",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop20t24",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop25t29",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop30t34",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop35t39",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop40t44",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop45t49",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop50t54",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop55t59",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop60t64",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop65t69",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop70t74",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop75t79",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop80t84",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop85pl",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop0t5",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop5t9",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop10t14",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop15t19",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop20t24",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop25t29",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop30t34",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop35t39",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop40t44",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop45t49",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop50t54",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop55t59",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop60t64",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop65t69",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop70t74",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop75t79",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop80t84",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop85pl",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
+        "pff_variable": "popu18m",
+        "census_variable": [],
+        "base_variable": "popu18_2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
+    },
+    {
+        "pff_variable": "popu18f",
+        "census_variable": [],
+        "base_variable": "popu18_2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
+    },
+    {
+        "pff_variable": "pop3",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "hsp1",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "wnh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "bnh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "anh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "onh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "twoplnh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "hunits",
+        "census_variable": [],
+        "base_variable": "hunits",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "ochu_1",
+        "census_variable": [],
+        "base_variable": "hunits",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "vachus",
+        "census_variable": [],
+        "base_variable": "hunits",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "landacres",
+        "census_variable": [],
+        "base_variable": "popperacre",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "For Persons per Acre"
     }
 ]

--- a/products/factfinder/factfinder/data/decennial/2010/metadata.json
+++ b/products/factfinder/factfinder/data/decennial/2010/metadata.json
@@ -1,827 +1,974 @@
 [
     {
-        "pff_variable": "GeogType",
-        "base_variable": null,
-        "category": null
-    },
-    {
-        "pff_variable": "Year",
-        "base_variable": null,
-        "category": null
-    },
-    {
-        "pff_variable": "GeoID",
-        "base_variable": null,
-        "category": null
-    },
-    {
         "pff_variable": "Pop1",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Male ",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Fem",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopU5",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop5t9",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop10t14",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop15t19",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop20t24",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop25t29",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop30t34",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop35t39",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop40t44",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop45t49",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop50t54",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop55t59",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop60t64",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop65t69",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop70t74",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop75t79",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop80t84",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop85pl",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MdAge",
         "base_variable": "median",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopU18",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop65pl",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AgDpdRt",
         "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OdAgDpdRt",
         "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ChldDpdRt",
         "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopAcre",
         "base_variable": "ratio",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop2",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Hsp1",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "WNH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "BNH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ANH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ONH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "TwoPlNH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop3",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopInHH_1",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HHldr",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "InGrpQtrs",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Institlzd",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQCrctl",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQJuv",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQNrsng",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQOInst",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "NoInstlzd",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQClgHsg",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQMltry",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQONInst",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH_1",
         "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "NFmLvgAln",
         "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "NFLvA65pl",
         "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH_2",
         "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HHwU18",
         "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HHw65pl",
         "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HUnits",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OcHU_1",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VacHUs",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUFRnt",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHURNOc",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUFSlO",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUSNOc",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUFSRoOU",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUMigWrk",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUOthVc",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HmOwnVcRt",
         "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "RntVcRt",
         "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OcHU_2",
         "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE"
+        "category": "HOUSING TENURE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHU_1",
         "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE"
+        "category": "HOUSING TENURE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHU_1",
         "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE"
+        "category": "HOUSING TENURE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OcHU_3",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH1person",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH2ppl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH3ppl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH4ppl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH5plPpl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AvgHHSz",
         "base_variable": "mean",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHU_2",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH1",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH2",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH3",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH4",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH5pl",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHU_2",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH1",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH2",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH3",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH4",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH5pl",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop4",
         "base_variable": "PopAcre",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "LandAcres",
         "base_variable": "PopAcre",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopInHH_2",
         "base_variable": "AvgHHSz",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH_3",
         "base_variable": "AvgHHSz",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AgeU5",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age5t9",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age10t14",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age15t17",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age18t19",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age20",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age21",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age22t24",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age25t29",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age30t34",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age35t39",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age40t44",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age45t49",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age50t54",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age55t59",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age60t61",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age62t64",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age65t66",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age67t69",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age70t74",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age75t79",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age80t84",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age85pl",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AgU1865pl",
         "base_variable": "AgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Ag18t64",
         "base_variable": "AgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OdAg65pl",
         "base_variable": "OdAgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OdAg18t64",
         "base_variable": "OdAgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "CDpdU18",
         "base_variable": "ChldDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "CDpd18t64",
         "base_variable": "ChldDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HOVacU",
         "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VacSale",
         "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "RntVacU",
         "base_variable": "RntVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VacRnt",
         "base_variable": "RntVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop5",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop0t5",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop5t9",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop10t14",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop15t19",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop20t24",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop25t29",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop30t34",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop35t39",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop40t44",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop45t49",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop50t54",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop55t59",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop60t64",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop65t69",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop70t74",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop75t79",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop80t84",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop85pl",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop0t5",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop5t9",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop10t14",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop15t19",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop20t24",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop25t29",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop30t34",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop35t39",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop40t44",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop45t49",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop50t54",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop55t59",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop60t64",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop65t69",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop70t74",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop75t79",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop80t84",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop85pl",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     }
 ]

--- a/products/factfinder/factfinder/data/decennial/2010/metadata.json
+++ b/products/factfinder/factfinder/data/decennial/2010/metadata.json
@@ -6,7 +6,7 @@
         "domain": "decennial"
     },
     {
-        "pff_variable": "Male ",
+        "pff_variable": "Male",
         "base_variable": "Pop1",
         "category": "POPULATION, SEX, AGE, AND DENSITY",
         "domain": "decennial"

--- a/products/factfinder/factfinder/data/decennial/2020/metadata.json
+++ b/products/factfinder/factfinder/data/decennial/2020/metadata.json
@@ -1,827 +1,1112 @@
 [
     {
-        "pff_variable": "GeogType",
-        "base_variable": null,
-        "category": null
-    },
-    {
-        "pff_variable": "Year",
-        "base_variable": null,
-        "category": null
-    },
-    {
-        "pff_variable": "GeoID",
-        "base_variable": null,
-        "category": null
-    },
-    {
         "pff_variable": "Pop1",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Male ",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Fem",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopU5",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop5t9",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop10t14",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop15t19",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop20t24",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop25t29",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop30t34",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop35t39",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop40t44",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop45t49",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop50t54",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop55t59",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop60t64",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop65t69",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop70t74",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop75t79",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop80t84",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop85pl",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MdAge",
         "base_variable": "median",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopU18",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop65pl",
         "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AgDpdRt",
         "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OdAgDpdRt",
         "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ChldDpdRt",
         "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopAcre",
         "base_variable": "ratio",
-        "category": "POPULATION, SEX, AGE, AND DENSITY"
+        "category": "POPULATION, SEX, AGE, AND DENSITY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop2",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Hsp1",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "WNH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "BNH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ANH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ONH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "TwoPlNH",
         "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop3",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopInHH_1",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HHldr",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "Spouse",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "OpSxS",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "SmSxS",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "UMrdPtnr",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "OpSxUMrd",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "SmSxUMrd",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "Child",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "ChildU18",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "GrndCh",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "GrndChU18",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "OthrRel",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "NonRel",
+        "base_variable": "Pop3",
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "InGrpQtrs",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Institlzd",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQCrctl",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQJuv",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQNrsng",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQOInst",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "NoInstlzd",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQClgHsg",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQMltry",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "GQONInst",
         "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)"
+        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH_1",
         "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "Fam",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "NFamHH",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "NFmHHU65",
+        "base_variable": "HH_1",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "NFmLvgAln",
         "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "NFLvA65pl",
         "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH_2",
         "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "MrdCplHH",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "MrdCh18",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "CoCplHH",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "CoCplCh18",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "MaleHHNS",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "MnSPChU18",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "FemHHNS",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
+    },
+    {
+        "pff_variable": "FnSPChU18",
+        "base_variable": "HH_2",
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HHwU18",
         "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HHw65pl",
         "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE "
+        "category": "HOUSEHOLD TYPE ",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HUnits",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OcHU_1",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VacHUs",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUFRnt",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHURNOc",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUFSlO",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUSNOc",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUFSRoOU",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUMigWrk",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VHUOthVc",
         "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HmOwnVcRt",
         "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "RntVcRt",
         "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY"
+        "category": "HOUSING OCCUPANCY",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OcHU_2",
         "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE"
+        "category": "HOUSING TENURE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHU_1",
         "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE"
+        "category": "HOUSING TENURE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHU_1",
         "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE"
+        "category": "HOUSING TENURE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OcHU_3",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH1person",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH2ppl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH3ppl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH4ppl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH5plPpl",
         "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AvgHHSz",
         "base_variable": "mean",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHU_2",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH1",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH2",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH3",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH4",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OOcHH5pl",
         "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHU_2",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH1",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH2",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH3",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH4",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "ROcHH5pl",
         "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE"
+        "category": "HOUSEHOLD SIZE",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop4",
         "base_variable": "PopAcre",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "LandAcres",
         "base_variable": "PopAcre",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "PopInHH_2",
         "base_variable": "AvgHHSz",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HH_3",
         "base_variable": "AvgHHSz",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AgeU5",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age5t9",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age10t14",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age15t17",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age18t19",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age20",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age21",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age22t24",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age25t29",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age30t34",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age35t39",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age40t44",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age45t49",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age50t54",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age55t59",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age60t61",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age62t64",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age65t66",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age67t69",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age70t74",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age75t79",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age80t84",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Age85pl",
         "base_variable": "MdAge",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "AgU1865pl",
         "base_variable": "AgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Ag18t64",
         "base_variable": "AgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OdAg65pl",
         "base_variable": "OdAgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "OdAg18t64",
         "base_variable": "OdAgDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "CDpdU18",
         "base_variable": "ChldDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "CDpd18t64",
         "base_variable": "ChldDpdRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "HOVacU",
         "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VacSale",
         "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "RntVacU",
         "base_variable": "RntVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "VacRnt",
         "base_variable": "RntVcRt",
-        "category": "Special Variable"
+        "category": "Special Variable",
+        "domain": "decennial"
     },
     {
         "pff_variable": "Pop5",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop0t5",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop5t9",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop10t14",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop15t19",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop20t24",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop25t29",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop30t34",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop35t39",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop40t44",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop45t49",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop50t54",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop55t59",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop60t64",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop65t69",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop70t74",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop75t79",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop80t84",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "MPop85pl",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop0t5",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop5t9",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop10t14",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop15t19",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop20t24",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop25t29",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop30t34",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop35t39",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop40t44",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop45t49",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop50t54",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop55t59",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop60t64",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop65t69",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop70t74",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop75t79",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop80t84",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     },
     {
         "pff_variable": "FPop85pl",
         "base_variable": "Pop5",
-        "category": "PopPyramid Only"
+        "category": "PopPyramid Only",
+        "domain": "decennial"
     }
 ]

--- a/products/factfinder/factfinder/data/decennial/2020/metadata.json
+++ b/products/factfinder/factfinder/data/decennial/2020/metadata.json
@@ -1,1112 +1,204 @@
 [
     {
-        "pff_variable": "Pop1",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Male",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Fem",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopU5",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop5t9",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop10t14",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop15t19",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop20t24",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop25t29",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop30t34",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop35t39",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop40t44",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop45t49",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop50t54",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop55t59",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop60t64",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop65t69",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop70t74",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop75t79",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop80t84",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop85pl",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MdAge",
-        "base_variable": "median",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopU18",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop65pl",
-        "base_variable": "Pop1",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AgDpdRt",
-        "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OdAgDpdRt",
-        "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ChldDpdRt",
-        "base_variable": "rate",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopAcre",
-        "base_variable": "ratio",
-        "category": "POPULATION, SEX, AGE, AND DENSITY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop2",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Hsp1",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "WNH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "BNH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ANH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ONH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "TwoPlNH",
-        "base_variable": "Pop2",
-        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop3",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopInHH_1",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HHldr",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Spouse",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OpSxS",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "SmSxS",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "UMrdPtnr",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OpSxUMrd",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "SmSxUMrd",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Child",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ChildU18",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GrndCh",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GrndChU18",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OthrRel",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NonRel",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "InGrpQtrs",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Institlzd",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQCrctl",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQJuv",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQNrsng",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQOInst",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NoInstlzd",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQClgHsg",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQMltry",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "GQONInst",
-        "base_variable": "Pop3",
-        "category": "RELATIONSHIP TO HEAD OF HOUSEHOLD (HOUSEHOLDER)",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH_1",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Fam",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NFamHH",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NFmHHU65",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NFmLvgAln",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "NFLvA65pl",
-        "base_variable": "HH_1",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH_2",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MrdCplHH",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MrdCh18",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "CoCplHH",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "CoCplCh18",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MaleHHNS",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MnSPChU18",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FemHHNS",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FnSPChU18",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HHwU18",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HHw65pl",
-        "base_variable": "HH_2",
-        "category": "HOUSEHOLD TYPE ",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HUnits",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OcHU_1",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VacHUs",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUFRnt",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHURNOc",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUFSlO",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUSNOc",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUFSRoOU",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUMigWrk",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VHUOthVc",
-        "base_variable": "HUnits",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HmOwnVcRt",
-        "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "RntVcRt",
-        "base_variable": "rate",
-        "category": "HOUSING OCCUPANCY",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OcHU_2",
-        "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OOcHU_1",
-        "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHU_1",
-        "base_variable": "OcHU_2",
-        "category": "HOUSING TENURE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OcHU_3",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH1person",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH2ppl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH3ppl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH4ppl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH5plPpl",
-        "base_variable": "OcHU_3",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AvgHHSz",
+        "pff_variable": "decennial_pop",
+        "base_variable": "decennial_pop",
+        "census_variable": [
+            "P001001"
+        ],
+        "domain": "community_profiles",
+        "rounding": 0,
+        "source": "decennial"
+    },
+    {
+        "pff_variable": "pop1",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "popinhh",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "ingrpqtrs",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "institlzd",
+        "census_variable": [],
+        "base_variable": "pop1",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
+    },
+    {
+        "pff_variable": "avghhsz",
+        "census_variable": [],
         "base_variable": "mean",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
     },
     {
-        "pff_variable": "OOcHU_2",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "popperacre",
+        "census_variable": [],
+        "base_variable": "ratio",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "POPULATION"
     },
     {
-        "pff_variable": "OOcHH1",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "pop2",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH2",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "male ",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH3",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "fem",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH4",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "popu18_1",
+        "census_variable": [],
+        "base_variable": "pop2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "OOcHH5pl",
-        "base_variable": "OOcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
+        "pff_variable": "popu18_2",
+        "census_variable": [],
+        "base_variable": "popu18_2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
     },
     {
-        "pff_variable": "ROcHU_2",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH1",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH2",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH3",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH4",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "ROcHH5pl",
-        "base_variable": "ROcHU_2",
-        "category": "HOUSEHOLD SIZE",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop4",
-        "base_variable": "PopAcre",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "LandAcres",
-        "base_variable": "PopAcre",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "PopInHH_2",
-        "base_variable": "AvgHHSz",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HH_3",
-        "base_variable": "AvgHHSz",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AgeU5",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age5t9",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age10t14",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age15t17",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age18t19",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age20",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age21",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age22t24",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age25t29",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age30t34",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age35t39",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age40t44",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age45t49",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age50t54",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age55t59",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age60t61",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age62t64",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age65t66",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age67t69",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age70t74",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age75t79",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age80t84",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Age85pl",
-        "base_variable": "MdAge",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "AgU1865pl",
-        "base_variable": "AgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Ag18t64",
-        "base_variable": "AgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OdAg65pl",
-        "base_variable": "OdAgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "OdAg18t64",
-        "base_variable": "OdAgDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "CDpdU18",
-        "base_variable": "ChldDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "CDpd18t64",
-        "base_variable": "ChldDpdRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "HOVacU",
-        "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VacSale",
-        "base_variable": "HmOwnrVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "RntVacU",
-        "base_variable": "RntVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "VacRnt",
-        "base_variable": "RntVcRt",
-        "category": "Special Variable",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "Pop5",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop0t5",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop5t9",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop10t14",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop15t19",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop20t24",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop25t29",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop30t34",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop35t39",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop40t44",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop45t49",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop50t54",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop55t59",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop60t64",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop65t69",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop70t74",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop75t79",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop80t84",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "MPop85pl",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop0t5",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop5t9",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop10t14",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop15t19",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop20t24",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop25t29",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop30t34",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop35t39",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop40t44",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop45t49",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop50t54",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop55t59",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop60t64",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop65t69",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop70t74",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop75t79",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop80t84",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
-    },
-    {
-        "pff_variable": "FPop85pl",
-        "base_variable": "Pop5",
-        "category": "PopPyramid Only",
-        "domain": "decennial"
+        "pff_variable": "popu18m",
+        "census_variable": [],
+        "base_variable": "popu18_2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
+    },
+    {
+        "pff_variable": "popu18f",
+        "census_variable": [],
+        "base_variable": "popu18_2",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "AGE AND SEX"
+    },
+    {
+        "pff_variable": "pop3",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "hsp1",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "wnh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "bnh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "anh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "onh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "twoplnh",
+        "census_variable": [],
+        "base_variable": "pop3",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "MUTUALLY EXCLUSIVE RACE / HISPANIC ORIGIN"
+    },
+    {
+        "pff_variable": "hunits",
+        "census_variable": [],
+        "base_variable": "hunits",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "ochu_1",
+        "census_variable": [],
+        "base_variable": "hunits",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "vachus",
+        "census_variable": [],
+        "base_variable": "hunits",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "HOUSING OCCUPANCY"
+    },
+    {
+        "pff_variable": "landacres",
+        "census_variable": [],
+        "base_variable": "popperacre",
+        "domain": "decennial",
+        "rounding": 0,
+        "category": "For Persons per Acre"
     }
 ]

--- a/products/factfinder/factfinder/data/decennial/2020/metadata.json
+++ b/products/factfinder/factfinder/data/decennial/2020/metadata.json
@@ -6,7 +6,7 @@
         "domain": "decennial"
     },
     {
-        "pff_variable": "Male ",
+        "pff_variable": "Male",
         "base_variable": "Pop1",
         "category": "POPULATION, SEX, AGE, AND DENSITY",
         "domain": "decennial"

--- a/products/factfinder/pipelines/decennial_manual_update.py
+++ b/products/factfinder/pipelines/decennial_manual_update.py
@@ -24,6 +24,8 @@ PIVOT_COLUMNS = ["year", "geoid"]
 
 COLUMN_CLEANUP = {"Male ": "Male", "Male P": "MaleP"}
 
+OUTPUT_FOLDER = DATA_PATH / ".output" / "decennial"
+
 
 def clean_data(df: pd.DataFrame) -> pd.DataFrame:
     # clean community districts
@@ -37,7 +39,7 @@ def clean_data(df: pd.DataFrame) -> pd.DataFrame:
 
 def process_data_sheet(excel_file, year, sheet_name):
     print(f"Processing data for decennial year {year} using sheet '{sheet_name}'")
-    output_file = Path(".output/decennial") / year / "decennial.csv"
+    output_file = OUTPUT_FOLDER / year / "decennial.csv"
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
     df = pd.read_excel(excel_file, sheet_name=sheet_name)
@@ -78,7 +80,8 @@ def process_metadata(excel_file):
     for year, year_df in df.groupby("year"):
         year_df = year_df[columns.values()]
         year_df["domain"] = "decennial"
-        file = DATA_PATH / "decennial" / year / "metadata.json"
+        file = OUTPUT_FOLDER / year / "metadata.json"
+        file.parent.mkdir(parents=True, exist_ok=True)
         with open(file, "w") as outfile:
             outfile.write(df_to_json(year_df))
         files[year] = file
@@ -98,9 +101,6 @@ if __name__ == "__main__":
         if not input_year or (input_year == year["year"]):
             output_file = process_data_sheet(excel, year["year"], year["sheet_name"])
             print(f"Finished decennial year {year['year']}")
-
-            output_file = Path(".output/decennial") / year["year"] / "decennial.csv"
-            output_file.parent.mkdir(parents=True, exist_ok=True)
 
             if upload:
                 print(f"Uploading {output_file}")

--- a/products/factfinder/pipelines/decennial_manual_update.py
+++ b/products/factfinder/pipelines/decennial_manual_update.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import pandas as pd
 
 from dcpy.utils.json import df_to_json
-from pipelines import PRODUCT_PATH
 from pipelines.utils import parse_args, download_manual_update, s3_upload, DATA_PATH
 
 
@@ -63,7 +62,7 @@ def process_data_sheet(excel_file, year, sheet_name):
 def process_metadata(excel_file):
     df = pd.read_excel(excel_file, sheet_name="Data Dictionary", skiprows=3)
     df = df.dropna(subset=["Category"])
-    df["year"] = df["Dataset"].str.split(", ")
+    df["year"] = df["Dataset"].astype(str).str.split(", ")
     df = df.explode("year")
     columns = {
         "VariableName": "pff_variable",

--- a/products/factfinder/pipelines/decennial_manual_update.py
+++ b/products/factfinder/pipelines/decennial_manual_update.py
@@ -22,6 +22,8 @@ YEAR_CONFIG = pd.DataFrame(
 
 PIVOT_COLUMNS = ["year", "geoid"]
 
+COLUMN_CLEANUP = {"Male ": "Male", "Male P": "MaleP"}
+
 
 def clean_data(df: pd.DataFrame) -> pd.DataFrame:
     # clean community districts
@@ -39,6 +41,7 @@ def process_data_sheet(excel_file, year, sheet_name):
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
     df = pd.read_excel(excel_file, sheet_name=sheet_name)
+    df.rename(columns=COLUMN_CLEANUP, inplace=True)
     df.columns = df.columns.str.lower()
     df["geoid"] = df["geoid"].astype(str)
 
@@ -62,6 +65,7 @@ def process_data_sheet(excel_file, year, sheet_name):
 def process_metadata(excel_file):
     df = pd.read_excel(excel_file, sheet_name="Data Dictionary", skiprows=3)
     df = df.dropna(subset=["Category"])
+    df["VariableName"] = df["VariableName"].apply(lambda c: COLUMN_CLEANUP.get(c, c))
     df["year"] = df["Dataset"].astype(str).str.split(", ")
     df = df.explode("year")
     columns = {


### PR DESCRIPTION
Closes #179, #180 

For 179, there was a bug that I'd introduced - hadn't realized that `object` types in pandas could be mixed types. So in the data dictionary, if a variable was present for `2010, 2020` it was interpreted correctly but for the couple cases where the year was `2020` it was interpreted as a float and converted to `NaN` by `.str.split(", ")` rather an array of years.

For 180, figured just keep it minimal - replace column names exactly rather than any sort of regex or trimming whitespace, just in case anything down the road requires anything different

[Successful build](https://github.com/NYCPlanning/data-engineering/actions/runs/5979687092) - I've manually QA'd outputs. Made small fix to commit 2 this morning and tested changes locally