### PR TITLE
pluto: fix failing build

### DIFF
--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -6,6 +6,9 @@ on:
       run_export:
         type: boolean
         required: true
+      recipe_file:
+        type: string
+        default: recipe.yml
   workflow_dispatch:
     inputs:
       run_export:


### PR DESCRIPTION
Sets a default for the recipe file to use in a build when called (this was already set on dispatch). We should probably just default in `dcpy` to use `recipe.yml` in the product dir