### PR TITLE
Fvk dtm duplicate bbl fix

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -3,13 +3,18 @@ name: Zoning Tax lots - 📁 DataLoading
 on:
   workflow_dispatch:
     inputs:
+      build_ztl:
+        description: "Build Zoning Tax Lots after dataloading is complete"
+        type: boolean
+        default: false
       build_pluto_minor:
+        description: "Build Pluto (minor) after dataloading is complete"
         type: boolean
         default: false
 
 jobs:
   dataloading:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       AWS_S3_BUCKET: edm-recipes
     strategy:
@@ -46,6 +51,15 @@ jobs:
           s3: true
           compress: true
           output_format: pgdump shapefile
+
+  build_ztl:
+    needs: [dataloading]
+    name: Build Ztl
+    if: inputs.build_ztl
+    uses: ./.github/workflows/zoningtaxlots_build.yml
+    secrets: inherit
+    with:
+      run_export: true
 
   pluto_minor:
     needs: [dataloading]

--- a/products/pluto/pluto_build/sql/create.sql
+++ b/products/pluto/pluto_build/sql/create.sql
@@ -1,6 +1,7 @@
 --Create empty PLUTO table
 DROP TABLE IF EXISTS pluto CASCADE;
 CREATE TABLE pluto (
+    id serial PRIMARY KEY,
     borough text,
     block text,
     lot text,

--- a/products/pluto/pluto_build/sql/zoning_specialdistrict.sql
+++ b/products/pluto/pluto_build/sql/zoning_specialdistrict.sql
@@ -6,23 +6,20 @@
 DROP TABLE IF EXISTS specialpurposeper;
 CREATE TABLE specialpurposeper AS
 SELECT
+    p.id,
     p.bbl,
     n.sdlbl,
     ST_AREA(
         CASE
-            WHEN ST_COVEREDBY(p.geom, n.geom)
-                THEN p.geom
-            ELSE
-                ST_MULTI(ST_INTERSECTION(p.geom, n.geom))
+            WHEN ST_COVEREDBY(p.geom, n.geom) THEN p.geom
+            ELSE ST_MULTI(ST_INTERSECTION(p.geom, n.geom))
         END
     ) AS segbblgeom,
     ST_AREA(p.geom) AS allbblgeom,
     ST_AREA(
         CASE
-            WHEN ST_COVEREDBY(n.geom, p.geom)
-                THEN n.geom
-            ELSE
-                ST_MULTI(ST_INTERSECTION(n.geom, p.geom))
+            WHEN ST_COVEREDBY(n.geom, p.geom) THEN n.geom
+            ELSE ST_MULTI(ST_INTERSECTION(n.geom, p.geom))
         END
     ) AS segzonegeom,
     ST_AREA(n.geom) AS allzonegeom
@@ -34,6 +31,7 @@ DROP TABLE IF EXISTS specialpurposeperorder;
 CREATE TABLE specialpurposeperorder AS
 WITH specialpurposeperorder_init AS (
     SELECT
+        id,
         bbl,
         sdlbl,
         segbblgeom,
@@ -52,10 +50,11 @@ WITH specialpurposeperorder_init AS (
 )
 
 SELECT
+    id,
     bbl,
     sdlbl,
     segbblgeom,
-    ROW_NUMBER() OVER (PARTITION BY bbl ORDER BY segbblgeom ASC, sdlbl DESC) AS row_number
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY segbblgeom ASC, sdlbl DESC) AS row_number
 FROM specialpurposeperorder_init
 WHERE
     perbblgeom >= 10
@@ -65,21 +64,21 @@ UPDATE pluto a
 SET spdist1 = sdlbl
 FROM specialpurposeperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.id = b.id
     AND row_number = 1;
 
 UPDATE pluto a
 SET spdist2 = sdlbl
 FROM specialpurposeperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.id = b.id
     AND row_number = 2;
 
 UPDATE pluto a
 SET spdist3 = sdlbl
 FROM specialpurposeperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.id = b.id
     AND row_number = 3;
 
 -- set the order of special districts 

--- a/products/zoningtaxlots/bash/03_qaqc_upload.sh
+++ b/products/zoningtaxlots/bash/03_qaqc_upload.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source bash/config.sh
+set_error_traps
 
 echo "Archive final output"
 

--- a/products/zoningtaxlots/bash/03_qaqc_upload.sh
+++ b/products/zoningtaxlots/bash/03_qaqc_upload.sh
@@ -4,6 +4,7 @@ source bash/config.sh
 echo "Archive final output"
 
 pg_dump -d ${BUILD_ENGINE} -t dcp_zoning_taxlot --no-owner --clean | psql ${EDM_DATA}
+
 psql ${EDM_DATA} -c "
   CREATE SCHEMA IF NOT EXISTS dcp_zoningtaxlots;
   ALTER TABLE dcp_zoning_taxlot SET SCHEMA dcp_zoningtaxlots;

--- a/products/zoningtaxlots/bash/03_qaqc_upload.sh
+++ b/products/zoningtaxlots/bash/03_qaqc_upload.sh
@@ -19,6 +19,9 @@ psql ${EDM_DATA} -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_
 psql ${EDM_DATA} -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_SQL_TABLE} -f sql/qaqc/out_bbldiffs.sql | 
     psql ${BUILD_ENGINE} -f sql/qaqc/in_bbldiffs.sql
 
