### PR TITLE
generate MVTs with specific zoom levels

### DIFF
--- a/.github/workflows/publish_generate_mvt.yml
+++ b/.github/workflows/publish_generate_mvt.yml
@@ -25,6 +25,16 @@ on:
         description: "Filepath within output folder to shapefile to convert"
         type: string
         required: true
+      min_zoom:
+        description: "Minimum zoom level"
+        type: string
+        required: true
+        default: '0'
+      max_zoom:
+        description: "Maximum zoom level"
+        type: string
+        required: true
+        default: '5'
 
 jobs:
   publish:

--- a/.github/workflows/publish_generate_mvt.yml
+++ b/.github/workflows/publish_generate_mvt.yml
@@ -37,7 +37,8 @@ on:
         default: '5'
 
 jobs:
-  publish:
+  build:
+    name: Build MVT files
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -59,24 +60,27 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
 
-      - name: Download file
+      - name: Download source file
         run: |
           python3 -m dcpy.connectors.edm.publishing download_file \
-            -p db-${{ inputs.product }} \
-            -v ${{ inputs.version }} \
-            -f ${{ inputs.filepath_to_shapefile }}
+            --product db-${{ inputs.product }} \
+            --version ${{ inputs.version }} \
+            --filepath ${{ inputs.filepath_to_shapefile }}
 
       - name: Generate MVT
         run: | 
           python3 -m dcpy.utils.geospatial \
-            -i $(basename ${{ inputs.filepath_to_shapefile }}) \
-            -o ${{ inputs.product }}_mvt
+            --product ${{ inputs.product }} \
+            --input-path $(basename ${{ inputs.filepath_to_shapefile }}) \
+            --min-zoom ${{ inputs.min_zoom }} \
+            --max-zoom ${{ inputs.max_zoom }}
 
-      - name: Publish MVT
+      - name: Upload MVT
         run: | 
           python3 -m dcpy.utils.s3 \
-            -b de-sandbox \
+            --bucket de-sandbox \
             --folder-path ${{ inputs.product }}_mvt \
             --s3-path mvt/${{ inputs.product }}/${{inputs.version}}/ \
             --acl private \
+            --max-files 800000 \
             --contents-only

--- a/dcpy/utils/geospatial.py
+++ b/dcpy/utils/geospatial.py
@@ -11,9 +11,10 @@ from rich.progress import (
 
 
 def translate_shp_to_mvt(
-    input_path: str, output_path: str, min_zoom: int = 0, max_zoom: int = 5
+    product: str, input_path: str, min_zoom: int = 0, max_zoom: int = 5
 ) -> None:
     """Keeping scope of this very limited - should be refactored once data library is fully brought in"""
+    output_path = f"{product}_mvt"
     with Progress(
         SpinnerColumn(spinner_name="earth"),
         TextColumn("[progress.description]{task.description}"),
@@ -44,17 +45,17 @@ def translate_shp_to_mvt(
 app = typer.Typer(add_completion=False)
 
 
-@app.command("translate")
+@app.command()
 def _cli_wrapper_translate(
+    product: str = typer.Option(
+        None,
+        "-p",
+        "--product",
+    ),
     input_path: str = typer.Option(
         None,
         "-i",
         "--input-path",
-    ),
-    output_path: str = typer.Option(
-        None,
-        "-o",
-        "--output-path",
     ),
     min_zoom: int = typer.Option(
         None,
@@ -65,7 +66,7 @@ def _cli_wrapper_translate(
         "--max-zoom",
     ),
 ):
-    translate_shp_to_mvt(input_path, output_path, min_zoom, max_zoom)
+    translate_shp_to_mvt(product, input_path, min_zoom, max_zoom)
 
 
 if __name__ == "__main__":

--- a/dcpy/utils/geospatial.py
+++ b/dcpy/utils/geospatial.py
@@ -30,6 +30,7 @@ def translate_shp_to_mvt(
         def update_progress(complete, message, unknown):
             progress.update(task, completed=floor(complete * 1000))
 
+        gdal.UseExceptions()
         gdal.VectorTranslate(
             output_path,
             f"/vsizip/{input_path}",

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -311,6 +311,7 @@ def get_file_as_text(bucket: str, path: str) -> str:
 app = typer.Typer(add_completion=False)
 
 
+# ? deprecate this CLI in favor of connectors.edm modules?
 @app.command("upload_folder")
 def _cli_wrapper_upload_folder(
     bucket: str = typer.Option(None, "-b", "--bucket", help="S3 bucket"),
@@ -318,7 +319,7 @@ def _cli_wrapper_upload_folder(
         None, "--folder-path", help="Path to local output folder"
     ),
     s3_path: Path = typer.Option(None, "--s3-path", help="Path to s3 output folder"),
-    acl: ACL = typer.Option(None, "-a", "--acl", help="Access level of file in s3"),
+    acl: str = typer.Option(None, "-a", "--acl", help="Access level of file in s3"),
     max_files: int = typer.Option(
         20, "--max-files", help="Maximum number of files to upload"
     ),
@@ -328,11 +329,12 @@ def _cli_wrapper_upload_folder(
         help="If true, uploads local folder into target folder. If false, uploads contents of local folder instead",
     ),
 ):
+    acl_literal = string_as_acl(acl)
     upload_folder(
         bucket,
         local_path,
         s3_path,
-        acl=acl,
+        acl=acl_literal,
         max_files=max_files,
         contents_only=contents_only,
     )


### PR DESCRIPTION
related to #250 

## motivation
- per chat with @TylerMatteo, zoom levels from 15-22 would be nice for prototyping

## notes
- this is meant to get the required zoom level feature working, not refactor @fvankrieken's initial approach for generating MVTs
- this includes limiting the source data fields because
  - the MVT files are too large to upload before the github action times out (6 hours)
  - it's a required feature from AE anyway (MVTs are meant for displaying geometries, not storing relational data)

## action runs
- [success](https://github.com/NYCPlanning/data-engineering/actions/runs/6565693509) using zooms 15-16 and 4 fields.  12 mins to upload
- [successfully raising gdal error](https://github.com/NYCPlanning/data-engineering/actions/runs/6395267663/job/17358522331#step:5:13) when exceeding max zoom of 22