### PR TITLE
object-oriented approach for publishing utils

### DIFF
--- a/apps/qa/src/colp/helpers.py
+++ b/apps/qa/src/colp/helpers.py
@@ -6,12 +6,12 @@ from dcpy.connectors.edm import publishing
 PRODUCT = "db-colp"
 
 
-def get_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
+def get_data(product_key: publishing.Product) -> dict[str, pd.DataFrame]:
     rv = {}
 
     def csv_from_DO(file):
         try:
-            return publishing.read_csv(product_key, "qaqc/" + file)
+            return product_key.read_csv("qaqc/" + file)
         except:
             st.warning(f"{file} not found")
 

--- a/apps/qa/src/components/sidebar.py
+++ b/apps/qa/src/components/sidebar.py
@@ -6,7 +6,7 @@ from dcpy.connectors.edm import publishing
 
 def data_selection(
     product: str, section_label: Optional[str] = None
-) -> publishing.ProductKey:
+) -> publishing.Product:
     if section_label is not None:
         st.sidebar.title(section_label)
     publish_or_draft = st.sidebar.selectbox(
@@ -23,6 +23,6 @@ def data_selection(
         options = publishing.get_published_versions(product)
     select = st.sidebar.selectbox(label, options, key=f"{section_label}_output")
     if is_draft:
-        return publishing.DraftKey(product, select)
+        return publishing.Draft(product, select)
     else:
-        return publishing.ProductKey(product, select)
+        return publishing.Product(product, select)

--- a/apps/qa/src/components/sources_report.py
+++ b/apps/qa/src/components/sources_report.py
@@ -12,8 +12,8 @@ from src.source_report_utils import (
 
 
 def sources_report(
-    reference_product_key: publishing.ProductKey,
-    staging_product_key: publishing.ProductKey,
+    reference_product_key: publishing.Product,
+    staging_product_key: publishing.Product,
 ):
     print("STARTING Source Data Review")
     st.header("Source Data Review")

--- a/apps/qa/src/cpdb/helpers.py
+++ b/apps/qa/src/cpdb/helpers.py
@@ -29,8 +29,8 @@ where would this list comes from? """
 
 
 def get_data(
-    staging_product_key: publishing.ProductKey,
-    reference_product_key: publishing.ProductKey,
+    staging_product_key: publishing.Product,
+    reference_product_key: publishing.Product,
 ) -> dict:
     rv = {}
     tables = {
@@ -41,16 +41,16 @@ def get_data(
     }
 
     for t in tables["analysis"]:
-        rv[t] = publishing.read_csv(staging_product_key, f"analysis/{t}.csv")
-        rv["pre_" + t] = publishing.read_csv(reference_product_key, f"analysis/{t}.csv")
+        rv[t] = staging_product_key.read_csv(f"analysis/{t}.csv")
+        rv["pre_" + t] = reference_product_key.read_csv(f"analysis/{t}.csv")
 
     for t in tables["others"]:
-        rv[t] = publishing.read_csv(staging_product_key, f"{t}.csv")
-        rv["pre_" + t] = publishing.read_csv(reference_product_key, f"{t}.csv")
+        rv[t] = staging_product_key.read_csv(f"{t}.csv")
+        rv["pre_" + t] = reference_product_key.read_csv(f"{t}.csv")
     for t in tables["no_version_compare"]:
-        rv[t] = publishing.read_csv(staging_product_key, f"{t}.csv")
+        rv[t] = staging_product_key.read_csv(f"{t}.csv")
     for t in tables["geometries"]:
-        rv[t] = publishing.read_shapefile(staging_product_key, f"{t}.shp.zip")
+        rv[t] = staging_product_key.read_shapefile(f"{t}.shp.zip")
     return rv
 
 

--- a/apps/qa/src/devdb/helpers.py
+++ b/apps/qa/src/devdb/helpers.py
@@ -167,23 +167,18 @@ QAQC_CHECK_DICTIONARY = {
 }
 
 
-def get_latest_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
+def get_latest_data(product_key: publishing.Product) -> dict[str, pd.DataFrame]:
     rv = {}
 
-    rv["qaqc_app"] = publishing.read_csv(
-        product_key, "qaqc_app.csv", dtype={"job_number": "str"}
-    )
+    rv["qaqc_app"] = product_key.read_csv("qaqc_app.csv", dtype={"job_number": "str"})
 
-    rv["qaqc_historic"] = publishing.read_csv(product_key, "qaqc_historic.csv")
+    rv["qaqc_historic"] = product_key.read_csv("qaqc_historic.csv")
 
-    rv["qaqc_field_distribution"] = publishing.read_csv(
-        product_key,
+    rv["qaqc_field_distribution"] = product_key.read_csv(
         "qaqc_field_distribution.csv",
         converters={"result": json.loads},
     )
 
-    rv["qaqc_quarter_check"] = publishing.read_csv(
-        product_key, "qaqc_quarter_check.csv"
-    )
+    rv["qaqc_quarter_check"] = product_key.read_csv("qaqc_quarter_check.csv")
 
     return rv

--- a/apps/qa/src/facdb/helpers.py
+++ b/apps/qa/src/facdb/helpers.py
@@ -7,9 +7,9 @@ REPO_NAME = "data-engineering"
 
 
 def get_latest_data(
-    product_key: publishing.ProductKey,
+    product_key: publishing.Product,
 ) -> tuple[dict[str, dict[str, Union[pd.DataFrame, str]]], pd.DataFrame, pd.DataFrame]:
-    read_csv = lambda csv: publishing.read_csv(product_key, f"{csv}.csv")
+    read_csv = lambda csv: product_key.read_csv(f"{csv}.csv")
 
     qc_diff = read_csv("qc_diff")
     qc_captype = read_csv("qc_captype")

--- a/apps/qa/src/pluto/helpers.py
+++ b/apps/qa/src/pluto/helpers.py
@@ -9,12 +9,11 @@ from apps.qa.src.publishing import unzip_csv
 PRODUCT = "db-pluto"
 
 
-def get_data(product_key: publishing.ProductKey) -> Dict[str, pd.DataFrame]:
+def get_data(product_key: publishing.Product) -> Dict[str, pd.DataFrame]:
     data = {}
 
     def read_pluto_csv(qaqc_type, **kwargs):
-        return publishing.read_csv(
-            product_key,
+        return product_key.read_csv(
             f"qaqc/qaqc_{qaqc_type}.csv",
             true_values=["t"],
             false_values=["f"],
@@ -31,9 +30,7 @@ def get_data(product_key: publishing.ProductKey) -> Dict[str, pd.DataFrame]:
 
     data = data | get_changes(product_key)
 
-    data["source_data_versions"] = publishing.read_csv(
-        product_key, "source_data_versions.csv"
-    )
+    data["source_data_versions"] = product_key.read_csv("source_data_versions.csv")
 
     data["version_text"] = data["source_data_versions"]
 
@@ -52,9 +49,9 @@ def get_data(product_key: publishing.ProductKey) -> Dict[str, pd.DataFrame]:
     return data
 
 
-def get_changes(product_key: publishing.ProductKey) -> Dict[str, pd.DataFrame]:
+def get_changes(product_key: publishing.Product) -> Dict[str, pd.DataFrame]:
     changes = {}
-    pluto_changes_zip = publishing.get_zip(product_key, "pluto_changes.zip")
+    pluto_changes_zip = product_key.get_zip("pluto_changes.zip")
     changes["pluto_changes_applied"] = unzip_csv(
         csv_filename="pluto_changes_applied.csv",
         zipfile=pluto_changes_zip,

--- a/apps/qa/src/publishing.py
+++ b/apps/qa/src/publishing.py
@@ -11,5 +11,5 @@ def unzip_csv(csv_filename: str, zipfile: ZipFile):
 
 
 @st.cache_data(ttl=600)
-def read_csv_cached(product_key: publishing.ProductKey, file: str, **kwargs):
-    return publishing.read_csv(product_key, file, **kwargs)
+def read_csv_cached(product_key: publishing.Product, file: str, **kwargs):
+    return product_key.read_csv(file, **kwargs)

--- a/apps/qa/src/source_report_utils.py
+++ b/apps/qa/src/source_report_utils.py
@@ -19,20 +19,18 @@ def dataframe_style_source_report_results(value: bool):
     return f"background-color: {color}"
 
 
-def get_source_dataset_names(product_key: publishing.ProductKey) -> pd.DataFrame:
+def get_source_dataset_names(product_key: publishing.Product) -> pd.DataFrame:
     """Gets names of source products used in build
     TODO this should not come from publishing, but should be defined in code for each data product
     """
-    source_data_versions = publishing.get_source_data_versions(product_key)
-    return sorted(source_data_versions.index.values.tolist())
+    return sorted(product_key.source_data_versions.index.values.tolist())
 
 
 def get_latest_source_data_versions(product: str) -> pd.DataFrame:
     """Gets latest available versions of source datasets for specific data product
     Does NOT return versions used in any specific build
-    TODO this should not come from publishing, but should be defined in code for each data product
     """
-    source_data_versions = publishing.get_source_data_versions(product, "latest")
+    source_data_versions = publishing.get_latest_source_versions(product)
     source_data_versions["version"] = source_data_versions.index.map(
         recipes.get_latest_version
     )
@@ -40,18 +38,12 @@ def get_latest_source_data_versions(product: str) -> pd.DataFrame:
 
 
 def get_source_data_versions_to_compare(
-    reference_product_key: publishing.ProductKey,
-    staging_product_key: publishing.ProductKey,
-):
+    reference_product_key: publishing.Product,
+    staging_product_key: publishing.Product,
+) -> pd.DataFrame:
     # TODO (nice-to-have) add column with links to data-library yaml templates
-    reference_source_data_versions = publishing.get_source_data_versions(
-        reference_product_key
-    )
-    latest_source_data_versions = publishing.get_source_data_versions(
-        staging_product_key
-    )
-    source_data_versions = reference_source_data_versions.merge(
-        latest_source_data_versions,
+    source_data_versions = reference_product_key.source_data_versions.merge(
+        staging_product_key.source_data_versions,
         left_index=True,
         right_index=True,
         suffixes=("_reference", "_latest"),

--- a/apps/qa/src/ztl/components/outputs_report.py
+++ b/apps/qa/src/ztl/components/outputs_report.py
@@ -37,25 +37,22 @@ ZONING_FIELD_CATEGORIES = {
 }
 
 
-def output_report(product_key: publishing.ProductKey):
-    def read_ztl_csv(file, **kwargs):
-        return publishing.read_csv(product_key, file, **kwargs)
-
-    bbldiff = read_ztl_csv(
+def output_report(product_key: publishing.Product):
+    bbldiff = product_key.read_csv(
         "qc_bbldiffs.csv",
         dtype=str,
         index_col=False,
     )
     bbldiff = bbldiff.fillna("NULL")
-    qaqc_mismatch = read_ztl_csv(
+    qaqc_mismatch = product_key.read_csv(
         "qaqc_mismatch.csv",
         index_col=False,
     )
-    qaqc_bbl = read_ztl_csv(
+    qaqc_bbl = product_key.read_csv(
         "qaqc_bbl.csv",
         index_col=False,
     )
-    qaqc_null = read_ztl_csv(
+    qaqc_null = product_key.read_csv(
         "qaqc_null.csv",
         index_col=False,
     )
@@ -170,8 +167,6 @@ def output_report(product_key: publishing.ProductKey):
 
     # SOURCE DATA REPORT  ====================================
     st.header("Source Data Versions")
-    source_data_versions = publishing.get_source_data_versions(
-        product=PRODUCT, version="latest"
-    )
+    source_data_versions = publishing.Product(PRODUCT, "latest").source_data_versions
     st.table(source_data_versions)
     # SOURCE DATA REPORT  ====================================

--- a/apps/qa/tests/test_pluto.py
+++ b/apps/qa/tests/test_pluto.py
@@ -11,7 +11,7 @@ TEST_VERSION_2 = "23v2"
 
 @pytest.fixture
 def example_ExpectedValueDifferencesReport():
-    data = get_data(publishing.ProductKey(PRODUCT, TEST_VERSION_1))
+    data = get_data(publishing.Product(PRODUCT, TEST_VERSION_1))
     return ExpectedValueDifferencesReport(
         data=data["df_expected"],
         v1=TEST_VERSION_1,

--- a/apps/qa/tests/test_source_report.py
+++ b/apps/qa/tests/test_source_report.py
@@ -34,9 +34,9 @@ TEST_SOURCE_REPORT_RESULTS = {
 
 
 def test_get_source_data_versions_from_build():
-    source_data_versions = publishing.get_source_data_versions(
-        publishing.ProductKey(TEST_DATASET_NAME, TEST_DATASET_REFERENCE_VERSION)
-    )
+    source_data_versions = publishing.Product(
+        TEST_DATASET_NAME, TEST_DATASET_REFERENCE_VERSION
+    ).source_data_versions
     assert isinstance(source_data_versions, pd.DataFrame)
     assert (
         source_data_versions.loc[TEST_DATA_SOURCE_NAME, "version"]
@@ -56,7 +56,7 @@ def test_get_source_data_versions_from_build():
 
 def test_get_source_dataset_names():
     source_dataset_names = get_source_dataset_names(
-        publishing.ProductKey(TEST_DATASET_NAME, REFERENCE_VESION)
+        publishing.Product(TEST_DATASET_NAME, REFERENCE_VESION)
     )
     assert source_dataset_names == TEST_DATA_SOURCE_NAMES
 

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -166,9 +166,9 @@ def plan_recipe(recipe_path: Path) -> dict:
     previous_versions = {}
     missing_version_strat = recipe["inputs"].get("missing_versions_strategy")
     if missing_version_strat == "copy_latest_release":
-        previous_versions = publishing.get_source_data_versions(
-            publishing.ProductKey(recipe["product"], "latest")
-        ).to_dict()["version"]
+        previous_versions = publishing.Product(
+            recipe["product"], "latest"
+        ).source_data_versions.to_dict()["version"]
 
     for ds in _recipe_datasets(recipe):
         if "version" not in ds:

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -262,8 +262,12 @@ def get_subfolders(bucket: str, prefix: str, index=1):
     return list(subfolders)
 
 
-def get_file_as_stream(bucket, path):
+def get_file_as_stream(bucket: str, path: str) -> BytesIO:
     stream = BytesIO()
     client().download_fileobj(Bucket=bucket, Key=path, Fileobj=stream)
     stream.seek(0)
     return stream
+
+
+def get_file_as_text(bucket: str, path: str) -> str:
+    return client().get_object(Bucket=bucket, Key=path).get("Body").read().decode()


### PR DESCRIPTION
Follow up to #191 - from discussions with @alexrichey we thought it could theoretically be cleaner to have interactions with products/drafts go through these objects representing them. This was a first pass. Not looking necessarily to merge, but just wanted to use this as a starting point for discussion for now. 

Don't worry too much about changes in the qa app, meat is really all in `dcpy.connectors.edm.publishing`