### PR TITLE
fix order of setup for data library unit tests

### DIFF
--- a/.github/workflows/data_library_test.yml
+++ b/.github/workflows/data_library_test.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install Dependencies
+      run: ./library.sh setup dev
+
     - name: Load Secrets
       uses: 1password/load-secrets-action@v1
       with:
@@ -42,9 +45,6 @@ jobs:
         AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
         AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
         AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
-
-    - name: Install Dependencies
-      run: ./library.sh setup dev
 
     - name: Pytest
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
               - pyproject.toml
               - python/**
             data-library:
+              - .github/workflows/data_library_test.yml
               - data-library/**.py
               - data-library/**.toml
               - data-library/**.yml

--- a/data-library/library.sh
+++ b/data-library/library.sh
@@ -18,7 +18,7 @@ function library_execute {
 
 function setup {
     apt update
-    apt-get install -y python3-pip python3-distutils gdal-bin libgdal-dev curl git
+    apt-get install -y python3-pip python3-distutils gdal-bin libgdal-dev curl git unzip
     apt-get -y install --reinstall build-essential
 
     python3 -m pip install poetry


### PR DESCRIPTION
Fixes failing test on main [here](https://github.com/NYCPlanning/data-engineering/actions/runs/6502202651/job/17660841762).

Theoretically could use a docker image so that this setup step isn't needed... But then we run into issue of published image vs one with changes in the PR. This docker image for whatever reason seemed more worthwhile to keep stable (and not push dev changes to) than our other ones for some slightly unquantifiable reason