### PR TITLE
fix pluto build use of `dcpy.builds`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,14 @@ on:
           - knownprojects
           - pluto
           - ztl
+      recipe_file:
+        description: "Filename of recipe to use"
+        type: choice
+        required: true
+        default: recipe
+        options:
+          - recipe
+          - recipe-minor
       logging_level:
         description: "Logging level"
         type: choice
@@ -52,6 +60,7 @@ jobs:
     uses: ./.github/workflows/template_build.yml
     secrets: inherit
     with:
+      recipe_file: ${{ inputs.recipe_file }}
       logging_level: ${{ inputs.logging_level }}
       build_note: ${{ inputs.build_note }}
       run_export: ${{ inputs.run_export }}
@@ -104,6 +113,7 @@ jobs:
     uses: ./.github/workflows/pluto_build.yml
     secrets: inherit
     with:
+      recipe_file: ${{ inputs.recipe_file }}
       run_export: ${{ inputs.run_export }}
   ztl:
     if: inputs.dataset_name == 'ztl'

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -95,10 +95,6 @@ jobs:
       - name: Load Local Data
         run: ./01_load_local_csvs.sh
 
-      - name: clean out raw source data
-        working-directory: ./
-        run: python3 -m dcpy.connectors.edm.recipes purge-recipe-cache
-
       - name: building ...
         run: ./02_build.sh
 

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -8,21 +8,25 @@ on:
         required: true
       recipe_file:
         type: string
-        default: recipe.yml
+        required: true
       create_issue:
         type: boolean
-        description: Create GH Issue for build?
         default: false
   workflow_dispatch:
     inputs:
       run_export:
-        description: "Run Export Step and Upload to DO"
         type: boolean
+        description: "Run Export Step and Upload to DO"
         required: true
         default: false
       recipe_file:
-        type: string
-        default: recipe.yml
+        description: "Name of recipe file to use"
+        type: choice
+        required: true
+        default: recipe
+        options:
+          - recipe
+          - recipe-minor
       create_issue:
         type: boolean
         description: Create GH Issue for build?
@@ -80,16 +84,13 @@ jobs:
       - name: Load data
         working-directory: products/pluto
         run: |
-          python3 -m dcpy.builds.load --product pluto
+          python3 -m dcpy.builds.load --recipe_path ./${{ inputs.recipe_file }}.yml
 
       - name: Set versions env vars
         working-directory: products/pluto
         run: |
           echo VERSION=$(yq .version recipe.lock.yml) >> "$GITHUB_ENV" && \
           echo VERSION_PREV=$(yq '.inputs.datasets.[] | select(.name == "dcp_pluto") | .version' recipe.lock.yml) >> "$GITHUB_ENV"
-
-      # - name: Data setup
-      #   run: ./00_setup.sh
 
       - name: Load Local Data
         run: ./01_load_local_csvs.sh

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -39,6 +39,7 @@ jobs:
     env:
       BUILD_ENGINE_SERVER: postgresql://postgres:postgres@postgis:5432
       BUILD_ENGINE_DB: postgres
+      BUILD_ENGINE_SCHEMA: public
       EDM_DATA: ${{ secrets.EDM_DATA }}
       AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -73,26 +74,22 @@ jobs:
 
       - name: Set build environment variables
         run: |
-          # replace dashes with underscores to create a valid postgres schema name
-          BUILD_ENGINE_SCHEMA=$(echo ${BUILD_ENGINE_SCHEMA} | tr - _)
-          echo "BUILD_ENGINE_SCHEMA=$BUILD_ENGINE_SCHEMA" >> "$GITHUB_ENV"
-          # set postgres schema search path to prioritize BUILD_ENGINE_SCHEMA
-          BUILD_ENGINE=${BUILD_ENGINE_DATABASE}?options=--search_path%3D${BUILD_ENGINE_SCHEMA},public
+          BUILD_ENGINE=${BUILD_ENGINE_SERVER}/${BUILD_ENGINE_DB}
           echo "BUILD_ENGINE=$BUILD_ENGINE" >> "$GITHUB_ENV"
 
-      - name: Plan Build
-        working-directory: ./
+      - name: Load data
+        working-directory: products/pluto
         run: |
-          python3 -m dcpy.builds.load pluto
+          python3 -m dcpy.builds.load --product pluto
 
       - name: Set versions env vars
