### PR TITLE
add ordering for EHC/TA, G/MX-1 special districts

### DIFF
--- a/products/pluto/pluto_build/sql/zoning_specialdistrict.sql
+++ b/products/pluto/pluto_build/sql/zoning_specialdistrict.sql
@@ -99,4 +99,13 @@ SET spdist1 = 'EC-6',
     spdist2 = 'MX-16'
 WHERE spdist1 = 'MX-16'
     AND spdist2 = 'EC-6';
--- missing EHC/TA, G/MX-1
+UPDATE pluto
+SET spdist1 = 'EHC',
+    spdist2 = 'TA'
+WHERE spdist1 = 'TA'
+    AND spdist2 = 'EHC';
+UPDATE pluto
+SET spdist1 = 'MX-1',
+    spdist2 = 'G'
+WHERE spdist1 = 'G'
+    AND spdist2 = 'MX-1';

--- a/products/pluto/pluto_build/sql/zoning_zoningdistrict.sql
+++ b/products/pluto/pluto_build/sql/zoning_zoningdistrict.sql
@@ -18,7 +18,7 @@ DROP TABLE IF EXISTS validzones;
 CREATE TABLE validzones AS (
 SELECT 
     CASE
-        WHEN zonedist = ANY('{"BALL FIELD", "PLAYGROUND", "PUBLIC SPACE"}') THEN 'PARK'
+        WHEN zonedist = ANY('{"BALL FIELD", "PLAYGROUND", "PUBLIC PLACE"}') THEN 'PARK'
         ELSE zonedist
     END AS zonedist, 
     ST_MakeValid(geom) AS geom  


### PR DESCRIPTION
Last part (hopefully) of #92 and #165 hopefully 
1. assign manual ordering of sp districts with overlapping zones. For now just the orderin that currently can be found in ZoLa (and for EHC/TA how the "joint" district was ordered), but contingent on confirmation from zoning. Much simpler cases than with zoning districts so this simple re-ordering is fine
2. Typo from #171 when grouping together multiple zoning districts together as parks. See [original code](https://github.com/NYCPlanning/data-engineering/pull/171/files#diff-bba800c5498a37821aa03a49d6dbeea0177f04df58bdd0b91e72874dde5cf8a6L8) and my [initial implementation](https://github.com/NYCPlanning/data-engineering/pull/171/files#diff-770a57c063965a3d5a24d9491a93ff110884d23f11391062fe6e20de2966af86R21)