### PR TITLE
fix date filtering to not exclude recently updated jobs

### DIFF
--- a/products/developments/sql/_export.sql
+++ b/products/developments/sql/_export.sql
@@ -3,12 +3,10 @@ DROP TABLE IF EXISTS EXPORT_devdb CASCADE;
 SELECT * 
 INTO EXPORT_devdb
 FROM FINAL_devdb
-WHERE (Date_Complete::date <=  :'CAPTURE_DATE'
-    OR (Date_Complete IS NULL  
-        AND Date_Permittd::date <=  :'CAPTURE_DATE')
-    OR (Date_Complete IS NULL 
-        AND Date_Permittd IS NULL 
-        AND Date_Filed::date <=  :'CAPTURE_DATE'));
+WHERE 
+    Date_Filed::date <= :'CAPTURE_DATE'
+    OR Date_Permittd::date <= :'CAPTURE_DATE'
+    OR Date_Complete::date <= :'CAPTURE_DATE';
 
 -- EXPORT HousingDB
 CREATE VIEW export_housing AS 


### PR DESCRIPTION
Per convo with @AmandaDoyle this is desired behavior. In the original code, if a job was filed in 2021 but not permitted, it would be in each devdb build. If it was then permitted on 2023-07-02 (and this data was accessible in the 23Q2 build later in july or august), it would then be filtered out erroneously