### PR TITLE
Docker Images: pin postgresql-tools to 15

### DIFF
--- a/docker/build-base
+++ b/docker/build-base
@@ -1,7 +1,14 @@
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.6.4
 
+# Add PG apt repo to enable PG 15 tools.
+# Note: This follows https://www.postgresql.org/download/linux/ubuntu/ with one modification
+# (lsb_release is broken on this image, so some longer bash is subbed in)
+RUN apt -y install wget gnupg \
+    && sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep VERSION_CODENAME | cut -d "=" -f2)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
 RUN apt update && export DEBIAN_FRONTEND=noninteractive \
-    && apt -y install postgresql-client python3-pip python3-distutils jq wget zip unzip git bash-completion locales
+    && apt -y install postgresql-client-15 python3-pip python3-distutils jq zip unzip git bash-completion locales
 
 RUN curl -O https://dl.min.io/client/mc/release/linux-amd64/mc \
     && chmod +x mc \

--- a/docker/build-geosupport
+++ b/docker/build-geosupport
@@ -1,7 +1,7 @@
 FROM nycplanning/docker-geosupport:latest
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install postgresql-client libpq-dev jq wget bash-completion gdal-bin
+    && apt-get -y install postgresql-client-15 libpq-dev jq wget bash-completion gdal-bin
 
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
 


### PR DESCRIPTION
Upgrades to postgresql-client v15 to fix failing Pluto builds (from `build-base` image) and pins in `build-geosupport`