+## remove dtm_id column from archive because it isn't a true id but rather one we generate during build
+psql $EDM_DATA -c "ALTER TABLE dcp_zoningtaxlots.\"${VERSION_SQL_TABLE}\" DROP COLUMN dtm_id;"
+
 rm -rf output && mkdir -p output
 (
     cd output

--- a/products/zoningtaxlots/bash/03_qaqc_upload.sh
+++ b/products/zoningtaxlots/bash/03_qaqc_upload.sh
@@ -52,7 +52,7 @@ rm -rf output && mkdir -p output
     FROM qc_bbldiffs
     ) TO STDOUT DELIMITER ',' CSV HEADER;" > qc_bbldiffs.csv &
 
-    shp_export qc_bbldiffs MULTIPOLYGON
+    shp_export qc_bbldiffs MULTIPOLYGON -t_srs "EPSG:2263"
 
     echo "${DATE}" > version.txt
     wait

--- a/products/zoningtaxlots/sql/area_mih.sql
+++ b/products/zoningtaxlots/sql/area_mih.sql
@@ -7,7 +7,8 @@ DROP TABLE IF EXISTS mihperorder;
 CREATE TABLE mihperorder AS
 WITH mihper AS (
     SELECT
-        p.bbl,
+        p.id AS dtm_id,
+        bbl,
         n.mih_option,
         ST_AREA(
             CASE
@@ -29,14 +30,14 @@ WITH mihper AS (
 )
 
 SELECT
-    bbl,
+    dtm_id,
     mih_option,
     segbblgeom,
     (segbblgeom / allbblgeom) * 100 AS perbblgeom,
     (segzonegeom / allzonegeom) * 100 AS perzonegeom,
     ROW_NUMBER()
         OVER (
-            PARTITION BY bbl
+            PARTITION BY dtm_id
             ORDER BY segbblgeom DESC
         )
     AS row_number
@@ -50,4 +51,4 @@ SET
         WHEN perbblgeom >= 10 THEN mih_option
     END
 FROM mihperorder AS b
-WHERE a.bbl::TEXT = b.bbl::TEXT;
+WHERE a.dtm_id = b.dtm_id;

--- a/products/zoningtaxlots/sql/area_specialdistrict.sql
+++ b/products/zoningtaxlots/sql/area_specialdistrict.sql
@@ -6,23 +6,20 @@
 DROP TABLE IF EXISTS specialpurposeper;
 CREATE TABLE specialpurposeper AS
 SELECT
+    p.id AS dtm_id,
     p.bbl,
     n.sdlbl,
     ST_AREA(
         CASE
-            WHEN ST_COVEREDBY(p.geom, n.geom)
-                THEN p.geom
-            ELSE
-                ST_MULTI(ST_INTERSECTION(p.geom, n.geom))
+            WHEN ST_COVEREDBY(p.geom, n.geom) THEN p.geom
+            ELSE ST_MULTI(ST_INTERSECTION(p.geom, n.geom))
         END
     ) AS segbblgeom,
     ST_AREA(p.geom) AS allbblgeom,
     ST_AREA(
         CASE
-            WHEN ST_COVEREDBY(n.geom, p.geom)
-                THEN n.geom
-            ELSE
-                ST_MULTI(ST_INTERSECTION(n.geom, p.geom))
+            WHEN ST_COVEREDBY(n.geom, p.geom) THEN n.geom
+            ELSE ST_MULTI(ST_INTERSECTION(n.geom, p.geom))
         END
     ) AS segzonegeom,
     ST_AREA(n.geom) AS allzonegeom
@@ -34,6 +31,7 @@ DROP TABLE IF EXISTS specialpurposeperorder;
 CREATE TABLE specialpurposeperorder AS
 WITH specialpurposeperorder_init AS (
     SELECT
+        dtm_id,
         bbl,
         sdlbl,
         segbblgeom,
@@ -52,10 +50,11 @@ WITH specialpurposeperorder_init AS (
 )
 
 SELECT
+    dtm_id,
     bbl,
     sdlbl,
     segbblgeom,
-    ROW_NUMBER() OVER (PARTITION BY bbl ORDER BY segbblgeom ASC, sdlbl DESC) AS row_number
+    ROW_NUMBER() OVER (PARTITION BY dtm_id ORDER BY segbblgeom ASC, sdlbl DESC) AS row_number
 FROM specialpurposeperorder_init
 WHERE
     perbblgeom >= 10
@@ -65,21 +64,21 @@ UPDATE dcp_zoning_taxlot a
 SET specialdistrict1 = sdlbl
 FROM specialpurposeperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.dtm_id = b.dtm_id
     AND row_number = 1;
 
 UPDATE dcp_zoning_taxlot a
 SET specialdistrict2 = sdlbl
 FROM specialpurposeperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.dtm_id = b.dtm_id
     AND row_number = 2;
 
 UPDATE dcp_zoning_taxlot a
 SET specialdistrict3 = sdlbl
 FROM specialpurposeperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.dtm_id = b.dtm_id
     AND row_number = 3;
 
 -- set the order of special districts 

--- a/products/zoningtaxlots/sql/area_zoningdistrict.sql
+++ b/products/zoningtaxlots/sql/area_zoningdistrict.sql
@@ -8,6 +8,7 @@
 DROP TABLE IF EXISTS validdtm;
 CREATE TABLE validdtm AS (
     SELECT
+        id AS dtm_id,
         bbl,
         ST_MAKEVALID(geom) AS geom
     FROM dof_dtm
@@ -36,7 +37,8 @@ ANALYZE validzones;
 DROP TABLE IF EXISTS lotzoneper;
 CREATE TABLE lotzoneper AS
 SELECT
-    p.bbl,
+    p.dtm_id,
+    bbl,
     n.zonedist,
     ST_AREA(
         CASE
@@ -66,6 +68,7 @@ ANALYZE lotzoneper;
 DROP TABLE IF EXISTS lotzoneper_grouped;
 CREATE TABLE lotzoneper_grouped AS
 SELECT
+    dtm_id,
     bbl,
     zonedist,
     allbblgeom,
@@ -73,13 +76,14 @@ SELECT
     SUM(segzonegeom) AS segzonegeom,
     SUM(allzonegeom) AS allzonegeom
 FROM lotzoneper
-GROUP BY bbl, allbblgeom, zonedist;
+GROUP BY dtm_id, bbl, allbblgeom, zonedist;
 
 -- ordered zonedists per lot before applying tie-breaking logic from zonedist_priority
 DROP TABLE IF EXISTS lotzoneperorder_init;
 CREATE TABLE lotzoneperorder_init AS
 WITH initial_rankings AS (
     SELECT
+        dtm_id,
         bbl,
         zonedist,
         segbblgeom,
@@ -89,7 +93,7 @@ WITH initial_rankings AS (
         (segbblgeom / allbblgeom) * 100 AS perbblgeom,
         (segzonegeom / allzonegeom) * 100 AS perzonegeom,
         -- zone districts per lot ranked by percent of lot covered
-        ROW_NUMBER() OVER (PARTITION BY bbl ORDER BY segbblgeom DESC) AS bbl_row_number,
+        ROW_NUMBER() OVER (PARTITION BY dtm_id ORDER BY segbblgeom DESC) AS lot_row_number,
         -- per zoning district type, rank by 
         --   1) if lot meets 10% coverage by zoning district threshold
         --   2) area of coverage
@@ -102,6 +106,7 @@ WITH initial_rankings AS (
 )
 
 SELECT
+    dtm_id,
     bbl,
     zonedist,
     segbblgeom,
@@ -110,18 +115,18 @@ SELECT
     segzonegeom,
     allzonegeom,
     perzonegeom,
-    ROW_NUMBER() OVER (PARTITION BY bbl ORDER BY segbblgeom DESC) AS row_number,
+    ROW_NUMBER() OVER (PARTITION BY dtm_id ORDER BY segbblgeom DESC) AS row_number,
     -- identifying whether zone of rank n for a lot is within 0.01 sq m of zone of rank (n-1) for same lot for tie-breaking logic in next query
     CASE
         WHEN
-            ROW_NUMBER() OVER (PARTITION BY bbl ORDER BY segbblgeom DESC) = 1
-            OR LAG(segbblgeom, 1, segbblgeom) OVER (PARTITION BY bbl ORDER BY segbblgeom DESC) - segbblgeom > 0.01
+            ROW_NUMBER() OVER (PARTITION BY dtm_id ORDER BY segbblgeom DESC) = 1
+            OR LAG(segbblgeom, 1, segbblgeom) OVER (PARTITION BY dtm_id ORDER BY segbblgeom DESC) - segbblgeom > 0.01
             THEN 1
         ELSE 0
     END AS group_start
 FROM initial_rankings
 WHERE
-    bbl_row_number = 1
+    lot_row_number = 1
     OR perbblgeom >= 10
     OR zonedist_row_number = 1;
 
@@ -132,30 +137,30 @@ DROP TABLE IF EXISTS lotzoneperorder;
 CREATE TABLE lotzoneperorder AS
 WITH group_column_added AS (
     SELECT
-        bbl,
+        dtm_id,
         -- this is not summing by any sql grouping, but rather summing in a window function as the rows are iterated through
         -- output column ends up being a grouping of lot/zone pairings that are "tied" within some limit and should be reordered
         --     based on ranking in zonedist_priority
         zonedist,
         row_number,
-        SUM(group_start) OVER (PARTITION BY bbl ORDER BY row_number) AS reorder_group
+        SUM(group_start) OVER (PARTITION BY dtm_id ORDER BY row_number) AS reorder_group
     FROM lotzoneperorder_init
 ),
 
 reorder_groups AS (
     SELECT
-        bbl,
+        dtm_id,
         reorder_group,
         MIN(row_number) - 1 AS order_start, -- starting point for re-ordering in "new_order" CTE down below
         ARRAY_AGG(zonedist) AS zonedist
     FROM group_column_added
-    GROUP BY bbl, reorder_group
+    GROUP BY dtm_id, reorder_group
     HAVING COUNT(*) > 1 -- Filter to actual groups and not just individual rows
 ),
 
 rows_to_reorder AS (
     SELECT
-        bbl,
+        dtm_id,
         reorder_group,
         order_start,
         UNNEST(zonedist) AS zonedist
@@ -164,14 +169,15 @@ rows_to_reorder AS (
 
 new_order AS (
     SELECT
-        g.bbl,
+        g.dtm_id,
         g.zonedist,
-        ROW_NUMBER() OVER (PARTITION BY bbl, reorder_group ORDER BY priority ASC) + g.order_start AS row_number
+        ROW_NUMBER() OVER (PARTITION BY dtm_id, reorder_group ORDER BY priority ASC) + g.order_start AS row_number
     FROM rows_to_reorder AS g
     INNER JOIN zonedist_priority AS zdp ON g.zonedist = zdp.zonedist
 )
 
 SELECT
+    a.dtm_id,
     a.bbl,
     a.zonedist,
     segbblgeom,
@@ -182,32 +188,32 @@ SELECT
     perzonegeom,
     COALESCE(new.row_number, a.row_number) AS row_number
 FROM lotzoneperorder_init AS a
-LEFT JOIN new_order AS new ON a.bbl = new.bbl AND a.zonedist = new.zonedist;
+LEFT JOIN new_order AS new ON a.dtm_id = new.dtm_id AND a.zonedist = new.zonedist;
 
 UPDATE dcp_zoning_taxlot a
 SET zoningdistrict1 = zonedist
 FROM lotzoneperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.dtm_id = b.dtm_id
     AND row_number = 1;
 
 UPDATE dcp_zoning_taxlot a
 SET zoningdistrict2 = zonedist
 FROM lotzoneperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.dtm_id = b.dtm_id
     AND row_number = 2;
 
 UPDATE dcp_zoning_taxlot a
 SET zoningdistrict3 = zonedist
 FROM lotzoneperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.dtm_id = b.dtm_id
     AND row_number = 3;
 
 UPDATE dcp_zoning_taxlot a
 SET zoningdistrict4 = zonedist
 FROM lotzoneperorder AS b
 WHERE
-    a.bbl = b.bbl
+    a.dtm_id = b.dtm_id
     AND row_number = 4;

--- a/products/zoningtaxlots/sql/area_zoningmap.sql
+++ b/products/zoningtaxlots/sql/area_zoningmap.sql
@@ -5,12 +5,12 @@
 -- OR more than a specified area of the lot if covered by the map
 --DROP INDEX IF EXISTS dcp_zoningmapindex_gix;
 --CREATE INDEX dcp_zoningmapindex_gix ON dcp_zoningmapindex USING GIST (geom);
-
-DROP TABLE IF EXISTS zoningmapperorder;
-CREATE TABLE zoningmapperorder AS (
+DROP TABLE IF EXISTS zoningmapper;
+CREATE TABLE zoningmapper AS (
     WITH validdtm AS (
         SELECT
-            a.bbl,
+            id AS dtm_id,
+            bbl,
             ST_MAKEVALID(a.geom) AS geom
         FROM dof_dtm AS a
     ),
@@ -20,36 +20,35 @@ CREATE TABLE zoningmapperorder AS (
             a.zoning_map,
             ST_MAKEVALID(a.geom) AS geom
         FROM dcp_zoningmapindex AS a
-    ),
-
-    zoningmapper AS (
-        SELECT
-            p.bbl,
-            n.zoning_map,
-            (ST_AREA(CASE
-                WHEN ST_COVEREDBY(ST_MAKEVALID(p.geom), n.geom)
-                    THEN p.geom
-                ELSE
-                    ST_MULTI(
-                        ST_INTERSECTION(ST_MAKEVALID(p.geom), n.geom)
-                    )
-            END)) AS segbblgeom,
-            ST_AREA(p.geom) AS allbblgeom,
-            (ST_AREA(CASE
-                WHEN ST_COVEREDBY(n.geom, ST_MAKEVALID(p.geom))
-                    THEN n.geom
-                ELSE
-                    ST_MULTI(
-                        ST_INTERSECTION(n.geom, ST_MAKEVALID(p.geom))
-                    )
-            END)) AS segzonegeom,
-            ST_AREA(n.geom) AS allzonegeom
-        FROM validdtm AS p
-        INNER JOIN validindex AS n
-            ON ST_INTERSECTS(p.geom, n.geom)
     )
 
     SELECT
+        dtm_id,
+        p.bbl,
+        n.zoning_map,
+        ST_AREA(
+            CASE
+                WHEN ST_COVEREDBY(ST_MAKEVALID(p.geom), n.geom) THEN p.geom
+                ELSE ST_MULTI(ST_INTERSECTION(ST_MAKEVALID(p.geom), n.geom))
+            END
+        ) AS segbblgeom,
+        ST_AREA(p.geom) AS allbblgeom,
+        ST_AREA(
+            CASE
+                WHEN ST_COVEREDBY(n.geom, ST_MAKEVALID(p.geom)) THEN n.geom
+                ELSE ST_MULTI(ST_INTERSECTION(n.geom, ST_MAKEVALID(p.geom)))
+            END
+        ) AS segzonegeom,
+        ST_AREA(n.geom) AS allzonegeom
+    FROM validdtm AS p
+    INNER JOIN validindex AS n
+        ON ST_INTERSECTS(p.geom, n.geom)
+);
+
+DROP TABLE IF EXISTS zoningmapperorder;
+CREATE TABLE zoningmapperorder AS (
+    SELECT
+        dtm_id,
         bbl,
         zoning_map,
         segbblgeom,
@@ -57,7 +56,7 @@ CREATE TABLE zoningmapperorder AS (
         (segzonegeom / allzonegeom) * 100 AS perzonegeom,
         ROW_NUMBER()
             OVER (
-                PARTITION BY bbl
+                PARTITION BY dtm_id
                 ORDER BY segbblgeom DESC
             )
         AS row_number
@@ -69,7 +68,7 @@ UPDATE dcp_zoning_taxlot a
 SET zoningmapnumber = zoning_map
 FROM zoningmapperorder AS b
 WHERE
-    a.bbl::TEXT = b.bbl::TEXT
+    a.dtm_id = b.dtm_id
     AND row_number = 1
     AND perbblgeom >= 10;
 
@@ -78,5 +77,5 @@ UPDATE dcp_zoning_taxlot a
 SET zoningmapcode = 'Y'
 FROM zoningmapperorder AS b
 WHERE
-    a.bbl::TEXT = b.bbl::TEXT
+    a.dtm_id = b.dtm_id
     AND row_number = 2;

--- a/products/zoningtaxlots/sql/bbl.sql
+++ b/products/zoningtaxlots/sql/bbl.sql
@@ -1,5 +1,6 @@
 -- insert unique bbls into table
 INSERT INTO dcp_zoning_taxlot (
+    dtm_id,
     bbl,
     boroughcode,
     taxblock,
@@ -7,13 +8,13 @@ INSERT INTO dcp_zoning_taxlot (
     area
 )
 SELECT
+    id,
     bbl,
     boro,
     block,
     lot,
-    ST_AREA(ST_MULTI(ST_UNION(geom))::geography) AS area
-FROM dof_dtm
-GROUP BY bbl, boro, block, lot;
+    ST_AREA(geom) AS area
+FROM dof_dtm;
 -- populate bbl field if it's NULL
 UPDATE dcp_zoning_taxlot
 SET bbl = boroughcode || LPAD(taxblock, 5, '0') || LPAD(taxlot, 4, '0')::text

--- a/products/zoningtaxlots/sql/create.sql
+++ b/products/zoningtaxlots/sql/create.sql
@@ -1,6 +1,7 @@
 -- create empty dcp_zoning_taxlot table
 DROP TABLE IF EXISTS dcp_zoning_taxlot CASCADE;
 CREATE TABLE dcp_zoning_taxlot (
+    dtm_id int,
     boroughcode text,
     taxblock text,
     taxlot text,

--- a/products/zoningtaxlots/sql/inzonechange.sql
+++ b/products/zoningtaxlots/sql/inzonechange.sql
@@ -3,6 +3,6 @@ UPDATE dcp_zoning_taxlot a
 SET inzonechange = 'Y'
 FROM dof_dtm AS b, dcp_zoningmapamendments AS c
 WHERE
-    a.bbl::TEXT = b.bbl::TEXT
+    a.dtm_id = b.id
     AND ST_INTERSECTS(b.geom, c.geom)
     AND c.effective::DATE > CURRENT_DATE - INTERVAL '2 months';

--- a/products/zoningtaxlots/sql/preprocessing.sql
+++ b/products/zoningtaxlots/sql/preprocessing.sql
@@ -25,13 +25,24 @@ RENAME COLUMN wkb_geometry TO geom;
 
 DROP TABLE IF EXISTS dof_dtm_tmp;
 CREATE TABLE dof_dtm_tmp AS (
+    WITH coalesced AS (
+        SELECT
+            bbl,
+            COALESCE(boro::text, LEFT(bbl::text, 1)) AS boro,
+            COALESCE(block::text, SUBSTRING(bbl::text, 2, 5)) AS block,
+            COALESCE(lot::text, SUBSTRING(bbl::text, 7, 4)) AS lot,
+            geom
+        FROM dof_dtm
+    )
+
     SELECT
+        ROW_NUMBER() OVER () AS id,
         bbl,
-        COALESCE(boro::text, LEFT(bbl::text, 1)) AS boro,
-        COALESCE(block::text, SUBSTRING(bbl::text, 2, 5)) AS block,
-        COALESCE(lot::text, SUBSTRING(bbl::text, 7, 4)) AS lot,
-        ST_MULTI(ST_UNION(ST_MAKEVALID(f.geom))) AS geom
-    FROM dof_dtm AS f
+        boro,
+        block,
+        lot,
+        ST_MULTI(ST_UNION(ST_MAKEVALID(geom))) AS geom
+    FROM coalesced
     GROUP BY bbl, boro, block, lot
 );
 

--- a/products/zoningtaxlots/sql/qaqc/in_bbldiffs.sql
+++ b/products/zoningtaxlots/sql/qaqc/in_bbldiffs.sql
@@ -1,5 +1,6 @@
 -- output a diff file with bbls that have changed in any field
 CREATE TEMP TABLE tmp (
+    dtm_id int,
     boroughcode text,
     taxblock text,
     taxlot text,
@@ -37,9 +38,39 @@ CREATE TEMP TABLE tmp (
 
 DROP TABLE IF EXISTS qc_bbldiffs;
 SELECT
-    a.*,
+    a.boroughcode,
+    a.taxblock,
+    a.taxlot,
+    a.bblnew,
+    a.zd1new,
+    a.zd2new,
+    a.zd3new,
+    a.zd4new,
+    a.co1new,
+    a.co2new,
+    a.sd1new,
+    a.sd2new,
+    a.sd3new,
+    a.lhdnew,
+    a.zmnnew,
+    a.zmcnew,
+    a.area,
+    a.inzonechange,
+    a.bblprev,
+    a.zd1prev,
+    a.zd2prev,
+    a.zd3prev,
+    a.zd4prev,
+    a.co1prev,
+    a.co2prev,
+    a.sd1prev,
+    a.sd2prev,
+    a.sd3prev,
+    a.lhdprev,
+    a.zmnprev,
+    a.zmcprev,
     b.geom
 INTO qc_bbldiffs
 FROM tmp AS a
 INNER JOIN dof_dtm AS b
-    ON a.bblnew::text = b.bbl::text;
+    ON a.dtm_id = b.id

--- a/products/zoningtaxlots/sql/qaqc/out_bbldiffs.sql
+++ b/products/zoningtaxlots/sql/qaqc/out_bbldiffs.sql
@@ -1,6 +1,7 @@
 -- output a diff file with bbls that have changed in any field
 CREATE TEMP TABLE bbldiffs AS (
     SELECT
+        a.dtm_id,
         a.boroughcode,
         a.taxblock,
         a.taxlot,
@@ -34,7 +35,10 @@ CREATE TEMP TABLE bbldiffs AS (
         b.zoningmapcode AS zmcprev
     FROM dcp_zoningtaxlots.:"VERSION" AS a, dcp_zoningtaxlots.:"VERSION_PREV" AS b
     WHERE
-        a.bbl::text = b.bbl::text
+        a.bbl = b.bbl
+        AND a.boroughcode = b.boroughcode
+        AND a.taxblock = b.taxblock
+        AND a.taxlot = b.taxlot
         AND (
             a.zoningdistrict1 != b.zoningdistrict1
             OR a.zoningdistrict2 != b.zoningdistrict2
@@ -73,4 +77,4 @@ CREATE TEMP TABLE bbldiffs AS (
         )
 );
 
-\COPY bbldiffs TO PSTDOUT DELIMITER ',' CSV HEADER;
+\COPY bbldiffs TO PSTDOUT DELIMITER ',' CSV;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ exclude_rules = [
     "ambiguous.column_count",
     "references.qualification",
     "structure.unused_cte",
+    "structure.column_order",
     "references.keywords",
     "references.consistent",
     "references.special_chars",


### PR DESCRIPTION
Fixes #278.

Essentially, bbls in dof dtm are not necessarily unique. This needed some cleanup in how we're de-duplicating in preprocessing as well as addition of essentially a primary key for the table to actually identify unique rows.

Pluto needs analogous changes, though it's a bit different - data doesn't just come from dtm, and the aggregations use pluto itself as a source. So for applying the same fix to pluto, I simply added a serial pk to the table