### PR TITLE
Updates for 23C GRU QA

### DIFF
--- a/.github/workflows/developments_publish.yml
+++ b/.github/workflows/developments_publish.yml
@@ -1,16 +1,18 @@
 name: DevDB - 🚀 Publish
 
 on:
-#  release:
-#    types:
-#      - published
   workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: True
 
 jobs:
   publish:
     name: Publishing ...
     runs-on: ubuntu-22.04
     env:
+      VERSION: ${{ inputs.version }}
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
@@ -18,40 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get Version
-        id: version
-        run: |
-          source version.env
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version is $VERSION"
-
       - uses: NYCPlanning/action-library-archive@v1.1
         id: dcp_housing
         with:
-          path: templates/dcp_housing.yml
+          path: products/developments/templates/dcp_housing.yml
           s3: true
           latest: true
           compress: true
           output_format: shapefile csv pgdump
-          version: ${{ steps.version.outputs.version }}
+          version: ${{ inputs.version }}
 
       - uses: NYCPlanning/action-library-archive@v1.1
         id: dcp_developments
         with:
-          path: templates/dcp_developments.yml
+          path: products/developments/templates/dcp_developments.yml
           s3: true
           latest: true
           compress: true
           output_format: shapefile csv pgdump
-          version: ${{ steps.version.outputs.version }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID_DATA_ENGINEERING }}
-          service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}
-          export_default_credentials: true
-
-      - name: Archive to BigQuery
-        working-directory: products/developments
-        run: ./devdb.sh bq
+          version: ${{ inputs.version }}

--- a/apps/qa/src/gru/gru.py
+++ b/apps/qa/src/gru/gru.py
@@ -31,7 +31,7 @@ Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
     st.header("Latest Source Data")
     source_table()
 
-    st.header("QAQC Checks")
+    st.header(f"QAQC Checks - Geosupport {geosupport_version}")
     workflows = get_qaqc_runs(geosupport_version)
     not_running_workflows = [
         action_name

--- a/products/developments/templates/dcp_developments.yml
+++ b/products/developments/templates/dcp_developments.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://nyc3.digitaloceanspaces.com/edm-publishing/db-developments/{{ version }}/output/devdb.csv
+      path: https://nyc3.digitaloceanspaces.com/edm-publishing/db-developments/publish/{{ version }}/devdb.csv
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"

--- a/products/developments/templates/dcp_housing.yml
+++ b/products/developments/templates/dcp_housing.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://nyc3.digitaloceanspaces.com/edm-publishing/db-developments/{{ version }}/output/housing.csv
+      path: https://nyc3.digitaloceanspaces.com/edm-publishing/db-developments/publish/{{ version }}/housing.csv
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
Commit 1 gets devdb publish via data library working
- [working action](https://github.com/NYCPlanning/data-engineering/actions/runs/6237296463)

Commit 2 cleans up some display stuff in gru qaqc page
1. displaying geosupport version above table to make it clear these results are only for the chosen geosupport version
2. expanding elements saying that no check has been run rather than just having empty cells

Before:
<img width="1328" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/e66924aa-2c10-434f-a2ac-d17544e00661">

After:
<img width="1324" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/1b69f00c-e386-40c3-a941-91b4b3b353a0">
