### PR TITLE
fix which github secret is used for data library docker publish

### DIFF
--- a/.github/workflows/data_library_docker.yml
+++ b/.github/workflows/data_library_docker.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          username: ${{ secrets.AW_Docker_Username }}
-          password: ${{ secrets.AW_Docker_Password }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:


### PR DESCRIPTION
See failed job here

https://github.com/NYCPlanning/data-engineering/actions/runs/6510381776

Fallout from AD updating which accounts are associated with NYCPlanning on dockerhub. The new names for vars specified here are the same as other docker secrets in the rpo