### PR TITLE
pluto: use max proximity code per billing-bbl

### DIFF
--- a/products/pluto/pluto_build/sql/cama_proxcode.sql
+++ b/products/pluto/pluto_build/sql/cama_proxcode.sql
@@ -3,7 +3,7 @@
 -- select proxcode for lot from record where bldgnum is 1
 -- all bbl reocrds have at least one record with a bldgnum = '1'
 WITH dcpcamavals AS (
-    SELECT DISTINCT
+    SELECT
         primebbl AS bbl,
         (CASE
             WHEN proxcode = '5' THEN '2'
@@ -16,12 +16,20 @@ WITH dcpcamavals AS (
         proxcode != '0'
         AND proxcode != 'N'
         AND bldgnum = '1'
+),
+
+max_bbl_proxcodes AS (
+    SELECT
+        bbl,
+        max(proxcode) AS proxcode
+    FROM dcpcamavals
+    GROUP BY bbl
 )
 
 UPDATE pluto a
-SET proxcode = dcpcamavals.proxcode
-FROM dcpcamavals
-WHERE a.bbl = dcpcamavals.bbl;
+SET proxcode = m.proxcode
+FROM max_bbl_proxcodes AS m
+WHERE a.bbl = m.bbl;
 
 -- assign 0 (Not Available) to remaining records
 UPDATE pluto


### PR DESCRIPTION
In the case of condos, there are sometimes multiple prox codes per bbl in a given billing bbl. Previously when we were assigning proxcodes, the choice of proxcode was not deterministic. This changes to use the most proximate condo unit. E.g.
```
+-----+--------------+-----------+
| bbl |  billing bbl |  proxcode |
+-----+--------------+-----------+
|   1 |          123 |         1 |
|   2 |          123 |         2 |
+-----+--------------+-----------+
```

billing bbl for `123` will use proxcode 2