-        working-directory: products/pluto/
+        working-directory: products/pluto
         run: |
           echo VERSION=$(yq .version recipe.lock.yml) >> "$GITHUB_ENV" && \
           echo VERSION_PREV=$(yq '.inputs.datasets.[] | select(.name == "dcp_pluto") | .version' recipe.lock.yml) >> "$GITHUB_ENV"
 
-      - name: Data setup
-        run: ./00_setup.sh
+      # - name: Data setup
+      #   run: ./00_setup.sh
 
       - name: Load Local Data
         run: ./01_load_local_csvs.sh

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -3,6 +3,9 @@ name: Template - Build
 on:
   workflow_call:
     inputs:
+      recipe_file:
+        type: string
+        required: true
       logging_level:
         type: string
         required: true
@@ -49,7 +52,7 @@ jobs:
 
       - name: Load
         run: |
-          python3 -m dcpy.builds.load -p template
+          python3 -m dcpy.builds.load --recipe_path ./${{ inputs.recipe_file }}.yml
 
       - name: Transform
         run: |

--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     uses: ./.github/workflows/template_build.yml
     with:
+      recipe_file: recipe
       run_export: false
       logging_level: DEBUG
       build_note: a test build

--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -34,6 +34,8 @@ def load_source_data(recipe_path: Path):
 
     [recipes.import_dataset(dataset, pg_client) for dataset in recipe.inputs.datasets]
 
+    recipes.purge_recipe_cache()
+
 
 app = typer.Typer(add_completion=False)
 

--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -17,18 +17,13 @@ def setup_build_environments(pg_client: postgres.PostgresClient):
 
 
 def load_source_data(recipe_path: Path):
-    recipe_lock_path = recipe_path.parent / f"{recipe_path}.lock.yml"
-
-    recipes.plan(
-        recipe_path,
-        recipe_lock_path,
-    )
+    recipe_lock_path = recipes.plan(recipe_path)
     recipes.write_source_data_versions(recipe_file=Path(recipe_lock_path))
     recipe = recipes.recipe_from_yaml(Path(recipe_lock_path))
 
-    logger.info(f"Loading source data for {recipe.name} build")
-
     build_name = build_metadata.build_name()
+    logger.info(f"Loading source data for {recipe.name} build named {build_name}")
+
     pg_client = postgres.PostgresClient(schema=build_name)
     setup_build_environments(pg_client)
 

--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -20,10 +20,7 @@ def load_source_data(product: str):
     product_path = REPO_ROOT_PATH / f"products/{product}"
     build_name = build_metadata.build_name()
 
-    pg_client = postgres.PostgresClient(
-        schema=build_name,
-        database=f"db-{product}",
-    )
+    pg_client = postgres.PostgresClient(schema=build_name)
 
     recipe_path = product_path / "recipe.yml"
     recipe_lock_path = recipe_path.parent / "recipe.lock.yml"

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -256,15 +256,7 @@ def write_source_data_versions(recipe_file: Path):
             writer.writerow([key, value])
 
 
-app = typer.Typer(add_completion=False)
-
-
-@app.command()
 def purge_recipe_cache():
     """Delete locally stored recipe files."""
     logger.info(f"Purging local recipes from {LIBRARY_DEFAULT_PATH}")
     shutil.rmtree(LIBRARY_DEFAULT_PATH)
-
-
-if __name__ == "__main__":
-    app()

--- a/dcpy/utils/postgres.py
+++ b/dcpy/utils/postgres.py
@@ -79,10 +79,11 @@ class PostgresClient:
         self.execute_query("VACUUM (ANALYZE)")
 
     def drop_schema(self) -> None:
-        self.execute_query(
-            "DROP SCHEMA IF EXISTS :schema_name CASCADE",
-            {"schema_name": AsIs(self.schema)},
-        )
+        if self.schema != DEFAULT_POSTGRES_SCHEMA:
+            self.execute_query(
+                "DROP SCHEMA IF EXISTS :schema_name CASCADE",
+                {"schema_name": AsIs(self.schema)},
+            )
 
     def create_schema(self) -> None:
         self.execute_query(


### PR DESCRIPTION
per Finn, this started as a fix for:

Pluto building is broken right now, two issues

- cli call in workflow doesn't work - [fixed here](https://github.com/NYCPlanning/data-engineering/pull/280/commits/cc81ea454843df89a2d5238bfc2a9bc755e71a4e)
- load currently tries to connect using db "db-{product_name}" and schema based on build env, but this isn't set up in pluto's gha at the moment since it uses a temp db, not the persisted one

and then it expanded to related improvements to `connectors.recipes` and `builds.load`