### PR TITLE
Refactor facdb pipelines (remove decorator pattern)

### DIFF
--- a/.github/workflows/facilities_test.yml
+++ b/.github/workflows/facilities_test.yml
@@ -1,0 +1,16 @@
+name: Facilities DB - Test
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: mypy
+    runs-on: ubuntu-22.04
+    container:
+      image: nycplanning/dev:latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: mypy
+      run: python3 -m mypy ./products/facilities/facdb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,11 @@ jobs:
               - dcpy/**
               - docker/**
               - python/**
+            facilities:
+              - products/facilities/**
+              - dcpy/**
+              - docker/**
+              - python/**
             knownprojects:
               - products/knownprojects/**
               - dcpy/**
@@ -110,6 +115,11 @@ jobs:
     needs: check_changes
     if: github.event_name != 'pull_request' || contains(needs.check_changes.outputs.path_filters, 'checkbook')
     uses: ./.github/workflows/checkbook_test.yml
+    secrets: inherit
+  facilities:
+    needs: check_changes
+    if: github.event_name != 'pull_request' || contains(needs.check_changes.outputs.path_filters, 'facilities')
+    uses: ./.github/workflows/facilities_test.yml
     secrets: inherit
   knownprojects:
     needs: check_changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,9 @@ jobs:
               - python/**
             knownprojects:
               - products/knownprojects/**
-              - dcpy/**
-              - docker/**
-              - python/**
+              # - dcpy/**
+              # - docker/**
+              # - python/**
             zap:
               - .github/workflows/zap_test.yml
               - .github/workflows/zap_build_mapzap.yml

--- a/products/facilities/facdb/__init__.py
+++ b/products/facilities/facdb/__init__.py
@@ -19,5 +19,5 @@ BASH_PATH = _module_top_path / "bash"
 CACHE_PATH = _product_path / ".cache"
 BASE_URL = "https://nyc3.digitaloceanspaces.com/edm-recipes/datasets"
 
-BUILD_ENGINE = os.environ.get("BUILD_ENGINE")
+BUILD_ENGINE = os.environ.get("BUILD_ENGINE", "")
 assert BUILD_ENGINE

--- a/products/facilities/facdb/cli.py
+++ b/products/facilities/facdb/cli.py
@@ -112,7 +112,7 @@ def run(
         sql = True
     for name in dataset_names:
         dataset = next(filter(lambda x: x["name"] == name, datasets), None)
-        scripts = dataset.get("scripts", None)
+        scripts = dataset.get("scripts") if dataset is not None else []
         if python:
             dataset = prepare(name)
             pipelines = importlib.import_module("facdb.pipelines")
@@ -143,7 +143,7 @@ def sql(
     """
     if scripts:
         for script in scripts:
-            postgres.execute_file_via_shell(script)
+            postgres.execute_file_via_shell(BUILD_ENGINE, script)
 
 
 @app.command()

--- a/products/facilities/facdb/cli.py
+++ b/products/facilities/facdb/cli.py
@@ -6,8 +6,9 @@ from typing import List, Optional
 import typer
 
 from dcpy.utils import postgres
-from .utility.prepare import read_datasets_yml
+from .utility.prepare import read_datasets_yml, prepare
 from .utility.metadata import dump_metadata
+from .utility.export import export
 
 from facdb import SQL_PATH, BASH_PATH, BUILD_ENGINE, CACHE_PATH, VERSION_PREV
 
@@ -113,9 +114,11 @@ def run(
         dataset = next(filter(lambda x: x["name"] == name, datasets), None)
         scripts = dataset.get("scripts", None)
         if python:
+            dataset = prepare(name)
             pipelines = importlib.import_module("facdb.pipelines")
             pipeline = getattr(pipelines, name)
-            pipeline()
+            dataset = pipeline(dataset)
+            export(dataset)
 
         if scripts and sql:
             for script in scripts:

--- a/products/facilities/facdb/geocode/function1B.py
+++ b/products/facilities/facdb/geocode/function1B.py
@@ -1,5 +1,4 @@
 import json
-from functools import wraps
 
 import pandas as pd
 from tqdm.contrib.concurrent import process_map

--- a/products/facilities/facdb/geocode/function1B.py
+++ b/products/facilities/facdb/geocode/function1B.py
@@ -9,10 +9,10 @@ from . import GeosupportError, g
 class Function1B:
     def __init__(
         self,
-        street_name_field: str = None,
-        house_number_field: str = None,
-        borough_field: str = None,
-        zipcode_field: str = None,
+        street_name_field: str | None = None,
+        house_number_field: str | None = None,
+        borough_field: str | None = None,
+        zipcode_field: str | None = None,
     ):
         self.street_name_field = street_name_field
         self.house_number_field = house_number_field

--- a/products/facilities/facdb/geocode/functionBL.py
+++ b/products/facilities/facdb/geocode/functionBL.py
@@ -7,7 +7,7 @@ from . import GeosupportError, g
 
 
 class FunctionBL:
-    def __init__(self, bbl_field: str = None):
+    def __init__(self, bbl_field: str):
         self.bbl_field = bbl_field
 
     def geocode_a_dataframe(self, df: pd.DataFrame):

--- a/products/facilities/facdb/geocode/functionBL.py
+++ b/products/facilities/facdb/geocode/functionBL.py
@@ -1,5 +1,4 @@
 import json
-from functools import wraps
 
 import pandas as pd
 from tqdm.contrib.concurrent import process_map

--- a/products/facilities/facdb/geocode/functionBN.py
+++ b/products/facilities/facdb/geocode/functionBN.py
@@ -7,7 +7,7 @@ from . import GeosupportError, g
 
 
 class FunctionBN:
-    def __init__(self, bin_field: str = None):
+    def __init__(self, bin_field: str):
         self.bin_field = bin_field
 
     def geocode_a_dataframe(self, df: pd.DataFrame):

--- a/products/facilities/facdb/geocode/functionBN.py
+++ b/products/facilities/facdb/geocode/functionBN.py
@@ -1,5 +1,4 @@
 import json
-from functools import wraps
 
 import pandas as pd
 from tqdm.contrib.concurrent import process_map

--- a/products/facilities/facdb/geocode/parseAddress.py
+++ b/products/facilities/facdb/geocode/parseAddress.py
@@ -39,7 +39,7 @@ def quick_clean(address):
     return re.sub(r"[,\%\$\#\@\!\_\.\?\`\"\(\)\ï\¿\½\�]", "", " ".join(result))
 
 
-def parse_address(df, raw_address_field: str = None):
+def parse_address(df, raw_address_field: str):
     df["raw_address"] = df[raw_address_field]
     df["cleaned_address"] = df.raw_address.apply(quick_clean)
     df["parsed_hnum"] = df.cleaned_address.apply(get_hnum)

--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -8,11 +8,10 @@ from .geocode.function1B import Function1B
 from .geocode.functionBL import FunctionBL
 from .geocode.functionBN import FunctionBN
 from .geocode.parseAddress import ParseAddress, UseAirportName
-from .utility.export import Export
+from .utility.export import export
 from .utility.prepare import prepare
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -26,10 +25,9 @@ def bpl_libraries(df: pd.DataFrame = None):
     df["latitude"] = df.position.apply(lambda x: x.split(",")[0].strip())
     df["zipcode"] = df.address.apply(lambda x: x[-6:])
     df["borough"] = "Brooklyn"
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -41,10 +39,9 @@ def nypl_libraries(df: pd.DataFrame = None):
     df = prepare("nypl_libraries")
     df["latitude"] = df.lat
     df["longitude"] = df.lon
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="address_street_name",
     house_number_field="address_building",
@@ -71,10 +68,9 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
     df = df.loc[((df.license_expiration_date >= today) & (df.industry == "Scrap Metal Processor"))|((df.license_expiration_date >= covid_freeze) & (df.industry != "Scrap Metal Processor")), :]\
         .loc[df.industry.isin(industry), :]
     # fmt:on
-    return df
+    export(df)
 
 
-@Export
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
 @Function1B(
@@ -87,10 +83,9 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
 def dcla_culturalinstitutions(df: pd.DataFrame = None):
     df = prepare("dcla_culturalinstitutions")
     df["zipcode"] = df.postcode.apply(lambda x: x[:5])
-    return df
+    export(df)
 
 
-@Export
 @FunctionBL(bbl_field="bbl")
 @Function1B(
     street_name_field="sname", house_number_field="hnum", borough_field="borough"
@@ -98,10 +93,9 @@ def dcla_culturalinstitutions(df: pd.DataFrame = None):
 def dcp_colp(df: pd.DataFrame = None):
     df = prepare("dcp_colp")
     df["bbl"] = df.bbl.str.split(pat=".").str[0]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street_name",
     house_number_field="address_number",
@@ -112,16 +106,14 @@ def dcp_colp(df: pd.DataFrame = None):
 @FunctionBN(bin_field="bin")
 def dcp_pops(df: pd.DataFrame = None):
     df = prepare("dcp_pops")
-    return df
+    export(df)
 
 
-@Export
 def dcp_sfpsd(df: pd.DataFrame = None):
     df = prepare("dcp_sfpsd")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street_name",
     house_number_field="house_number",
@@ -129,10 +121,9 @@ def dcp_sfpsd(df: pd.DataFrame = None):
 )
 def dep_wwtc(df: pd.DataFrame = None):
     df = prepare("dep_wwtc")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -141,10 +132,9 @@ def dep_wwtc(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="program_address")
 def dfta_contracts(df: pd.DataFrame = None):
     df = prepare("dfta_contracts")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -157,10 +147,9 @@ def doe_busroutesgarages(df: pd.DataFrame = None):
     # SCHOOL_YEAR = f"{datetime.date.today().year-1}-{datetime.date.today().year}"
     SCHOOL_YEAR = "2019-2020"  # No records from 2020-2021 school year
     df = df.loc[df.school_year == SCHOOL_YEAR, :]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -171,10 +160,9 @@ def doe_busroutesgarages(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="primary_address")
 def doe_lcgms(df: pd.DataFrame = None):
     df = prepare("doe_lcgms")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -193,10 +181,9 @@ def doe_universalprek(df: pd.DataFrame = None):
             "R": "Staten Island",
         }
     )
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street",
     house_number_field="building",
@@ -206,10 +193,9 @@ def doe_universalprek(df: pd.DataFrame = None):
 @FunctionBN(bin_field="building_identification_number")
 def dohmh_daycare(df: pd.DataFrame = None):
     df = prepare("dohmh_daycare")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -219,10 +205,9 @@ def dohmh_daycare(df: pd.DataFrame = None):
 def dot_bridgehouses(df: pd.DataFrame = None):
     df = prepare("dot_bridgehouses")
     df["address"] = df.address.astype(str).replace("n/a", None)
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -233,10 +218,9 @@ def dot_bridgehouses(df: pd.DataFrame = None):
 def dot_ferryterminals(df: pd.DataFrame = None):
     df = prepare("dot_ferryterminals")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -248,16 +232,14 @@ def dot_mannedfacilities(df: pd.DataFrame = None):
     df = prepare("dot_mannedfacilities")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
-    return df
+    export(df)
 
 
-@Export
 def dot_pedplazas(df: pd.DataFrame = None):
     df = prepare("dot_pedplazas")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -269,10 +251,9 @@ def dot_publicparking(df: pd.DataFrame = None):
     df = prepare("dot_publicparking")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -292,10 +273,9 @@ def dpr_parksproperties(df: pd.DataFrame = None):
             "R": "Staten Island",
         }
     )
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -308,10 +288,9 @@ def dpr_parksproperties(df: pd.DataFrame = None):
 def dsny_garages(df: pd.DataFrame = None):
     df = prepare("dsny_garages")
     df["address"] = df.address.astype(str)
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -321,10 +300,9 @@ def dsny_garages(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 def dsny_specialwastedrop(df: pd.DataFrame = None):
     df = prepare("dsny_specialwastedrop")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street", house_number_field="number", borough_field="borough"
 )
@@ -337,10 +315,9 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
         df["categoriesaccepted"].notna()
         & df["categoriesaccepted"].str.contains("Clothing")
     ]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -353,10 +330,9 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
 def dsny_leafdrop(df: pd.DataFrame = None):
     df = prepare("dsny_leafdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -372,10 +348,9 @@ def dsny_fooddrop(df: pd.DataFrame = None):
         return location_str[:-5] if location_str[:-5].isnumeric() else None
 
     df["zip_code"] = df["location"].apply(_loc_to_zipcode)
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street",
     house_number_field="number",
@@ -387,10 +362,9 @@ def dsny_fooddrop(df: pd.DataFrame = None):
 def dsny_electronicsdrop(df: pd.DataFrame = None):
     df = prepare("dsny_electronicsdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -414,10 +388,9 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
     df["spatial"] = df.spatial.apply(lambda x: x.replace("(", "").replace(")", ""))
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -427,10 +400,9 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 def fbop_corrections(df: pd.DataFrame = None):
     df = prepare("fbop_corrections")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -459,10 +431,9 @@ def fdny_firehouses(df: pd.DataFrame = None):
         df_research.facilityname.isin(df.facilityname),
         ["facilityaddress", "borough", "postcode", "wkt"],
     ].values
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -471,10 +442,9 @@ def fdny_firehouses(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 def foodbankny_foodbanks(df: pd.DataFrame = None):
     df = prepare("foodbankny_foodbanks")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -490,10 +460,9 @@ def hhc_hospitals(df: pd.DataFrame = None):
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
     df.location_1 = df.location_1.apply(lambda x: x.replace("\n", " "))
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -505,10 +474,9 @@ def hhc_hospitals(df: pd.DataFrame = None):
 @FunctionBN(bin_field="bin")
 def hra_snapcenters(df: pd.DataFrame = None):
     df = prepare("hra_snapcenters")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -520,10 +488,9 @@ def hra_snapcenters(df: pd.DataFrame = None):
 @FunctionBN(bin_field="bin")
 def hra_jobcenters(df: pd.DataFrame = None):
     df = prepare("hra_jobcenters")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -535,10 +502,9 @@ def hra_jobcenters(df: pd.DataFrame = None):
 @FunctionBN(bin_field="bin")
 def hra_medicaid(df: pd.DataFrame = None):
     df = prepare("hra_medicaid")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -556,10 +522,9 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
     df["bin"] = df.bin.fillna(0).astype(float).astype(int)
     df["postcode"] = df.bbl.fillna(0).astype(float).astype(int)
     df["postcode"] = df.postcode.astype(str).apply(lambda x: x[:5])
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street_name",
     house_number_field="house_number",
@@ -567,10 +532,9 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
 )
 def nycdoc_corrections(df: pd.DataFrame = None):
     df = prepare("nycdoc_corrections")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -581,10 +545,9 @@ def nycdoc_corrections(df: pd.DataFrame = None):
 @FunctionBN(bin_field="bin")
 def nycha_communitycenters(df: pd.DataFrame = None):
     df = prepare("nycha_communitycenters")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -594,10 +557,9 @@ def nycha_communitycenters(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 def nycha_policeservice(df: pd.DataFrame = None):
     df = prepare("nycha_policeservice")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -607,17 +569,15 @@ def nycha_policeservice(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 def nycourts_courts(df: pd.DataFrame = None):
     df = prepare("nycourts_courts")
-    return df
+    export(df)
 
 
-@Export
 def nysdec_lands(df: pd.DataFrame = None):
     df = prepare("nysdec_lands")
     df = df[df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -628,10 +588,9 @@ def nysdec_lands(df: pd.DataFrame = None):
 def nysdec_solidwaste(df: pd.DataFrame = None):
     df = prepare("nysdec_solidwaste")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street_name",
     house_number_field="house_number",
@@ -642,10 +601,9 @@ def nysdoccs_corrections(df: pd.DataFrame = None):
     df = prepare("nysdoccs_corrections")
     df["zipcode"] = df.zipcode.apply(lambda x: x[:5])
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -659,10 +617,9 @@ def nysdoh_healthfacilities(df: pd.DataFrame = None):
         df.facility_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"]), :
     ].copy()
     df["zipcode"] = df.facility_zip_code.apply(lambda x: x[:5])
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -673,22 +630,19 @@ def nysdoh_healthfacilities(df: pd.DataFrame = None):
 def nysdoh_nursinghomes(df: pd.DataFrame = None):
     df = prepare("nysdoh_nursinghomes")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
-    return df
+    export(df)
 
 
-@Export
 def nysed_nonpublicenrollment(df: pd.DataFrame = None):
     df = prepare("nysed_nonpublicenrollment")
-    return df
+    export(df)
 
 
-@Export
 def sca_enrollment_capacity(df: pd.DataFrame = None):
     df = prepare("sca_enrollment_capacity")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -701,10 +655,9 @@ def nysed_activeinstitutions(df: pd.DataFrame = None):
     df = df[
         df.county_description.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])
     ]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -717,10 +670,9 @@ def nysoasas_programs(df: pd.DataFrame = None):
     df = df[
         df.provider_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -733,10 +685,9 @@ def nysomh_mentalhealth(df: pd.DataFrame = None):
     df = df[
         df.program_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -747,24 +698,21 @@ def nysomh_mentalhealth(df: pd.DataFrame = None):
 def nysopwdd_providers(df: pd.DataFrame = None):
     df = prepare("nysopwdd_providers")
     df = df[df.county.isin(["BRONX", "NEW YORK", "KINGS", "QUEENS", "RICHMOND"])]
-    return df
+    export(df)
 
 
-@Export
 def nysparks_historicplaces(df: pd.DataFrame = None):
     df = prepare("nysparks_historicplaces")
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
-    return df
+    export(df)
 
 
-@Export
 def nysparks_parks(df: pd.DataFrame = None):
     df = prepare("nysparks_parks")
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -776,10 +724,9 @@ def nysparks_parks(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 def qpl_libraries(df: pd.DataFrame = None):
     df = prepare("qpl_libraries")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="street",
     house_number_field="number",
@@ -790,10 +737,9 @@ def qpl_libraries(df: pd.DataFrame = None):
 @FunctionBL(bbl_field="bbl")
 def sbs_workforce1(df: pd.DataFrame = None):
     df = prepare("sbs_workforce1")
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -803,10 +749,9 @@ def sbs_workforce1(df: pd.DataFrame = None):
 def uscourts_courts(df: pd.DataFrame = None):
     df = prepare("uscourts_courts")
     df["zipcode"] = df.buildingzip.apply(lambda x: x[:5])
-    return df
+    export(df)
 
 
-@Export
 @Function1B(
     street_name_field="parsed_sname",
     house_number_field="parsed_hnum",
@@ -829,10 +774,9 @@ def usdot_airports(df: pd.DataFrame = None):
         df.name == "JOHN F KENNEDY INTL", "airport_name"
     ] = "JOHN F KENNEDY INTL AIRPORT"
     df.loc[df.name == "LAGUARDIA", "airport_name"] = "LAGUARDIA AIRPORT"
-    return df
+    export(df)
 
 
-@Export
 def usdot_ports(df: pd.DataFrame = None):
     df = prepare("usdot_ports")
     df = df.loc[
@@ -840,11 +784,10 @@ def usdot_ports(df: pd.DataFrame = None):
         & (df.county_nam.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])),
         :,
     ]
-    return df
+    export(df)
 
 
-@Export
 def usnps_parks(df: pd.DataFrame = None):
     df = prepare("usnps_parks")
     df = df[df.state == "NY"]
-    return df
+    export(df)

--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -11,7 +11,7 @@ from .geocode.parseAddress import parse_address, use_airport_name
 from facdb.utility.utils import sanitize_df
 
 
-def bpl_libraries(df: pd.DataFrame = None):
+def bpl_libraries(df: pd.DataFrame):
     df["longitude"] = df.position.apply(lambda x: x.split(",")[1].strip())
     df["latitude"] = df.position.apply(lambda x: x.split(",")[0].strip())
     df["zipcode"] = df.address.apply(lambda x: x[-6:])
@@ -27,7 +27,7 @@ def bpl_libraries(df: pd.DataFrame = None):
     return df
 
 
-def nypl_libraries(df: pd.DataFrame = None):
+def nypl_libraries(df: pd.DataFrame):
     df["latitude"] = df.lat
     df["longitude"] = df.lon
     df = sanitize_df(df)
@@ -41,7 +41,7 @@ def nypl_libraries(df: pd.DataFrame = None):
     return df
 
 
-def dca_operatingbusinesses(df: pd.DataFrame = None):
+def dca_operatingbusinesses(df: pd.DataFrame):
     industry = [
         "Scrap Metal Processor",
         "Parking Lot",
@@ -70,7 +70,7 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
     return df
 
 
-def dcla_culturalinstitutions(df: pd.DataFrame = None):
+def dcla_culturalinstitutions(df: pd.DataFrame):
     df["zipcode"] = df.postcode.apply(lambda x: x[:5])
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
@@ -85,7 +85,7 @@ def dcla_culturalinstitutions(df: pd.DataFrame = None):
     return df
 
 
-def dcp_colp(df: pd.DataFrame = None):
+def dcp_colp(df: pd.DataFrame):
     df["bbl"] = df.bbl.str.split(pat=".").str[0]
     df = sanitize_df(df)
     df = Function1B(
@@ -95,7 +95,7 @@ def dcp_colp(df: pd.DataFrame = None):
     return df
 
 
-def dcp_pops(df: pd.DataFrame = None):
+def dcp_pops(df: pd.DataFrame):
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -108,12 +108,12 @@ def dcp_pops(df: pd.DataFrame = None):
     return df
 
 
-def dcp_sfpsd(df: pd.DataFrame = None):
+def dcp_sfpsd(df: pd.DataFrame):
     df = sanitize_df(df)
     return df
 
 
-def dep_wwtc(df: pd.DataFrame = None):
+def dep_wwtc(df: pd.DataFrame):
     df = sanitize_df(df)
     df = Function1B(
         street_name_field="street_name",
@@ -123,7 +123,7 @@ def dep_wwtc(df: pd.DataFrame = None):
     return df
 
 
-def dfta_contracts(df: pd.DataFrame = None):
+def dfta_contracts(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="program_address")
     df = Function1B(
@@ -134,7 +134,7 @@ def dfta_contracts(df: pd.DataFrame = None):
     return df
 
 
-def doe_busroutesgarages(df: pd.DataFrame = None):
+def doe_busroutesgarages(df: pd.DataFrame):
     # SCHOOL_YEAR = f"{datetime.date.today().year-1}-{datetime.date.today().year}"
     SCHOOL_YEAR = "2019-2020"  # No records from 2020-2021 school year
     df = df.loc[df.school_year == SCHOOL_YEAR, :]
@@ -149,7 +149,7 @@ def doe_busroutesgarages(df: pd.DataFrame = None):
     return df
 
 
-def doe_lcgms(df: pd.DataFrame = None):
+def doe_lcgms(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="primary_address")
     df = FunctionBL(bbl_field="borough_block_lot").geocode_a_dataframe(df)
@@ -162,7 +162,7 @@ def doe_lcgms(df: pd.DataFrame = None):
     return df
 
 
-def doe_universalprek(df: pd.DataFrame = None):
+def doe_universalprek(df: pd.DataFrame):
     df["boro"] = df.borough.map(
         {
             "M": "Manhattan",
@@ -183,7 +183,7 @@ def doe_universalprek(df: pd.DataFrame = None):
     return df
 
 
-def dohmh_daycare(df: pd.DataFrame = None):
+def dohmh_daycare(df: pd.DataFrame):
     df = sanitize_df(df)
     df = FunctionBN(bin_field="building_identification_number").geocode_a_dataframe(df)
     df = Function1B(
@@ -195,7 +195,7 @@ def dohmh_daycare(df: pd.DataFrame = None):
     return df
 
 
-def dot_bridgehouses(df: pd.DataFrame = None):
+def dot_bridgehouses(df: pd.DataFrame):
     df["address"] = df.address.astype(str).replace("n/a", None)
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="site")
@@ -207,7 +207,7 @@ def dot_bridgehouses(df: pd.DataFrame = None):
     return df
 
 
-def dot_ferryterminals(df: pd.DataFrame = None):
+def dot_ferryterminals(df: pd.DataFrame):
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
@@ -220,7 +220,7 @@ def dot_ferryterminals(df: pd.DataFrame = None):
     return df
 
 
-def dot_mannedfacilities(df: pd.DataFrame = None):
+def dot_mannedfacilities(df: pd.DataFrame):
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = sanitize_df(df)
@@ -234,12 +234,12 @@ def dot_mannedfacilities(df: pd.DataFrame = None):
     return df
 
 
-def dot_pedplazas(df: pd.DataFrame = None):
+def dot_pedplazas(df: pd.DataFrame):
     df = sanitize_df(df)
     return df
 
 
-def dot_publicparking(df: pd.DataFrame = None):
+def dot_publicparking(df: pd.DataFrame):
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = sanitize_df(df)
@@ -253,7 +253,7 @@ def dot_publicparking(df: pd.DataFrame = None):
     return df
 
 
-def dpr_parksproperties(df: pd.DataFrame = None):
+def dpr_parksproperties(df: pd.DataFrame):
     df["zipcode"] = df.zipcode.astype(str).apply(lambda x: x[:5])
     df["boro"] = df.borough.map(
         {
@@ -275,7 +275,7 @@ def dpr_parksproperties(df: pd.DataFrame = None):
     return df
 
 
-def dsny_garages(df: pd.DataFrame = None):
+def dsny_garages(df: pd.DataFrame):
     df["address"] = df.address.astype(str)
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
@@ -290,7 +290,7 @@ def dsny_garages(df: pd.DataFrame = None):
     return df
 
 
-def dsny_specialwastedrop(df: pd.DataFrame = None):
+def dsny_specialwastedrop(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
@@ -302,7 +302,7 @@ def dsny_specialwastedrop(df: pd.DataFrame = None):
     return df
 
 
-def dsny_donatenycdirectory(df: pd.DataFrame = None):
+def dsny_donatenycdirectory(df: pd.DataFrame):
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = df[
         df["categoriesaccepted"].notna()
@@ -317,7 +317,7 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
     return df
 
 
-def dsny_leafdrop(df: pd.DataFrame = None):
+def dsny_leafdrop(df: pd.DataFrame):
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
@@ -332,7 +332,7 @@ def dsny_leafdrop(df: pd.DataFrame = None):
     return df
 
 
-def dsny_fooddrop(df: pd.DataFrame = None):
+def dsny_fooddrop(df: pd.DataFrame):
     def _loc_to_zipcode(location):
         location_str = str(location)
         return location_str[:-5] if location_str[:-5].isnumeric() else None
@@ -349,7 +349,7 @@ def dsny_fooddrop(df: pd.DataFrame = None):
     return df
 
 
-def dsny_electronicsdrop(df: pd.DataFrame = None):
+def dsny_electronicsdrop(df: pd.DataFrame):
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
@@ -363,7 +363,7 @@ def dsny_electronicsdrop(df: pd.DataFrame = None):
     return df
 
 
-def dycd_afterschoolprograms(df: pd.DataFrame = None):
+def dycd_afterschoolprograms(df: pd.DataFrame):
     df["address"] = df.location_1.apply(
         lambda x: str(x).replace("nan", "").split("\n")[0][:-5]
     )
@@ -389,7 +389,7 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
     return df
 
 
-def fbop_corrections(df: pd.DataFrame = None):
+def fbop_corrections(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
@@ -401,7 +401,7 @@ def fbop_corrections(df: pd.DataFrame = None):
     return df
 
 
-def fdny_firehouses(df: pd.DataFrame = None):
+def fdny_firehouses(df: pd.DataFrame):
     df["cleaned_address"] = df["facilityaddress"].map(
         lambda x: re.sub("[^A-Za-z0-9- ]+", "", x)
     )
@@ -432,7 +432,7 @@ def fdny_firehouses(df: pd.DataFrame = None):
     return df
 
 
-def foodbankny_foodbanks(df: pd.DataFrame = None):
+def foodbankny_foodbanks(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
@@ -443,7 +443,7 @@ def foodbankny_foodbanks(df: pd.DataFrame = None):
     return df
 
 
-def hhc_hospitals(df: pd.DataFrame = None):
+def hhc_hospitals(df: pd.DataFrame):
     df["spatial"] = df.location_1.apply(lambda x: x.split("(")[-1].replace(")", ""))
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
@@ -461,7 +461,7 @@ def hhc_hospitals(df: pd.DataFrame = None):
     return df
 
 
-def hra_snapcenters(df: pd.DataFrame = None):
+def hra_snapcenters(df: pd.DataFrame):
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -475,7 +475,7 @@ def hra_snapcenters(df: pd.DataFrame = None):
     return df
 
 
-def hra_jobcenters(df: pd.DataFrame = None):
+def hra_jobcenters(df: pd.DataFrame):
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -489,7 +489,7 @@ def hra_jobcenters(df: pd.DataFrame = None):
     return df
 
 
-def hra_medicaid(df: pd.DataFrame = None):
+def hra_medicaid(df: pd.DataFrame):
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -503,7 +503,7 @@ def hra_medicaid(df: pd.DataFrame = None):
     return df
 
 
-def moeo_socialservicesitelocations(df: pd.DataFrame = None):
+def moeo_socialservicesitelocations(df: pd.DataFrame):
     df["borough"] = df.borough.str.upper()
     df["bbl"] = df.bbl.replace("undefinedundefinedundefined", None)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
@@ -523,7 +523,7 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
     return df
 
 
-def nycdoc_corrections(df: pd.DataFrame = None):
+def nycdoc_corrections(df: pd.DataFrame):
     df = sanitize_df(df)
     df = Function1B(
         street_name_field="street_name",
@@ -533,7 +533,7 @@ def nycdoc_corrections(df: pd.DataFrame = None):
     return df
 
 
-def nycha_communitycenters(df: pd.DataFrame = None):
+def nycha_communitycenters(df: pd.DataFrame):
     df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -546,7 +546,7 @@ def nycha_communitycenters(df: pd.DataFrame = None):
     return df
 
 
-def nycha_policeservice(df: pd.DataFrame = None):
+def nycha_policeservice(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
@@ -558,7 +558,7 @@ def nycha_policeservice(df: pd.DataFrame = None):
     return df
 
 
-def nycourts_courts(df: pd.DataFrame = None):
+def nycourts_courts(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
@@ -570,13 +570,13 @@ def nycourts_courts(df: pd.DataFrame = None):
     return df
 
 
-def nysdec_lands(df: pd.DataFrame = None):
+def nysdec_lands(df: pd.DataFrame):
     df = df[df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])]
     df = sanitize_df(df)
     return df
 
 
-def nysdec_solidwaste(df: pd.DataFrame = None):
+def nysdec_solidwaste(df: pd.DataFrame):
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="location_address")
@@ -589,7 +589,7 @@ def nysdec_solidwaste(df: pd.DataFrame = None):
     return df
 
 
-def nysdoccs_corrections(df: pd.DataFrame = None):
+def nysdoccs_corrections(df: pd.DataFrame):
     df["zipcode"] = df.zipcode.apply(lambda x: x[:5])
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     df = sanitize_df(df)
@@ -602,7 +602,7 @@ def nysdoccs_corrections(df: pd.DataFrame = None):
     return df
 
 
-def nysdoh_healthfacilities(df: pd.DataFrame = None):
+def nysdoh_healthfacilities(df: pd.DataFrame):
     df = df.loc[
         df.facility_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"]), :
     ].copy()
@@ -618,7 +618,7 @@ def nysdoh_healthfacilities(df: pd.DataFrame = None):
     return df
 
 
-def nysdoh_nursinghomes(df: pd.DataFrame = None):
+def nysdoh_nursinghomes(df: pd.DataFrame):
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="street_address")
@@ -631,17 +631,17 @@ def nysdoh_nursinghomes(df: pd.DataFrame = None):
     return df
 
 
-def nysed_nonpublicenrollment(df: pd.DataFrame = None):
+def nysed_nonpublicenrollment(df: pd.DataFrame):
     df = sanitize_df(df)
     return df
 
 
-def sca_enrollment_capacity(df: pd.DataFrame = None):
+def sca_enrollment_capacity(df: pd.DataFrame):
     df = sanitize_df(df)
     return df
 
 
-def nysed_activeinstitutions(df: pd.DataFrame = None):
+def nysed_activeinstitutions(df: pd.DataFrame):
     df = df[
         df.county_description.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])
     ]
@@ -656,7 +656,7 @@ def nysed_activeinstitutions(df: pd.DataFrame = None):
     return df
 
 
-def nysoasas_programs(df: pd.DataFrame = None):
+def nysoasas_programs(df: pd.DataFrame):
     df = df[
         df.provider_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
@@ -671,7 +671,7 @@ def nysoasas_programs(df: pd.DataFrame = None):
     return df
 
 
-def nysomh_mentalhealth(df: pd.DataFrame = None):
+def nysomh_mentalhealth(df: pd.DataFrame):
     df = df[
         df.program_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
@@ -686,7 +686,7 @@ def nysomh_mentalhealth(df: pd.DataFrame = None):
     return df
 
 
-def nysopwdd_providers(df: pd.DataFrame = None):
+def nysopwdd_providers(df: pd.DataFrame):
     df = df[df.county.isin(["BRONX", "NEW YORK", "KINGS", "QUEENS", "RICHMOND"])]
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="street_address")
@@ -699,19 +699,19 @@ def nysopwdd_providers(df: pd.DataFrame = None):
     return df
 
 
-def nysparks_historicplaces(df: pd.DataFrame = None):
+def nysparks_historicplaces(df: pd.DataFrame):
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
     df = sanitize_df(df)
     return df
 
 
-def nysparks_parks(df: pd.DataFrame = None):
+def nysparks_parks(df: pd.DataFrame):
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
     df = sanitize_df(df)
     return df
 
 
-def qpl_libraries(df: pd.DataFrame = None):
+def qpl_libraries(df: pd.DataFrame):
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -725,7 +725,7 @@ def qpl_libraries(df: pd.DataFrame = None):
     return df
 
 
-def sbs_workforce1(df: pd.DataFrame = None):
+def sbs_workforce1(df: pd.DataFrame):
     df = sanitize_df(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
@@ -738,7 +738,7 @@ def sbs_workforce1(df: pd.DataFrame = None):
     return df
 
 
-def uscourts_courts(df: pd.DataFrame = None):
+def uscourts_courts(df: pd.DataFrame):
     df["zipcode"] = df.buildingzip.apply(lambda x: x[:5])
     df = sanitize_df(df)
     df = parse_address(df, raw_address_field="buildingaddress")
@@ -750,7 +750,7 @@ def uscourts_courts(df: pd.DataFrame = None):
     return df
 
 
-def usdot_airports(df: pd.DataFrame = None):
+def usdot_airports(df: pd.DataFrame):
     df = df.loc[
         (df["state_name"] == "NEW YORK")
         & (df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])),
@@ -775,7 +775,7 @@ def usdot_airports(df: pd.DataFrame = None):
     return df
 
 
-def usdot_ports(df: pd.DataFrame = None):
+def usdot_ports(df: pd.DataFrame):
     df = df.loc[
         (df.state_post == "NY")
         & (df.county_nam.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])),
@@ -785,7 +785,7 @@ def usdot_ports(df: pd.DataFrame = None):
     return df
 
 
-def usnps_parks(df: pd.DataFrame = None):
+def usnps_parks(df: pd.DataFrame):
     df = df[df.state == "NY"]
     df = sanitize_df(df)
     return df

--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -7,49 +7,41 @@ import pandas as pd
 from .geocode.function1B import Function1B
 from .geocode.functionBL import FunctionBL
 from .geocode.functionBN import FunctionBN
-from .geocode.parseAddress import ParseAddress, UseAirportName
+from .geocode.parseAddress import parse_address, use_airport_name
 from .utility.export import export
 from .utility.prepare import prepare
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
 def bpl_libraries(df: pd.DataFrame = None):
     df = prepare("bpl_libraries")
     df["longitude"] = df.position.apply(lambda x: x.split(",")[1].strip())
     df["latitude"] = df.position.apply(lambda x: x.split(",")[0].strip())
     df["zipcode"] = df.address.apply(lambda x: x[-6:])
     df["borough"] = "Brooklyn"
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="locality",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
 def nypl_libraries(df: pd.DataFrame = None):
     df = prepare("nypl_libraries")
     df["latitude"] = df.lat
     df["longitude"] = df.lon
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="locality",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="address_street_name",
-    house_number_field="address_building",
-    borough_field="address_borough",
-    zipcode_field="address_zip",
-)
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def dca_operatingbusinesses(df: pd.DataFrame = None):
     df = prepare("dca_operatingbusinesses")
     industry = [
@@ -68,44 +60,52 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
     df = df.loc[((df.license_expiration_date >= today) & (df.industry == "Scrap Metal Processor"))|((df.license_expiration_date >= covid_freeze) & (df.industry != "Scrap Metal Processor")), :]\
         .loc[df.industry.isin(industry), :]
     # fmt:on
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="address_street_name",
+        house_number_field="address_building",
+        borough_field="address_borough",
+        zipcode_field="address_zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
 def dcla_culturalinstitutions(df: pd.DataFrame = None):
     df = prepare("dcla_culturalinstitutions")
     df["zipcode"] = df.postcode.apply(lambda x: x[:5])
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     export(df)
 
 
-@FunctionBL(bbl_field="bbl")
-@Function1B(
-    street_name_field="sname", house_number_field="hnum", borough_field="borough"
-)
 def dcp_colp(df: pd.DataFrame = None):
     df = prepare("dcp_colp")
     df["bbl"] = df.bbl.str.split(pat=".").str[0]
+    df = Function1B(
+        street_name_field="sname", house_number_field="hnum", borough_field="borough"
+    ).geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="street_name",
-    house_number_field="address_number",
-    borough_field="borough_name",
-    zipcode_field="zip_code",
-)
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def dcp_pops(df: pd.DataFrame = None):
     df = prepare("dcp_pops")
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="street_name",
+        house_number_field="address_number",
+        borough_field="borough_name",
+        zipcode_field="zip_code",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
@@ -114,62 +114,55 @@ def dcp_sfpsd(df: pd.DataFrame = None):
     export(df)
 
 
-@Function1B(
-    street_name_field="street_name",
-    house_number_field="house_number",
-    zipcode_field="zipcode",
-)
 def dep_wwtc(df: pd.DataFrame = None):
     df = prepare("dep_wwtc")
+    df = Function1B(
+        street_name_field="street_name",
+        house_number_field="house_number",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    zipcode_field="program_zipcode",
-)
-@ParseAddress(raw_address_field="program_address")
 def dfta_contracts(df: pd.DataFrame = None):
     df = prepare("dfta_contracts")
+    df = parse_address(df, raw_address_field="program_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        zipcode_field="program_zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="garage_city",
-    zipcode_field="garage_zip",
-)
-@ParseAddress(raw_address_field="garage__street_address")
 def doe_busroutesgarages(df: pd.DataFrame = None):
     df = prepare("doe_busroutesgarages")
     # SCHOOL_YEAR = f"{datetime.date.today().year-1}-{datetime.date.today().year}"
     SCHOOL_YEAR = "2019-2020"  # No records from 2020-2021 school year
     df = df.loc[df.school_year == SCHOOL_YEAR, :]
+    df = parse_address(df, raw_address_field="garage__street_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="garage_city",
+        zipcode_field="garage_zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="city",
-    zipcode_field="zip",
-)
-@FunctionBL(bbl_field="borough_block_lot")
-@ParseAddress(raw_address_field="primary_address")
 def doe_lcgms(df: pd.DataFrame = None):
     df = prepare("doe_lcgms")
+    df = parse_address(df, raw_address_field="primary_address")
+    df = FunctionBL(bbl_field="borough_block_lot").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="city",
+        zipcode_field="zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boro",
-    zipcode_field="zip",
-)
-@ParseAddress(raw_address_field="address")
 def doe_universalprek(df: pd.DataFrame = None):
     df = prepare("doe_universalprek")
     df["boro"] = df.borough.map(
@@ -181,57 +174,64 @@ def doe_universalprek(df: pd.DataFrame = None):
             "R": "Staten Island",
         }
     )
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boro",
+        zipcode_field="zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="street",
-    house_number_field="building",
-    borough_field="borough",
-    zipcode_field="zipcode",
-)
-@FunctionBN(bin_field="building_identification_number")
 def dohmh_daycare(df: pd.DataFrame = None):
     df = prepare("dohmh_daycare")
+    df = FunctionBN(bin_field="building_identification_number").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="street",
+        house_number_field="building",
+        borough_field="borough",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boroname",
-)
-@ParseAddress(raw_address_field="site")
 def dot_bridgehouses(df: pd.DataFrame = None):
     df = prepare("dot_bridgehouses")
     df["address"] = df.address.astype(str).replace("n/a", None)
+    df = parse_address(df, raw_address_field="site")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boroname",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boroname",
-)
-@FunctionBL(bbl_field="bbl")
-@ParseAddress(raw_address_field="address")
 def dot_ferryterminals(df: pd.DataFrame = None):
     df = prepare("dot_ferryterminals")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = parse_address(df, raw_address_field="address")
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boroname",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boroname",
-)
-@FunctionBL(bbl_field="bbl")
-@ParseAddress(raw_address_field="address")
 def dot_mannedfacilities(df: pd.DataFrame = None):
     df = prepare("dot_mannedfacilities")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = parse_address(df, raw_address_field="address")
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boroname",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
@@ -240,27 +240,20 @@ def dot_pedplazas(df: pd.DataFrame = None):
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boroname",
-)
-@FunctionBL(bbl_field="bbl")
-@ParseAddress(raw_address_field="address")
 def dot_publicparking(df: pd.DataFrame = None):
     df = prepare("dot_publicparking")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = parse_address(df, raw_address_field="address")
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boroname",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boro",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
 def dpr_parksproperties(df: pd.DataFrame = None):
     df = prepare("dpr_parksproperties")
     df["zipcode"] = df.zipcode.astype(str).apply(lambda x: x[:5])
@@ -273,41 +266,43 @@ def dpr_parksproperties(df: pd.DataFrame = None):
             "R": "Staten Island",
         }
     )
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boro",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boro",
-    zipcode_field="zip",
-)
-@ParseAddress(raw_address_field="address")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def dsny_garages(df: pd.DataFrame = None):
     df = prepare("dsny_garages")
     df["address"] = df.address.astype(str)
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boro",
+        zipcode_field="zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="boro",
-    zipcode_field="zip",
-)
-@ParseAddress(raw_address_field="address")
 def dsny_specialwastedrop(df: pd.DataFrame = None):
     df = prepare("dsny_specialwastedrop")
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="boro",
+        zipcode_field="zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="street", house_number_field="number", borough_field="borough"
-)
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def dsny_donatenycdirectory(df: pd.DataFrame = None):
     df = prepare("dsny_donatenycdirectory")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
@@ -315,31 +310,29 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
         df["categoriesaccepted"].notna()
         & df["categoriesaccepted"].str.contains("Clothing")
     ]
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="street", house_number_field="number", borough_field="borough"
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def dsny_leafdrop(df: pd.DataFrame = None):
     df = prepare("dsny_leafdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="zip_code",
-)
-@ParseAddress(raw_address_field="location")
 def dsny_fooddrop(df: pd.DataFrame = None):
     df = prepare("dsny_fooddrop")
 
@@ -348,32 +341,30 @@ def dsny_fooddrop(df: pd.DataFrame = None):
         return location_str[:-5] if location_str[:-5].isnumeric() else None
 
     df["zip_code"] = df["location"].apply(_loc_to_zipcode)
+    df = parse_address(df, raw_address_field="location")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="zip_code",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="street",
-    house_number_field="number",
-    borough_field="borough",
-    zipcode_field="zipcode",
-)
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def dsny_electronicsdrop(df: pd.DataFrame = None):
     df = prepare("dsny_electronicsdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="street",
+        house_number_field="number",
+        borough_field="borough",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough__community",
-    zipcode_field="zipcode",
-)
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
-@ParseAddress(raw_address_field="address")
 def dycd_afterschoolprograms(df: pd.DataFrame = None):
     df = prepare("dycd_afterschoolprograms")
     df["address"] = df.location_1.apply(
@@ -388,30 +379,30 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
     df["spatial"] = df.spatial.apply(lambda x: x.replace("(", "").replace(")", ""))
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
+    df = parse_address(df, raw_address_field="address")
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough__community",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="city",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
 def fbop_corrections(df: pd.DataFrame = None):
     df = prepare("fbop_corrections")
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="city",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
-@ParseAddress(raw_address_field="cleaned_address")
 def fdny_firehouses(df: pd.DataFrame = None):
     df = prepare("fdny_firehouses")
     df["cleaned_address"] = df["facilityaddress"].map(
@@ -431,89 +422,89 @@ def fdny_firehouses(df: pd.DataFrame = None):
         df_research.facilityname.isin(df.facilityname),
         ["facilityaddress", "borough", "postcode", "wkt"],
     ].values
+    df = parse_address(df, raw_address_field="cleaned_address")
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    zipcode_field="zip_code",
-)
-@ParseAddress(raw_address_field="address")
 def foodbankny_foodbanks(df: pd.DataFrame = None):
     df = prepare("foodbankny_foodbanks")
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        zipcode_field="zip_code",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@ParseAddress(raw_address_field="location_1")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def hhc_hospitals(df: pd.DataFrame = None):
     df = prepare("hhc_hospitals")
     df["spatial"] = df.location_1.apply(lambda x: x.split("(")[-1].replace(")", ""))
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
     df.location_1 = df.location_1.apply(lambda x: x.replace("\n", " "))
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="location_1")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@ParseAddress(raw_address_field="street_address")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def hra_snapcenters(df: pd.DataFrame = None):
     df = prepare("hra_snapcenters")
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="street_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@ParseAddress(raw_address_field="street_address")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def hra_jobcenters(df: pd.DataFrame = None):
     df = prepare("hra_jobcenters")
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="street_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@ParseAddress(raw_address_field="office_address")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def hra_medicaid(df: pd.DataFrame = None):
     df = prepare("hra_medicaid")
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="office_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@ParseAddress(raw_address_field="address_1")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def moeo_socialservicesitelocations(df: pd.DataFrame = None):
     df = prepare("moeo_socialservicesitelocations")
     df["borough"] = df.borough.str.upper()
@@ -522,53 +513,62 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
     df["bin"] = df.bin.fillna(0).astype(float).astype(int)
     df["postcode"] = df.bbl.fillna(0).astype(float).astype(int)
     df["postcode"] = df.postcode.astype(str).apply(lambda x: x[:5])
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="address_1")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="street_name",
-    house_number_field="house_number",
-    zipcode_field="zipcode",
-)
 def nycdoc_corrections(df: pd.DataFrame = None):
     df = prepare("nycdoc_corrections")
+    df = Function1B(
+        street_name_field="street_name",
+        house_number_field="house_number",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-)
-@ParseAddress(raw_address_field="address")
-@FunctionBL(bbl_field="bbl")
-@FunctionBN(bin_field="bin")
 def nycha_communitycenters(df: pd.DataFrame = None):
     df = prepare("nycha_communitycenters")
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
 def nycha_policeservice(df: pd.DataFrame = None):
     df = prepare("nycha_policeservice")
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="address")
 def nycourts_courts(df: pd.DataFrame = None):
     df = prepare("nycourts_courts")
+    df = parse_address(df, raw_address_field="address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
@@ -578,58 +578,58 @@ def nysdec_lands(df: pd.DataFrame = None):
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="county",
-    zipcode_field="zip_code",
-)
-@ParseAddress(raw_address_field="location_address")
 def nysdec_solidwaste(df: pd.DataFrame = None):
     df = prepare("nysdec_solidwaste")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
+    df = parse_address(df, raw_address_field="location_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="county",
+        zipcode_field="zip_code",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="street_name",
-    house_number_field="house_number",
-    borough_field="county",
-    zipcode_field="zipcode",
-)
 def nysdoccs_corrections(df: pd.DataFrame = None):
     df = prepare("nysdoccs_corrections")
     df["zipcode"] = df.zipcode.apply(lambda x: x[:5])
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
+    df = Function1B(
+        street_name_field="street_name",
+        house_number_field="house_number",
+        borough_field="county",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="facility_county",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="facility_address_1")
 def nysdoh_healthfacilities(df: pd.DataFrame = None):
     df = prepare("nysdoh_healthfacilities")
     df = df.loc[
         df.facility_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"]), :
     ].copy()
     df["zipcode"] = df.facility_zip_code.apply(lambda x: x[:5])
+    df = parse_address(df, raw_address_field="facility_address_1")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="facility_county",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="county",
-    zipcode_field="zip",
-)
-@ParseAddress(raw_address_field="street_address")
 def nysdoh_nursinghomes(df: pd.DataFrame = None):
     df = prepare("nysdoh_nursinghomes")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
+    df = parse_address(df, raw_address_field="street_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="county",
+        zipcode_field="zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
@@ -643,61 +643,61 @@ def sca_enrollment_capacity(df: pd.DataFrame = None):
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="county_description",
-    zipcode_field="physical_zipcd5",
-)
-@ParseAddress(raw_address_field="physical_address_line1")
 def nysed_activeinstitutions(df: pd.DataFrame = None):
     df = prepare("nysed_activeinstitutions")
     df = df[
         df.county_description.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])
     ]
+    df = parse_address(df, raw_address_field="physical_address_line1")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="county_description",
+        zipcode_field="physical_zipcd5",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="provider_county",
-    zipcode_field="provider_zip_code",
-)
-@ParseAddress(raw_address_field="provider_street")
 def nysoasas_programs(df: pd.DataFrame = None):
     df = prepare("nysoasas_programs")
     df = df[
         df.provider_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
+    df = parse_address(df, raw_address_field="provider_street")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="provider_county",
+        zipcode_field="provider_zip_code",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="program_county",
-    zipcode_field="program_zip",
-)
-@ParseAddress(raw_address_field="program_address_1")
 def nysomh_mentalhealth(df: pd.DataFrame = None):
     df = prepare("nysomh_mentalhealth")
     df = df[
         df.program_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
+    df = parse_address(df, raw_address_field="program_address_1")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="program_county",
+        zipcode_field="program_zip",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="county",
-    zipcode_field="zip_code",
-)
-@ParseAddress(raw_address_field="street_address")
 def nysopwdd_providers(df: pd.DataFrame = None):
     df = prepare("nysopwdd_providers")
     df = df[df.county.isin(["BRONX", "NEW YORK", "KINGS", "QUEENS", "RICHMOND"])]
+    df = parse_address(df, raw_address_field="street_address")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="county",
+        zipcode_field="zip_code",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
@@ -713,53 +713,45 @@ def nysparks_parks(df: pd.DataFrame = None):
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@FunctionBN(bin_field="bin")
-@FunctionBL(bbl_field="bbl")
-@ParseAddress(raw_address_field="address")
 def qpl_libraries(df: pd.DataFrame = None):
     df = prepare("qpl_libraries")
+    df = parse_address(df, raw_address_field="address")
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="street",
-    house_number_field="number",
-    borough_field="borough",
-    zipcode_field="postcode",
-)
-@FunctionBN(bin_field="bin")
-@FunctionBL(bbl_field="bbl")
 def sbs_workforce1(df: pd.DataFrame = None):
     df = prepare("sbs_workforce1")
+    df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
+    df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
+    df = Function1B(
+        street_name_field="street",
+        house_number_field="number",
+        borough_field="borough",
+        zipcode_field="postcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    zipcode_field="zipcode",
-)
-@ParseAddress(raw_address_field="buildingaddress")
 def uscourts_courts(df: pd.DataFrame = None):
     df = prepare("uscourts_courts")
     df["zipcode"] = df.buildingzip.apply(lambda x: x[:5])
+    df = parse_address(df, raw_address_field="buildingaddress")
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 
-@Function1B(
-    street_name_field="parsed_sname",
-    house_number_field="parsed_hnum",
-    borough_field="county",
-    zipcode_field="zipcode",
-)
-@UseAirportName
-@ParseAddress(raw_address_field="manager_address")
 def usdot_airports(df: pd.DataFrame = None):
     df = prepare("usdot_airports")
     df = df.loc[
@@ -774,6 +766,14 @@ def usdot_airports(df: pd.DataFrame = None):
         df.name == "JOHN F KENNEDY INTL", "airport_name"
     ] = "JOHN F KENNEDY INTL AIRPORT"
     df.loc[df.name == "LAGUARDIA", "airport_name"] = "LAGUARDIA AIRPORT"
+    df = parse_address(df, raw_address_field="manager_address")
+    df = use_airport_name(df)
+    df = Function1B(
+        street_name_field="parsed_sname",
+        house_number_field="parsed_hnum",
+        borough_field="county",
+        zipcode_field="zipcode",
+    ).geocode_a_dataframe(df)
     export(df)
 
 

--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -9,7 +9,7 @@ from .geocode.functionBL import FunctionBL
 from .geocode.functionBN import FunctionBN
 from .geocode.parseAddress import ParseAddress, UseAirportName
 from .utility.export import Export
-from .utility.prepare import Prepare
+from .utility.prepare import prepare
 
 
 @Export
@@ -20,8 +20,8 @@ from .utility.prepare import Prepare
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def bpl_libraries(df: pd.DataFrame = None):
+    df = prepare("bpl_libraries")
     df["longitude"] = df.position.apply(lambda x: x.split(",")[1].strip())
     df["latitude"] = df.position.apply(lambda x: x.split(",")[0].strip())
     df["zipcode"] = df.address.apply(lambda x: x[-6:])
@@ -37,8 +37,8 @@ def bpl_libraries(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def nypl_libraries(df: pd.DataFrame = None):
+    df = prepare("nypl_libraries")
     df["latitude"] = df.lat
     df["longitude"] = df.lon
     return df
@@ -53,8 +53,8 @@ def nypl_libraries(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def dca_operatingbusinesses(df: pd.DataFrame = None):
+    df = prepare("dca_operatingbusinesses")
     industry = [
         "Scrap Metal Processor",
         "Parking Lot",
@@ -84,8 +84,8 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def dcla_culturalinstitutions(df: pd.DataFrame = None):
+    df = prepare("dcla_culturalinstitutions")
     df["zipcode"] = df.postcode.apply(lambda x: x[:5])
     return df
 
@@ -95,8 +95,8 @@ def dcla_culturalinstitutions(df: pd.DataFrame = None):
 @Function1B(
     street_name_field="sname", house_number_field="hnum", borough_field="borough"
 )
-@Prepare
 def dcp_colp(df: pd.DataFrame = None):
+    df = prepare("dcp_colp")
     df["bbl"] = df.bbl.str.split(pat=".").str[0]
     return df
 
@@ -110,14 +110,14 @@ def dcp_colp(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def dcp_pops(df: pd.DataFrame = None):
+    df = prepare("dcp_pops")
     return df
 
 
 @Export
-@Prepare
 def dcp_sfpsd(df: pd.DataFrame = None):
+    df = prepare("dcp_sfpsd")
     return df
 
 
@@ -127,8 +127,8 @@ def dcp_sfpsd(df: pd.DataFrame = None):
     house_number_field="house_number",
     zipcode_field="zipcode",
 )
-@Prepare
 def dep_wwtc(df: pd.DataFrame = None):
+    df = prepare("dep_wwtc")
     return df
 
 
@@ -139,8 +139,8 @@ def dep_wwtc(df: pd.DataFrame = None):
     zipcode_field="program_zipcode",
 )
 @ParseAddress(raw_address_field="program_address")
-@Prepare
 def dfta_contracts(df: pd.DataFrame = None):
+    df = prepare("dfta_contracts")
     return df
 
 
@@ -152,8 +152,8 @@ def dfta_contracts(df: pd.DataFrame = None):
     zipcode_field="garage_zip",
 )
 @ParseAddress(raw_address_field="garage__street_address")
-@Prepare
 def doe_busroutesgarages(df: pd.DataFrame = None):
+    df = prepare("doe_busroutesgarages")
     # SCHOOL_YEAR = f"{datetime.date.today().year-1}-{datetime.date.today().year}"
     SCHOOL_YEAR = "2019-2020"  # No records from 2020-2021 school year
     df = df.loc[df.school_year == SCHOOL_YEAR, :]
@@ -169,8 +169,8 @@ def doe_busroutesgarages(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="borough_block_lot")
 @ParseAddress(raw_address_field="primary_address")
-@Prepare
 def doe_lcgms(df: pd.DataFrame = None):
+    df = prepare("doe_lcgms")
     return df
 
 
@@ -182,8 +182,8 @@ def doe_lcgms(df: pd.DataFrame = None):
     zipcode_field="zip",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def doe_universalprek(df: pd.DataFrame = None):
+    df = prepare("doe_universalprek")
     df["boro"] = df.borough.map(
         {
             "M": "Manhattan",
@@ -204,8 +204,8 @@ def doe_universalprek(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @FunctionBN(bin_field="building_identification_number")
-@Prepare
 def dohmh_daycare(df: pd.DataFrame = None):
+    df = prepare("dohmh_daycare")
     return df
 
 
@@ -216,8 +216,8 @@ def dohmh_daycare(df: pd.DataFrame = None):
     borough_field="boroname",
 )
 @ParseAddress(raw_address_field="site")
-@Prepare
 def dot_bridgehouses(df: pd.DataFrame = None):
+    df = prepare("dot_bridgehouses")
     df["address"] = df.address.astype(str).replace("n/a", None)
     return df
 
@@ -230,8 +230,8 @@ def dot_bridgehouses(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="bbl")
 @ParseAddress(raw_address_field="address")
-@Prepare
 def dot_ferryterminals(df: pd.DataFrame = None):
+    df = prepare("dot_ferryterminals")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     return df
 
@@ -244,16 +244,16 @@ def dot_ferryterminals(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="bbl")
 @ParseAddress(raw_address_field="address")
-@Prepare
 def dot_mannedfacilities(df: pd.DataFrame = None):
+    df = prepare("dot_mannedfacilities")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     return df
 
 
 @Export
-@Prepare
 def dot_pedplazas(df: pd.DataFrame = None):
+    df = prepare("dot_pedplazas")
     return df
 
 
@@ -265,8 +265,8 @@ def dot_pedplazas(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="bbl")
 @ParseAddress(raw_address_field="address")
-@Prepare
 def dot_publicparking(df: pd.DataFrame = None):
+    df = prepare("dot_publicparking")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     return df
@@ -280,8 +280,8 @@ def dot_publicparking(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def dpr_parksproperties(df: pd.DataFrame = None):
+    df = prepare("dpr_parksproperties")
     df["zipcode"] = df.zipcode.astype(str).apply(lambda x: x[:5])
     df["boro"] = df.borough.map(
         {
@@ -305,8 +305,8 @@ def dpr_parksproperties(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def dsny_garages(df: pd.DataFrame = None):
+    df = prepare("dsny_garages")
     df["address"] = df.address.astype(str)
     return df
 
@@ -319,8 +319,8 @@ def dsny_garages(df: pd.DataFrame = None):
     zipcode_field="zip",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def dsny_specialwastedrop(df: pd.DataFrame = None):
+    df = prepare("dsny_specialwastedrop")
     return df
 
 
@@ -330,8 +330,8 @@ def dsny_specialwastedrop(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def dsny_donatenycdirectory(df: pd.DataFrame = None):
+    df = prepare("dsny_donatenycdirectory")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = df[
         df["categoriesaccepted"].notna()
@@ -350,8 +350,8 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def dsny_leafdrop(df: pd.DataFrame = None):
+    df = prepare("dsny_leafdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     return df
 
@@ -364,8 +364,9 @@ def dsny_leafdrop(df: pd.DataFrame = None):
     zipcode_field="zip_code",
 )
 @ParseAddress(raw_address_field="location")
-@Prepare
 def dsny_fooddrop(df: pd.DataFrame = None):
+    df = prepare("dsny_fooddrop")
+
     def _loc_to_zipcode(location):
         location_str = str(location)
         return location_str[:-5] if location_str[:-5].isnumeric() else None
@@ -383,8 +384,8 @@ def dsny_fooddrop(df: pd.DataFrame = None):
 )
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def dsny_electronicsdrop(df: pd.DataFrame = None):
+    df = prepare("dsny_electronicsdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     return df
 
@@ -399,8 +400,8 @@ def dsny_electronicsdrop(df: pd.DataFrame = None):
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
 @ParseAddress(raw_address_field="address")
-@Prepare
 def dycd_afterschoolprograms(df: pd.DataFrame = None):
+    df = prepare("dycd_afterschoolprograms")
     df["address"] = df.location_1.apply(
         lambda x: str(x).replace("nan", "").split("\n")[0][:-5]
     )
@@ -424,8 +425,8 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def fbop_corrections(df: pd.DataFrame = None):
+    df = prepare("fbop_corrections")
     return df
 
 
@@ -439,8 +440,8 @@ def fbop_corrections(df: pd.DataFrame = None):
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
 @ParseAddress(raw_address_field="cleaned_address")
-@Prepare
 def fdny_firehouses(df: pd.DataFrame = None):
+    df = prepare("fdny_firehouses")
     df["cleaned_address"] = df["facilityaddress"].map(
         lambda x: re.sub("[^A-Za-z0-9- ]+", "", x)
     )
@@ -468,8 +469,8 @@ def fdny_firehouses(df: pd.DataFrame = None):
     zipcode_field="zip_code",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def foodbankny_foodbanks(df: pd.DataFrame = None):
+    df = prepare("foodbankny_foodbanks")
     return df
 
 
@@ -483,8 +484,8 @@ def foodbankny_foodbanks(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="location_1")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def hhc_hospitals(df: pd.DataFrame = None):
+    df = prepare("hhc_hospitals")
     df["spatial"] = df.location_1.apply(lambda x: x.split("(")[-1].replace(")", ""))
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
@@ -502,8 +503,8 @@ def hhc_hospitals(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="street_address")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def hra_snapcenters(df: pd.DataFrame = None):
+    df = prepare("hra_snapcenters")
     return df
 
 
@@ -517,8 +518,8 @@ def hra_snapcenters(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="street_address")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def hra_jobcenters(df: pd.DataFrame = None):
+    df = prepare("hra_jobcenters")
     return df
 
 
@@ -532,8 +533,8 @@ def hra_jobcenters(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="office_address")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def hra_medicaid(df: pd.DataFrame = None):
+    df = prepare("hra_medicaid")
     return df
 
 
@@ -547,8 +548,8 @@ def hra_medicaid(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address_1")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def moeo_socialservicesitelocations(df: pd.DataFrame = None):
+    df = prepare("moeo_socialservicesitelocations")
     df["borough"] = df.borough.str.upper()
     df["bbl"] = df.bbl.replace("undefinedundefinedundefined", None)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
@@ -564,8 +565,8 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
     house_number_field="house_number",
     zipcode_field="zipcode",
 )
-@Prepare
 def nycdoc_corrections(df: pd.DataFrame = None):
+    df = prepare("nycdoc_corrections")
     return df
 
 
@@ -578,8 +579,8 @@ def nycdoc_corrections(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="address")
 @FunctionBL(bbl_field="bbl")
 @FunctionBN(bin_field="bin")
-@Prepare
 def nycha_communitycenters(df: pd.DataFrame = None):
+    df = prepare("nycha_communitycenters")
     return df
 
 
@@ -591,8 +592,8 @@ def nycha_communitycenters(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def nycha_policeservice(df: pd.DataFrame = None):
+    df = prepare("nycha_policeservice")
     return df
 
 
@@ -604,14 +605,14 @@ def nycha_policeservice(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="address")
-@Prepare
 def nycourts_courts(df: pd.DataFrame = None):
+    df = prepare("nycourts_courts")
     return df
 
 
 @Export
-@Prepare
 def nysdec_lands(df: pd.DataFrame = None):
+    df = prepare("nysdec_lands")
     df = df[df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])]
     return df
 
@@ -624,8 +625,8 @@ def nysdec_lands(df: pd.DataFrame = None):
     zipcode_field="zip_code",
 )
 @ParseAddress(raw_address_field="location_address")
-@Prepare
 def nysdec_solidwaste(df: pd.DataFrame = None):
+    df = prepare("nysdec_solidwaste")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     return df
 
@@ -637,8 +638,8 @@ def nysdec_solidwaste(df: pd.DataFrame = None):
     borough_field="county",
     zipcode_field="zipcode",
 )
-@Prepare
 def nysdoccs_corrections(df: pd.DataFrame = None):
+    df = prepare("nysdoccs_corrections")
     df["zipcode"] = df.zipcode.apply(lambda x: x[:5])
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     return df
@@ -652,8 +653,8 @@ def nysdoccs_corrections(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="facility_address_1")
-@Prepare
 def nysdoh_healthfacilities(df: pd.DataFrame = None):
+    df = prepare("nysdoh_healthfacilities")
     df = df.loc[
         df.facility_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"]), :
     ].copy()
@@ -669,21 +670,21 @@ def nysdoh_healthfacilities(df: pd.DataFrame = None):
     zipcode_field="zip",
 )
 @ParseAddress(raw_address_field="street_address")
-@Prepare
 def nysdoh_nursinghomes(df: pd.DataFrame = None):
+    df = prepare("nysdoh_nursinghomes")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     return df
 
 
 @Export
-@Prepare
 def nysed_nonpublicenrollment(df: pd.DataFrame = None):
+    df = prepare("nysed_nonpublicenrollment")
     return df
 
 
 @Export
-@Prepare
 def sca_enrollment_capacity(df: pd.DataFrame = None):
+    df = prepare("sca_enrollment_capacity")
     return df
 
 
@@ -695,8 +696,8 @@ def sca_enrollment_capacity(df: pd.DataFrame = None):
     zipcode_field="physical_zipcd5",
 )
 @ParseAddress(raw_address_field="physical_address_line1")
-@Prepare
 def nysed_activeinstitutions(df: pd.DataFrame = None):
+    df = prepare("nysed_activeinstitutions")
     df = df[
         df.county_description.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])
     ]
@@ -711,8 +712,8 @@ def nysed_activeinstitutions(df: pd.DataFrame = None):
     zipcode_field="provider_zip_code",
 )
 @ParseAddress(raw_address_field="provider_street")
-@Prepare
 def nysoasas_programs(df: pd.DataFrame = None):
+    df = prepare("nysoasas_programs")
     df = df[
         df.provider_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
@@ -727,8 +728,8 @@ def nysoasas_programs(df: pd.DataFrame = None):
     zipcode_field="program_zip",
 )
 @ParseAddress(raw_address_field="program_address_1")
-@Prepare
 def nysomh_mentalhealth(df: pd.DataFrame = None):
+    df = prepare("nysomh_mentalhealth")
     df = df[
         df.program_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
@@ -743,22 +744,22 @@ def nysomh_mentalhealth(df: pd.DataFrame = None):
     zipcode_field="zip_code",
 )
 @ParseAddress(raw_address_field="street_address")
-@Prepare
 def nysopwdd_providers(df: pd.DataFrame = None):
+    df = prepare("nysopwdd_providers")
     df = df[df.county.isin(["BRONX", "NEW YORK", "KINGS", "QUEENS", "RICHMOND"])]
     return df
 
 
 @Export
-@Prepare
 def nysparks_historicplaces(df: pd.DataFrame = None):
+    df = prepare("nysparks_historicplaces")
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
     return df
 
 
 @Export
-@Prepare
 def nysparks_parks(df: pd.DataFrame = None):
+    df = prepare("nysparks_parks")
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
     return df
 
@@ -773,8 +774,8 @@ def nysparks_parks(df: pd.DataFrame = None):
 @FunctionBN(bin_field="bin")
 @FunctionBL(bbl_field="bbl")
 @ParseAddress(raw_address_field="address")
-@Prepare
 def qpl_libraries(df: pd.DataFrame = None):
+    df = prepare("qpl_libraries")
     return df
 
 
@@ -787,8 +788,8 @@ def qpl_libraries(df: pd.DataFrame = None):
 )
 @FunctionBN(bin_field="bin")
 @FunctionBL(bbl_field="bbl")
-@Prepare
 def sbs_workforce1(df: pd.DataFrame = None):
+    df = prepare("sbs_workforce1")
     return df
 
 
@@ -799,8 +800,8 @@ def sbs_workforce1(df: pd.DataFrame = None):
     zipcode_field="zipcode",
 )
 @ParseAddress(raw_address_field="buildingaddress")
-@Prepare
 def uscourts_courts(df: pd.DataFrame = None):
+    df = prepare("uscourts_courts")
     df["zipcode"] = df.buildingzip.apply(lambda x: x[:5])
     return df
 
@@ -814,8 +815,8 @@ def uscourts_courts(df: pd.DataFrame = None):
 )
 @UseAirportName
 @ParseAddress(raw_address_field="manager_address")
-@Prepare
 def usdot_airports(df: pd.DataFrame = None):
+    df = prepare("usdot_airports")
     df = df.loc[
         (df["state_name"] == "NEW YORK")
         & (df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])),
@@ -832,8 +833,8 @@ def usdot_airports(df: pd.DataFrame = None):
 
 
 @Export
-@Prepare
 def usdot_ports(df: pd.DataFrame = None):
+    df = prepare("usdot_ports")
     df = df.loc[
         (df.state_post == "NY")
         & (df.county_nam.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])),
@@ -843,7 +844,7 @@ def usdot_ports(df: pd.DataFrame = None):
 
 
 @Export
-@Prepare
 def usnps_parks(df: pd.DataFrame = None):
+    df = prepare("usnps_parks")
     df = df[df.state == "NY"]
     return df

--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -8,12 +8,9 @@ from .geocode.function1B import Function1B
 from .geocode.functionBL import FunctionBL
 from .geocode.functionBN import FunctionBN
 from .geocode.parseAddress import parse_address, use_airport_name
-from .utility.export import export
-from .utility.prepare import prepare
 
 
 def bpl_libraries(df: pd.DataFrame = None):
-    df = prepare("bpl_libraries")
     df["longitude"] = df.position.apply(lambda x: x.split(",")[1].strip())
     df["latitude"] = df.position.apply(lambda x: x.split(",")[0].strip())
     df["zipcode"] = df.address.apply(lambda x: x[-6:])
@@ -25,11 +22,10 @@ def bpl_libraries(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nypl_libraries(df: pd.DataFrame = None):
-    df = prepare("nypl_libraries")
     df["latitude"] = df.lat
     df["longitude"] = df.lon
     df = parse_address(df, raw_address_field="address")
@@ -39,11 +35,10 @@ def nypl_libraries(df: pd.DataFrame = None):
         borough_field="locality",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dca_operatingbusinesses(df: pd.DataFrame = None):
-    df = prepare("dca_operatingbusinesses")
     industry = [
         "Scrap Metal Processor",
         "Parking Lot",
@@ -68,11 +63,10 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
         borough_field="address_borough",
         zipcode_field="address_zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dcla_culturalinstitutions(df: pd.DataFrame = None):
-    df = prepare("dcla_culturalinstitutions")
     df["zipcode"] = df.postcode.apply(lambda x: x[:5])
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
@@ -83,21 +77,19 @@ def dcla_culturalinstitutions(df: pd.DataFrame = None):
     ).geocode_a_dataframe(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dcp_colp(df: pd.DataFrame = None):
-    df = prepare("dcp_colp")
     df["bbl"] = df.bbl.str.split(pat=".").str[0]
     df = Function1B(
         street_name_field="sname", house_number_field="hnum", borough_field="borough"
     ).geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dcp_pops(df: pd.DataFrame = None):
-    df = prepare("dcp_pops")
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -106,37 +98,33 @@ def dcp_pops(df: pd.DataFrame = None):
         borough_field="borough_name",
         zipcode_field="zip_code",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dcp_sfpsd(df: pd.DataFrame = None):
-    df = prepare("dcp_sfpsd")
-    export(df)
+    return df
 
 
 def dep_wwtc(df: pd.DataFrame = None):
-    df = prepare("dep_wwtc")
     df = Function1B(
         street_name_field="street_name",
         house_number_field="house_number",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dfta_contracts(df: pd.DataFrame = None):
-    df = prepare("dfta_contracts")
     df = parse_address(df, raw_address_field="program_address")
     df = Function1B(
         street_name_field="parsed_sname",
         house_number_field="parsed_hnum",
         zipcode_field="program_zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def doe_busroutesgarages(df: pd.DataFrame = None):
-    df = prepare("doe_busroutesgarages")
     # SCHOOL_YEAR = f"{datetime.date.today().year-1}-{datetime.date.today().year}"
     SCHOOL_YEAR = "2019-2020"  # No records from 2020-2021 school year
     df = df.loc[df.school_year == SCHOOL_YEAR, :]
@@ -147,11 +135,10 @@ def doe_busroutesgarages(df: pd.DataFrame = None):
         borough_field="garage_city",
         zipcode_field="garage_zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def doe_lcgms(df: pd.DataFrame = None):
-    df = prepare("doe_lcgms")
     df = parse_address(df, raw_address_field="primary_address")
     df = FunctionBL(bbl_field="borough_block_lot").geocode_a_dataframe(df)
     df = Function1B(
@@ -160,11 +147,10 @@ def doe_lcgms(df: pd.DataFrame = None):
         borough_field="city",
         zipcode_field="zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def doe_universalprek(df: pd.DataFrame = None):
-    df = prepare("doe_universalprek")
     df["boro"] = df.borough.map(
         {
             "M": "Manhattan",
@@ -181,11 +167,10 @@ def doe_universalprek(df: pd.DataFrame = None):
         borough_field="boro",
         zipcode_field="zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dohmh_daycare(df: pd.DataFrame = None):
-    df = prepare("dohmh_daycare")
     df = FunctionBN(bin_field="building_identification_number").geocode_a_dataframe(df)
     df = Function1B(
         street_name_field="street",
@@ -193,11 +178,10 @@ def dohmh_daycare(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dot_bridgehouses(df: pd.DataFrame = None):
-    df = prepare("dot_bridgehouses")
     df["address"] = df.address.astype(str).replace("n/a", None)
     df = parse_address(df, raw_address_field="site")
     df = Function1B(
@@ -205,11 +189,10 @@ def dot_bridgehouses(df: pd.DataFrame = None):
         house_number_field="parsed_hnum",
         borough_field="boroname",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dot_ferryterminals(df: pd.DataFrame = None):
-    df = prepare("dot_ferryterminals")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = parse_address(df, raw_address_field="address")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -218,11 +201,10 @@ def dot_ferryterminals(df: pd.DataFrame = None):
         house_number_field="parsed_hnum",
         borough_field="boroname",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dot_mannedfacilities(df: pd.DataFrame = None):
-    df = prepare("dot_mannedfacilities")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = parse_address(df, raw_address_field="address")
@@ -232,16 +214,14 @@ def dot_mannedfacilities(df: pd.DataFrame = None):
         house_number_field="parsed_hnum",
         borough_field="boroname",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dot_pedplazas(df: pd.DataFrame = None):
-    df = prepare("dot_pedplazas")
-    export(df)
+    return df
 
 
 def dot_publicparking(df: pd.DataFrame = None):
-    df = prepare("dot_publicparking")
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = parse_address(df, raw_address_field="address")
@@ -251,11 +231,10 @@ def dot_publicparking(df: pd.DataFrame = None):
         house_number_field="parsed_hnum",
         borough_field="boroname",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dpr_parksproperties(df: pd.DataFrame = None):
-    df = prepare("dpr_parksproperties")
     df["zipcode"] = df.zipcode.astype(str).apply(lambda x: x[:5])
     df["boro"] = df.borough.map(
         {
@@ -273,11 +252,10 @@ def dpr_parksproperties(df: pd.DataFrame = None):
         borough_field="boro",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dsny_garages(df: pd.DataFrame = None):
-    df = prepare("dsny_garages")
     df["address"] = df.address.astype(str)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -288,11 +266,10 @@ def dsny_garages(df: pd.DataFrame = None):
         borough_field="boro",
         zipcode_field="zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dsny_specialwastedrop(df: pd.DataFrame = None):
-    df = prepare("dsny_specialwastedrop")
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -300,11 +277,10 @@ def dsny_specialwastedrop(df: pd.DataFrame = None):
         borough_field="boro",
         zipcode_field="zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dsny_donatenycdirectory(df: pd.DataFrame = None):
-    df = prepare("dsny_donatenycdirectory")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = df[
         df["categoriesaccepted"].notna()
@@ -315,11 +291,10 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
     df = Function1B(
         street_name_field="street", house_number_field="number", borough_field="borough"
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dsny_leafdrop(df: pd.DataFrame = None):
-    df = prepare("dsny_leafdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -330,12 +305,10 @@ def dsny_leafdrop(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dsny_fooddrop(df: pd.DataFrame = None):
-    df = prepare("dsny_fooddrop")
-
     def _loc_to_zipcode(location):
         location_str = str(location)
         return location_str[:-5] if location_str[:-5].isnumeric() else None
@@ -348,11 +321,10 @@ def dsny_fooddrop(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="zip_code",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dsny_electronicsdrop(df: pd.DataFrame = None):
-    df = prepare("dsny_electronicsdrop")
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -362,11 +334,10 @@ def dsny_electronicsdrop(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def dycd_afterschoolprograms(df: pd.DataFrame = None):
-    df = prepare("dycd_afterschoolprograms")
     df["address"] = df.location_1.apply(
         lambda x: str(x).replace("nan", "").split("\n")[0][:-5]
     )
@@ -388,11 +359,10 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
         borough_field="borough__community",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def fbop_corrections(df: pd.DataFrame = None):
-    df = prepare("fbop_corrections")
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -400,11 +370,10 @@ def fbop_corrections(df: pd.DataFrame = None):
         borough_field="city",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def fdny_firehouses(df: pd.DataFrame = None):
-    df = prepare("fdny_firehouses")
     df["cleaned_address"] = df["facilityaddress"].map(
         lambda x: re.sub("[^A-Za-z0-9- ]+", "", x)
     )
@@ -431,22 +400,20 @@ def fdny_firehouses(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def foodbankny_foodbanks(df: pd.DataFrame = None):
-    df = prepare("foodbankny_foodbanks")
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
         house_number_field="parsed_hnum",
         zipcode_field="zip_code",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def hhc_hospitals(df: pd.DataFrame = None):
-    df = prepare("hhc_hospitals")
     df["spatial"] = df.location_1.apply(lambda x: x.split("(")[-1].replace(")", ""))
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
@@ -460,11 +427,10 @@ def hhc_hospitals(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def hra_snapcenters(df: pd.DataFrame = None):
-    df = prepare("hra_snapcenters")
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="street_address")
@@ -474,11 +440,10 @@ def hra_snapcenters(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def hra_jobcenters(df: pd.DataFrame = None):
-    df = prepare("hra_jobcenters")
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="street_address")
@@ -488,11 +453,10 @@ def hra_jobcenters(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def hra_medicaid(df: pd.DataFrame = None):
-    df = prepare("hra_medicaid")
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="office_address")
@@ -502,11 +466,10 @@ def hra_medicaid(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def moeo_socialservicesitelocations(df: pd.DataFrame = None):
-    df = prepare("moeo_socialservicesitelocations")
     df["borough"] = df.borough.str.upper()
     df["bbl"] = df.bbl.replace("undefinedundefinedundefined", None)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
@@ -522,21 +485,19 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nycdoc_corrections(df: pd.DataFrame = None):
-    df = prepare("nycdoc_corrections")
     df = Function1B(
         street_name_field="street_name",
         house_number_field="house_number",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nycha_communitycenters(df: pd.DataFrame = None):
-    df = prepare("nycha_communitycenters")
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="address")
@@ -545,11 +506,10 @@ def nycha_communitycenters(df: pd.DataFrame = None):
         house_number_field="parsed_hnum",
         borough_field="borough",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nycha_policeservice(df: pd.DataFrame = None):
-    df = prepare("nycha_policeservice")
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -557,11 +517,10 @@ def nycha_policeservice(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nycourts_courts(df: pd.DataFrame = None):
-    df = prepare("nycourts_courts")
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -569,17 +528,15 @@ def nycourts_courts(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysdec_lands(df: pd.DataFrame = None):
-    df = prepare("nysdec_lands")
     df = df[df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])]
-    export(df)
+    return df
 
 
 def nysdec_solidwaste(df: pd.DataFrame = None):
-    df = prepare("nysdec_solidwaste")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     df = parse_address(df, raw_address_field="location_address")
     df = Function1B(
@@ -588,11 +545,10 @@ def nysdec_solidwaste(df: pd.DataFrame = None):
         borough_field="county",
         zipcode_field="zip_code",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysdoccs_corrections(df: pd.DataFrame = None):
-    df = prepare("nysdoccs_corrections")
     df["zipcode"] = df.zipcode.apply(lambda x: x[:5])
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     df = Function1B(
@@ -601,11 +557,10 @@ def nysdoccs_corrections(df: pd.DataFrame = None):
         borough_field="county",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysdoh_healthfacilities(df: pd.DataFrame = None):
-    df = prepare("nysdoh_healthfacilities")
     df = df.loc[
         df.facility_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"]), :
     ].copy()
@@ -617,11 +572,10 @@ def nysdoh_healthfacilities(df: pd.DataFrame = None):
         borough_field="facility_county",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysdoh_nursinghomes(df: pd.DataFrame = None):
-    df = prepare("nysdoh_nursinghomes")
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
     df = parse_address(df, raw_address_field="street_address")
     df = Function1B(
@@ -630,21 +584,18 @@ def nysdoh_nursinghomes(df: pd.DataFrame = None):
         borough_field="county",
         zipcode_field="zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysed_nonpublicenrollment(df: pd.DataFrame = None):
-    df = prepare("nysed_nonpublicenrollment")
-    export(df)
+    return df
 
 
 def sca_enrollment_capacity(df: pd.DataFrame = None):
-    df = prepare("sca_enrollment_capacity")
-    export(df)
+    return df
 
 
 def nysed_activeinstitutions(df: pd.DataFrame = None):
-    df = prepare("nysed_activeinstitutions")
     df = df[
         df.county_description.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])
     ]
@@ -655,11 +606,10 @@ def nysed_activeinstitutions(df: pd.DataFrame = None):
         borough_field="county_description",
         zipcode_field="physical_zipcd5",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysoasas_programs(df: pd.DataFrame = None):
-    df = prepare("nysoasas_programs")
     df = df[
         df.provider_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
@@ -670,11 +620,10 @@ def nysoasas_programs(df: pd.DataFrame = None):
         borough_field="provider_county",
         zipcode_field="provider_zip_code",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysomh_mentalhealth(df: pd.DataFrame = None):
-    df = prepare("nysomh_mentalhealth")
     df = df[
         df.program_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
@@ -685,11 +634,10 @@ def nysomh_mentalhealth(df: pd.DataFrame = None):
         borough_field="program_county",
         zipcode_field="program_zip",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysopwdd_providers(df: pd.DataFrame = None):
-    df = prepare("nysopwdd_providers")
     df = df[df.county.isin(["BRONX", "NEW YORK", "KINGS", "QUEENS", "RICHMOND"])]
     df = parse_address(df, raw_address_field="street_address")
     df = Function1B(
@@ -698,23 +646,20 @@ def nysopwdd_providers(df: pd.DataFrame = None):
         borough_field="county",
         zipcode_field="zip_code",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def nysparks_historicplaces(df: pd.DataFrame = None):
-    df = prepare("nysparks_historicplaces")
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
-    export(df)
+    return df
 
 
 def nysparks_parks(df: pd.DataFrame = None):
-    df = prepare("nysparks_parks")
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
-    export(df)
+    return df
 
 
 def qpl_libraries(df: pd.DataFrame = None):
-    df = prepare("qpl_libraries")
     df = parse_address(df, raw_address_field="address")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
@@ -724,11 +669,10 @@ def qpl_libraries(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def sbs_workforce1(df: pd.DataFrame = None):
-    df = prepare("sbs_workforce1")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = Function1B(
@@ -737,11 +681,10 @@ def sbs_workforce1(df: pd.DataFrame = None):
         borough_field="borough",
         zipcode_field="postcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def uscourts_courts(df: pd.DataFrame = None):
-    df = prepare("uscourts_courts")
     df["zipcode"] = df.buildingzip.apply(lambda x: x[:5])
     df = parse_address(df, raw_address_field="buildingaddress")
     df = Function1B(
@@ -749,11 +692,10 @@ def uscourts_courts(df: pd.DataFrame = None):
         house_number_field="parsed_hnum",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def usdot_airports(df: pd.DataFrame = None):
-    df = prepare("usdot_airports")
     df = df.loc[
         (df["state_name"] == "NEW YORK")
         & (df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])),
@@ -774,20 +716,18 @@ def usdot_airports(df: pd.DataFrame = None):
         borough_field="county",
         zipcode_field="zipcode",
     ).geocode_a_dataframe(df)
-    export(df)
+    return df
 
 
 def usdot_ports(df: pd.DataFrame = None):
-    df = prepare("usdot_ports")
     df = df.loc[
         (df.state_post == "NY")
         & (df.county_nam.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])),
         :,
     ]
-    export(df)
+    return df
 
 
 def usnps_parks(df: pd.DataFrame = None):
-    df = prepare("usnps_parks")
     df = df[df.state == "NY"]
-    export(df)
+    return df

--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -8,6 +8,7 @@ from .geocode.function1B import Function1B
 from .geocode.functionBL import FunctionBL
 from .geocode.functionBN import FunctionBN
 from .geocode.parseAddress import parse_address, use_airport_name
+from facdb.utility.utils import sanitize_df
 
 
 def bpl_libraries(df: pd.DataFrame = None):
@@ -15,6 +16,7 @@ def bpl_libraries(df: pd.DataFrame = None):
     df["latitude"] = df.position.apply(lambda x: x.split(",")[0].strip())
     df["zipcode"] = df.address.apply(lambda x: x[-6:])
     df["borough"] = "Brooklyn"
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -28,6 +30,7 @@ def bpl_libraries(df: pd.DataFrame = None):
 def nypl_libraries(df: pd.DataFrame = None):
     df["latitude"] = df.lat
     df["longitude"] = df.lon
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -55,6 +58,7 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
     df = df.loc[((df.license_expiration_date >= today) & (df.industry == "Scrap Metal Processor"))|((df.license_expiration_date >= covid_freeze) & (df.industry != "Scrap Metal Processor")), :]\
         .loc[df.industry.isin(industry), :]
     # fmt:on
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -68,6 +72,7 @@ def dca_operatingbusinesses(df: pd.DataFrame = None):
 
 def dcla_culturalinstitutions(df: pd.DataFrame = None):
     df["zipcode"] = df.postcode.apply(lambda x: x[:5])
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -82,6 +87,7 @@ def dcla_culturalinstitutions(df: pd.DataFrame = None):
 
 def dcp_colp(df: pd.DataFrame = None):
     df["bbl"] = df.bbl.str.split(pat=".").str[0]
+    df = sanitize_df(df)
     df = Function1B(
         street_name_field="sname", house_number_field="hnum", borough_field="borough"
     ).geocode_a_dataframe(df)
@@ -90,6 +96,7 @@ def dcp_colp(df: pd.DataFrame = None):
 
 
 def dcp_pops(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -102,10 +109,12 @@ def dcp_pops(df: pd.DataFrame = None):
 
 
 def dcp_sfpsd(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     return df
 
 
 def dep_wwtc(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = Function1B(
         street_name_field="street_name",
         house_number_field="house_number",
@@ -115,6 +124,7 @@ def dep_wwtc(df: pd.DataFrame = None):
 
 
 def dfta_contracts(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="program_address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -128,6 +138,7 @@ def doe_busroutesgarages(df: pd.DataFrame = None):
     # SCHOOL_YEAR = f"{datetime.date.today().year-1}-{datetime.date.today().year}"
     SCHOOL_YEAR = "2019-2020"  # No records from 2020-2021 school year
     df = df.loc[df.school_year == SCHOOL_YEAR, :]
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="garage__street_address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -139,6 +150,7 @@ def doe_busroutesgarages(df: pd.DataFrame = None):
 
 
 def doe_lcgms(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="primary_address")
     df = FunctionBL(bbl_field="borough_block_lot").geocode_a_dataframe(df)
     df = Function1B(
@@ -160,6 +172,7 @@ def doe_universalprek(df: pd.DataFrame = None):
             "R": "Staten Island",
         }
     )
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -171,6 +184,7 @@ def doe_universalprek(df: pd.DataFrame = None):
 
 
 def dohmh_daycare(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="building_identification_number").geocode_a_dataframe(df)
     df = Function1B(
         street_name_field="street",
@@ -183,6 +197,7 @@ def dohmh_daycare(df: pd.DataFrame = None):
 
 def dot_bridgehouses(df: pd.DataFrame = None):
     df["address"] = df.address.astype(str).replace("n/a", None)
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="site")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -194,6 +209,7 @@ def dot_bridgehouses(df: pd.DataFrame = None):
 
 def dot_ferryterminals(df: pd.DataFrame = None):
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -207,6 +223,7 @@ def dot_ferryterminals(df: pd.DataFrame = None):
 def dot_mannedfacilities(df: pd.DataFrame = None):
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -218,12 +235,14 @@ def dot_mannedfacilities(df: pd.DataFrame = None):
 
 
 def dot_pedplazas(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     return df
 
 
 def dot_publicparking(df: pd.DataFrame = None):
     df["address"] = df.address.astype(str)
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -245,6 +264,7 @@ def dpr_parksproperties(df: pd.DataFrame = None):
             "R": "Staten Island",
         }
     )
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -257,6 +277,7 @@ def dpr_parksproperties(df: pd.DataFrame = None):
 
 def dsny_garages(df: pd.DataFrame = None):
     df["address"] = df.address.astype(str)
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="address")
@@ -270,6 +291,7 @@ def dsny_garages(df: pd.DataFrame = None):
 
 
 def dsny_specialwastedrop(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -286,6 +308,7 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
         df["categoriesaccepted"].notna()
         & df["categoriesaccepted"].str.contains("Clothing")
     ]
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -296,6 +319,7 @@ def dsny_donatenycdirectory(df: pd.DataFrame = None):
 
 def dsny_leafdrop(df: pd.DataFrame = None):
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="address")
@@ -314,6 +338,7 @@ def dsny_fooddrop(df: pd.DataFrame = None):
         return location_str[:-5] if location_str[:-5].isnumeric() else None
 
     df["zip_code"] = df["location"].apply(_loc_to_zipcode)
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="location")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -326,6 +351,7 @@ def dsny_fooddrop(df: pd.DataFrame = None):
 
 def dsny_electronicsdrop(df: pd.DataFrame = None):
     df["bbl"] = df.bbl.fillna(0).astype(float).astype(int)
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = Function1B(
@@ -350,6 +376,7 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
     df["spatial"] = df.spatial.apply(lambda x: x.replace("(", "").replace(")", ""))
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -363,6 +390,7 @@ def dycd_afterschoolprograms(df: pd.DataFrame = None):
 
 
 def fbop_corrections(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -391,6 +419,7 @@ def fdny_firehouses(df: pd.DataFrame = None):
         df_research.facilityname.isin(df.facilityname),
         ["facilityaddress", "borough", "postcode", "wkt"],
     ].values
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="cleaned_address")
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
@@ -404,6 +433,7 @@ def fdny_firehouses(df: pd.DataFrame = None):
 
 
 def foodbankny_foodbanks(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -418,6 +448,7 @@ def hhc_hospitals(df: pd.DataFrame = None):
     df["longitude"] = df.spatial.apply(lambda x: x.split(",")[-1])
     df["latitude"] = df.spatial.apply(lambda x: x.split(",")[0])
     df.location_1 = df.location_1.apply(lambda x: x.replace("\n", " "))
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="location_1")
@@ -431,6 +462,7 @@ def hhc_hospitals(df: pd.DataFrame = None):
 
 
 def hra_snapcenters(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="street_address")
@@ -444,6 +476,7 @@ def hra_snapcenters(df: pd.DataFrame = None):
 
 
 def hra_jobcenters(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="street_address")
@@ -457,6 +490,7 @@ def hra_jobcenters(df: pd.DataFrame = None):
 
 
 def hra_medicaid(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="office_address")
@@ -476,6 +510,7 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
     df["bin"] = df.bin.fillna(0).astype(float).astype(int)
     df["postcode"] = df.bbl.fillna(0).astype(float).astype(int)
     df["postcode"] = df.postcode.astype(str).apply(lambda x: x[:5])
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="address_1")
@@ -489,6 +524,7 @@ def moeo_socialservicesitelocations(df: pd.DataFrame = None):
 
 
 def nycdoc_corrections(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = Function1B(
         street_name_field="street_name",
         house_number_field="house_number",
@@ -498,6 +534,7 @@ def nycdoc_corrections(df: pd.DataFrame = None):
 
 
 def nycha_communitycenters(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = parse_address(df, raw_address_field="address")
@@ -510,6 +547,7 @@ def nycha_communitycenters(df: pd.DataFrame = None):
 
 
 def nycha_policeservice(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -521,6 +559,7 @@ def nycha_policeservice(df: pd.DataFrame = None):
 
 
 def nycourts_courts(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -533,11 +572,13 @@ def nycourts_courts(df: pd.DataFrame = None):
 
 def nysdec_lands(df: pd.DataFrame = None):
     df = df[df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])]
+    df = sanitize_df(df)
     return df
 
 
 def nysdec_solidwaste(df: pd.DataFrame = None):
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="location_address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -551,6 +592,7 @@ def nysdec_solidwaste(df: pd.DataFrame = None):
 def nysdoccs_corrections(df: pd.DataFrame = None):
     df["zipcode"] = df.zipcode.apply(lambda x: x[:5])
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
+    df = sanitize_df(df)
     df = Function1B(
         street_name_field="street_name",
         house_number_field="house_number",
@@ -565,6 +607,7 @@ def nysdoh_healthfacilities(df: pd.DataFrame = None):
         df.facility_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"]), :
     ].copy()
     df["zipcode"] = df.facility_zip_code.apply(lambda x: x[:5])
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="facility_address_1")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -577,6 +620,7 @@ def nysdoh_healthfacilities(df: pd.DataFrame = None):
 
 def nysdoh_nursinghomes(df: pd.DataFrame = None):
     df = df[df.county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])]
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="street_address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -588,10 +632,12 @@ def nysdoh_nursinghomes(df: pd.DataFrame = None):
 
 
 def nysed_nonpublicenrollment(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     return df
 
 
 def sca_enrollment_capacity(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     return df
 
 
@@ -599,6 +645,7 @@ def nysed_activeinstitutions(df: pd.DataFrame = None):
     df = df[
         df.county_description.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])
     ]
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="physical_address_line1")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -613,6 +660,7 @@ def nysoasas_programs(df: pd.DataFrame = None):
     df = df[
         df.provider_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="provider_street")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -627,6 +675,7 @@ def nysomh_mentalhealth(df: pd.DataFrame = None):
     df = df[
         df.program_county.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])
     ]
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="program_address_1")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -639,6 +688,7 @@ def nysomh_mentalhealth(df: pd.DataFrame = None):
 
 def nysopwdd_providers(df: pd.DataFrame = None):
     df = df[df.county.isin(["BRONX", "NEW YORK", "KINGS", "QUEENS", "RICHMOND"])]
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="street_address")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -651,15 +701,18 @@ def nysopwdd_providers(df: pd.DataFrame = None):
 
 def nysparks_historicplaces(df: pd.DataFrame = None):
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
+    df = sanitize_df(df)
     return df
 
 
 def nysparks_parks(df: pd.DataFrame = None):
     df = df[df.county.isin(["Bronx", "New York", "Kings", "Queens", "Richmond"])]
+    df = sanitize_df(df)
     return df
 
 
 def qpl_libraries(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="address")
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
@@ -673,6 +726,7 @@ def qpl_libraries(df: pd.DataFrame = None):
 
 
 def sbs_workforce1(df: pd.DataFrame = None):
+    df = sanitize_df(df)
     df = FunctionBL(bbl_field="bbl").geocode_a_dataframe(df)
     df = FunctionBN(bin_field="bin").geocode_a_dataframe(df)
     df = Function1B(
@@ -686,6 +740,7 @@ def sbs_workforce1(df: pd.DataFrame = None):
 
 def uscourts_courts(df: pd.DataFrame = None):
     df["zipcode"] = df.buildingzip.apply(lambda x: x[:5])
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="buildingaddress")
     df = Function1B(
         street_name_field="parsed_sname",
@@ -708,6 +763,7 @@ def usdot_airports(df: pd.DataFrame = None):
         df.name == "JOHN F KENNEDY INTL", "airport_name"
     ] = "JOHN F KENNEDY INTL AIRPORT"
     df.loc[df.name == "LAGUARDIA", "airport_name"] = "LAGUARDIA AIRPORT"
+    df = sanitize_df(df)
     df = parse_address(df, raw_address_field="manager_address")
     df = use_airport_name(df)
     df = Function1B(
@@ -725,9 +781,11 @@ def usdot_ports(df: pd.DataFrame = None):
         & (df.county_nam.isin(["New York", "Kings", "Bronx", "Queens", "Richmond"])),
         :,
     ]
+    df = sanitize_df(df)
     return df
 
 
 def usnps_parks(df: pd.DataFrame = None):
     df = df[df.state == "NY"]
+    df = sanitize_df(df)
     return df

--- a/products/facilities/facdb/utility/export.py
+++ b/products/facilities/facdb/utility/export.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from sqlalchemy import dialects
 from dcpy.utils import postgres
 from facdb import BUILD_ENGINE
@@ -7,22 +6,17 @@ from sqlalchemy import create_engine
 ENGINE = create_engine(BUILD_ENGINE)
 
 
-def Export(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        df = func()
-        name = df.loc[df.index.min(), "source"]
-        df.to_sql(
-            name,
-            con=ENGINE,
-            if_exists="replace",
-            index=False,
-            dtype={
-                "geo_1b": dialects.postgresql.JSON,
-                "geo_bl": dialects.postgresql.JSON,
-                "geo_bn": dialects.postgresql.JSON,
-            },
-            method=postgres.insert_copy,
-        )
-
-    return wrapper
+def export(df):
+    name = df.loc[df.index.min(), "source"]
+    df.to_sql(
+        name,
+        con=ENGINE,
+        if_exists="replace",
+        index=False,
+        dtype={
+            "geo_1b": dialects.postgresql.JSON,
+            "geo_bl": dialects.postgresql.JSON,
+            "geo_bn": dialects.postgresql.JSON,
+        },
+        method=postgres.insert_copy,
+    )

--- a/products/facilities/facdb/utility/metadata.py
+++ b/products/facilities/facdb/utility/metadata.py
@@ -1,9 +1,8 @@
-import os
 from pathlib import Path
 
 import yaml
 
-metadata = {"datasets": []}
+metadata: dict = {"datasets": []}
 
 
 class MyDumper(yaml.Dumper):

--- a/products/facilities/facdb/utility/prepare.py
+++ b/products/facilities/facdb/utility/prepare.py
@@ -57,8 +57,5 @@ def prepare(name: str) -> pd.DataFrame:
         print("reading from cached data")
         df = pd.read_pickle(pkl_path)
 
-    # Apply custom wrangler
     df["source"] = name
-    df = df.replace({np.nan: None})
-    df = df.drop_duplicates()
     return df

--- a/products/facilities/facdb/utility/prepare.py
+++ b/products/facilities/facdb/utility/prepare.py
@@ -1,6 +1,4 @@
-import json
 import os
-from functools import wraps
 from pathlib import Path
 
 import numpy as np
@@ -43,30 +41,24 @@ def version_from_config(name, read_version):
     add_version(dataset=name, version=version)
 
 
-def Prepare(func) -> callable:
-    @wraps(func)
-    def wrapper(*args, **kwargs) -> pd.DataFrame:
-        name = func.__name__
-        pkl_path = CACHE_PATH / f"{name}.pkl"
-        if not os.path.isfile(pkl_path):
-            # pull from data library
-            print(f"pulling from {name} data library")
-            # fmt:off
-            df = read_from_S3(name)\
-                .pipe(hash_each_row)\
-                .pipe(format_field_names)
-            df.to_pickle(pkl_path)
-            # fmt:on
-        else:
-            # read from cache
-            print("reading from cached data")
-            df = pd.read_pickle(pkl_path)
+def prepare(name: str) -> pd.DataFrame:
+    pkl_path = CACHE_PATH / f"{name}.pkl"
+    if not os.path.isfile(pkl_path):
+        # pull from data library
+        print(f"pulling from {name} data library")
+        # fmt:off
+        df = read_from_S3(name)\
+            .pipe(hash_each_row)\
+            .pipe(format_field_names)
+        df.to_pickle(pkl_path)
+        # fmt:on
+    else:
+        # read from cache
+        print("reading from cached data")
+        df = pd.read_pickle(pkl_path)
 
-        # Apply custom wrangler
-        df = func(df)
-        df["source"] = name
-        df = df.replace({np.nan: None})
-        df = df.drop_duplicates()
-        return df
-
-    return wrapper
+    # Apply custom wrangler
+    df["source"] = name
+    df = df.replace({np.nan: None})
+    df = df.drop_duplicates()
+    return df

--- a/products/facilities/facdb/utility/utils.py
+++ b/products/facilities/facdb/utility/utils.py
@@ -1,9 +1,6 @@
-import csv
 import hashlib
-import os
+import numpy as np
 import re
-from functools import wraps
-from io import StringIO
 
 import pandas as pd
 
@@ -38,4 +35,10 @@ def format_field_names(df: pd.DataFrame) -> pd.DataFrame:
         return re.sub(r"\W+", "", x.lower().strip().replace("-", "_").replace(" ", "_"))
 
     df.columns = df.columns.map(format_func)
+    return df
+
+
+def sanitize_df(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.replace({np.nan: None})
+    df = df.drop_duplicates()
     return df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ ignore = ["D100", "D101", "D102", "D107", "D104", "D213", "D407", "D413"]
 [tool.black]
 
 [[tool.mypy.overrides]]
-module = "geopandas.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*" # no stubs available
+module = "geopandas.*,geosupport.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*" # no stubs available
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -30,13 +30,13 @@ blinker==1.6.2
     # via streamlit
 boto3==1.28.60
     # via -r ./python/requirements.in
-boto3-stubs==1.28.59
+boto3-stubs==1.28.60
     # via -r ./python/requirements.in
 botocore==1.31.60
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.31.59
+botocore-stubs==1.31.60
     # via
     #   -r ./python/requirements.in
     #   boto3-stubs
@@ -373,7 +373,7 @@ rich==13.6.0
     # via
     #   -r ./python/requirements.in
     #   streamlit
-rpds-py==0.10.3
+rpds-py==0.10.4
     # via
     #   jsonschema
     #   referencing
@@ -470,6 +470,8 @@ types-s3transfer==0.7.0
     # via boto3-stubs
 types-setuptools==68.2.0.0
     # via -r ./python/requirements.in
+types-tqdm==4.66.0.2
+    # via -r ./python/requirements.in
 types-urllib3==1.26.25.14
     # via types-requests
 typing-extensions==4.8.0
@@ -500,7 +502,7 @@ wcwidth==0.2.8
     # via prompt-toolkit
 xlrd==2.0.1
     # via -r ./python/requirements.in
-xyzservices==2023.7.0
+xyzservices==2023.10.0
     # via contextily
 zipp==3.17.0
     # via importlib-metadata

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -41,6 +41,7 @@ streamlit-aggrid==0.*
 streamlit-folium==0.*
 tabulate==0.9.0
 tqdm>=4.59.0
+types-tqdm==4.66.0.2
 typer==0.8.0
 types-beautifulsoup4
 types-python-dateutil

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -30,13 +30,13 @@ blinker==1.6.2
     # via streamlit
 boto3==1.28.60
     # via -r ./python/requirements.in
-boto3-stubs[s3]==1.28.59
+boto3-stubs[s3]==1.28.60
     # via -r ./python/requirements.in
 botocore==1.31.60
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.31.59
+botocore-stubs==1.31.60
     # via
     #   -r ./python/requirements.in
     #   boto3-stubs
@@ -373,7 +373,7 @@ rich==13.6.0
     # via
     #   -r ./python/requirements.in
     #   streamlit
-rpds-py==0.10.3
+rpds-py==0.10.4
     # via
     #   jsonschema
     #   referencing
@@ -470,6 +470,8 @@ types-s3transfer==0.7.0
     # via boto3-stubs
 types-setuptools==68.2.0.0
     # via -r ./python/requirements.in
+types-tqdm==4.66.0.2
+    # via -r ./python/requirements.in
 types-urllib3==1.26.25.14
     # via types-requests
 typing-extensions==4.8.0
@@ -500,7 +502,7 @@ wcwidth==0.2.8
     # via prompt-toolkit
 xlrd==2.0.1
     # via -r ./python/requirements.in
-xyzservices==2023.7.0
+xyzservices==2023.10.0
     # via contextily
 zipp==3.17.0
     # via importlib-metadata


### PR DESCRIPTION
The decorators were causing issues when implementing dcpy recipes here, so I've gone ahead an inlined all the decorated functions. (I was able to automate most of this via the magic of emacs macros). For cleanliness, I thought a separate PR might be nice. 

Anyway, for transformation, process was something like this. For a sample fn like below:

```
@Export
@Function1B(
    street_name_field="address_street_name",
    house_number_field="address_building",
    borough_field="address_borough",
    zipcode_field="address_zip",
)
@FunctionBL(bbl_field="bbl")
@FunctionBN(bin_field="bin")
@Prepare
def my_func():
    ....
```

1. `@Prepare` -> moved the dataset-download call into the CLI, and the sanitizing into the fn body immediately after existing code 
2. `@Export`  -> moved into the CLI
3. For the others -> moved them into the function body above `export`, then reversed their order. (since decorators execute from bottom up)

You could review commit-by-commit, but it might be easiest to just review all changed files. For the pipelines, as I mentioned the process was largely automated, so I'm not sure you need to check every single function (though don't let me stop you!). I believe the control flow should be basically identical to how it was before. May not be pretty, but now it's explicit. 

I tested this by loading data. I didn't do a full build to compare to previous versions. But last time I build FacDB, it was pretty fussy, so I expect that completed loading is a sufficient test. However, happy to do a full build comparison if folks want that assurance.