### PR TITLE
Fvk cleanup publishing s3 calls

### DIFF
--- a/apps/qa/src/components/sidebar.py
+++ b/apps/qa/src/components/sidebar.py
@@ -25,4 +25,4 @@ def data_selection(
     if is_draft:
         return publishing.DraftKey(product, select)
     else:
-        return publishing.ProductKey(product, select)
+        return publishing.PublishKey(product, select)

--- a/apps/qa/src/components/sources_report.py
+++ b/apps/qa/src/components/sources_report.py
@@ -22,7 +22,7 @@ def sources_report(
     This page reviews the status of all source data used to build this dataset.
     It compares the latest versions of source data to those used in the build of a reference version of this dataset.
     
-    The reference dataset version is `{reference_product_key.label}`.
+    The reference dataset version is `{reference_product_key}`.
     """
     )
 

--- a/apps/qa/src/edde/components.py
+++ b/apps/qa/src/edde/components.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 from dcpy.utils import s3
-from apps.qa.src.publishing import get_active_s3_folders
+from src.publishing import get_active_s3_folders
 from src.edde.helpers import compare_columns
 
 

--- a/apps/qa/src/pluto/helpers.py
+++ b/apps/qa/src/pluto/helpers.py
@@ -4,7 +4,7 @@ import json
 from typing import Dict
 
 from dcpy.connectors.edm import publishing
-from apps.qa.src.publishing import unzip_csv
+from src.publishing import unzip_csv
 
 PRODUCT = "db-pluto"
 

--- a/apps/qa/tests/test_pluto.py
+++ b/apps/qa/tests/test_pluto.py
@@ -11,7 +11,7 @@ TEST_VERSION_2 = "23v2"
 
 @pytest.fixture
 def example_ExpectedValueDifferencesReport():
-    data = get_data(publishing.ProductKey(PRODUCT, TEST_VERSION_1))
+    data = get_data(publishing.PublishKey(PRODUCT, TEST_VERSION_1))
     return ExpectedValueDifferencesReport(
         data=data["df_expected"],
         v1=TEST_VERSION_1,

--- a/apps/qa/tests/test_source_report.py
+++ b/apps/qa/tests/test_source_report.py
@@ -35,7 +35,7 @@ TEST_SOURCE_REPORT_RESULTS = {
 
 def test_get_source_data_versions_from_build():
     source_data_versions = publishing.get_source_data_versions(
-        publishing.ProductKey(TEST_DATASET_NAME, TEST_DATASET_REFERENCE_VERSION)
+        publishing.PublishKey(TEST_DATASET_NAME, TEST_DATASET_REFERENCE_VERSION)
     )
     assert isinstance(source_data_versions, pd.DataFrame)
     assert (
@@ -56,7 +56,7 @@ def test_get_source_data_versions_from_build():
 
 def test_get_source_dataset_names():
     source_dataset_names = get_source_dataset_names(
-        publishing.ProductKey(TEST_DATASET_NAME, REFERENCE_VESION)
+        publishing.PublishKey(TEST_DATASET_NAME, REFERENCE_VESION)
     )
     assert source_dataset_names == TEST_DATA_SOURCE_NAMES
 

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -22,8 +22,7 @@ class ProductKey:
     product: str
     version: str
 
-    @property
-    def label(self):
+    def __str__(self):
         return f"{self.product} - {self.version}"
 
     @cached_property
@@ -51,8 +50,7 @@ class DraftKey(ProductKey):
 
         return self.__getattribute__(name)
 
-    @property
-    def label(self):
+    def __str__(self):
         return f"{self.product} - {self.version} - {self.build}"
 
     @property

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -167,7 +167,7 @@ def plan_recipe(recipe_path: Path) -> dict:
     missing_version_strat = recipe["inputs"].get("missing_versions_strategy")
     if missing_version_strat == "copy_latest_release":
         previous_versions = publishing.get_source_data_versions(
-            publishing.ProductKey(recipe["product"], "latest")
+            publishing.PublishKey(recipe["product"], "latest")
         ).to_dict()["version"]
 
     for ds in _recipe_datasets(recipe):

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -262,8 +262,12 @@ def get_subfolders(bucket: str, prefix: str, index=1):
     return list(subfolders)
 
 
-def get_file_as_stream(bucket, path):
+def get_file_as_stream(bucket: str, path: str) -> BytesIO:
     stream = BytesIO()
     client().download_fileobj(Bucket=bucket, Key=path, Fileobj=stream)
     stream.seek(0)
     return stream
+
+
+def get_file_as_text(bucket: str, path: str) -> str:
+    return client().get_object(Bucket=bucket, Key=path).get("Body").read().decode()


### PR DESCRIPTION
in #225, realized it'd also be nice to use only s3 utils within publishing (and not requests assuming that certain files would be public-read).

Commits:
1. above-mentioned issue
2. move `product_path` to a property of the keys. This makes sense and is nice within the `publishing` module as it really is a property of the key, but maybe shouldn't be included because then we need to expose it to anyone using a product key. Fine either way, can either leave this commit in or just drop it
3. fix some import paths causing issues on prod for pluto and edde at the moment