### PR TITLE
delete stale build DB schemas

### DIFF
--- a/.github/workflows/developments_build.yml
+++ b/.github/workflows/developments_build.yml
@@ -7,11 +7,6 @@ on:
         type: boolean
         required: true
         default: false
-      # archive:
-      #   description: "Would you like to archive developments and dcp_housing to EDM-DATA? (yes/no)"
-      #   type: boolean
-      #   required: true
-      #   default: false
 
 jobs:
   build:
@@ -20,11 +15,12 @@ jobs:
       run:
         shell: bash
         working-directory: products/developments
-    container: 
+    container:
       image: nycplanning/build-geosupport:latest
       env:
-        BUILD_ENGINE_DATABASE: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}/devdb-build
-        BUILD_ENGINE_SCHEMA: build_${{ github.event_name }}_${{ github.ref_name }}
+        BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
+        BUILD_ENGINE_DB: db-devdb
+        BUILD_ENGINE_SCHEMA: build_${{ github.event.pull_request.number || github.ref_name }}
         EDM_DATA: ${{ secrets.EDM_DATA }}
     steps:
       - uses: actions/checkout@v3
@@ -39,18 +35,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
 
-      - name: Set build environment variables
-        run: |
-          # replace dashes with underscores to create a valid postgres schema name
-          BUILD_ENGINE_SCHEMA=$(echo ${BUILD_ENGINE_SCHEMA} | tr - _)
-          echo "BUILD_ENGINE_SCHEMA=$BUILD_ENGINE_SCHEMA" >> "$GITHUB_ENV"
-          # set postgres schema search path to prioritize BUILD_ENGINE_SCHEMA
-          BUILD_ENGINE=${BUILD_ENGINE_DATABASE}?options=--search_path%3D${BUILD_ENGINE_SCHEMA},public
-          echo "BUILD_ENGINE=$BUILD_ENGINE" >> "$GITHUB_ENV"
-
       - name: Finish container setup ...
         working-directory: ./
         run: ./bash/docker_container_setup.sh
+
+      - name: Set build environment variables
+        working-directory: ./
+        run: ./bash/build_env_setup.sh
 
       - name: 1. dataloading for EDM builds
         run: ./devdb.sh dataloading edm && ls -l

--- a/.github/workflows/stale_builds.yml
+++ b/.github/workflows/stale_builds.yml
@@ -14,10 +14,11 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      GHP_TOKEN: ${{ github.GITHUB_TOKEN }}
+      BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
     steps:
       - uses: actions/checkout@v3
       - name: Delete build artifacts
         run: |
-          # TODO add functionality
-          # python3 -m dcpy.builds.clean_artifacts
-          echo "TODO add functionality"
+          python3 -m dcpy.builds.clean_artifacts

--- a/dcpy/builds/__init__.py
+++ b/dcpy/builds/__init__.py
@@ -1,0 +1,8 @@
+BUILD_REPO = "data-engineering"
+BUILD_DBS = [
+    "db-template",
+    "db-cpdb",
+    "db-devdb",
+    "db-pluto",
+    "kpdb",
+]

--- a/dcpy/builds/clean_artifacts.py
+++ b/dcpy/builds/clean_artifacts.py
@@ -1,0 +1,49 @@
+from dcpy.utils import postgres
+from dcpy.utils.logging import logger
+from dcpy.connectors import github
+from dcpy.connectors.edm import build_metadata
+
+from . import BUILD_REPO, BUILD_DBS
+
+
+def get_active_build_names() -> list:
+    # all remote branches
+    branches = github.get_branches(repo=BUILD_REPO)
+    branch_build_names = sorted(
+        [build_metadata.build_name("branch", branch) for branch in branches]
+    )
+    logger.info(f"Valid branch build names: {branch_build_names}")
+
+    # all open PR numbers
+    pull_requests = github.get_pull_requests(repo=BUILD_REPO)
+    pr_build_names = sorted(
+        [build_metadata.build_name("pull_request", pr) for pr in pull_requests]
+    )
+    logger.info(f"Valid PR build names: {pr_build_names}")
+
+    return pr_build_names + branch_build_names
+
+
+def delete_stale_builds(active_build_names: list):
+    for database in BUILD_DBS:
+        pg_client_default = postgres.PostgresClient(
+            schema=postgres.DEFAULT_POSTGRES_SCHEMA,
+            database=database,
+        )
+        existing_build_schemas = pg_client_default.get_build_schemas()
+
+        for active_name in active_build_names:
+            if active_name not in existing_build_schemas:
+                logger.info(f"No build schema named {database}.{active_name}")
+
+        for build_schema in existing_build_schemas:
+            if build_schema not in active_build_names:
+                logger.warning(f"Dropping schema {database}.{build_schema}")
+                pg_client_default.drop_schema(build_schema)
+            else:
+                logger.info(f"Keeping schema {database}.{build_schema}")
+
+
+if __name__ == "__main__":
+    active_build_names = get_active_build_names()
+    delete_stale_builds(active_build_names)

--- a/dcpy/connectors/edm/build_metadata.py
+++ b/dcpy/connectors/edm/build_metadata.py
@@ -5,10 +5,18 @@ import pytz
 from dcpy.utils import git
 
 
-def build_name() -> str:
+def build_name(event: str | None = None, branch: str | None = None) -> str:
     if os.environ.get("BUILD_ENGINE_SCHEMA"):
         return os.environ["BUILD_ENGINE_SCHEMA"]
-    return git.run_name()
+
+    event = git.event_name() if not event else event
+    branch = git.branch() if not branch else branch
+    if event == "pull_request":
+        prefix = "pr"
+    else:
+        prefix = "run"
+    suffix = branch.replace("-", "_")
+    return f"{prefix}_{suffix}"
 
 
 def generate() -> dict[str, str]:

--- a/dcpy/connectors/github.py
+++ b/dcpy/connectors/github.py
@@ -37,6 +37,12 @@ def get_branches(repo: str, branches_blacklist: List[str] | None = None):
     return [b for b in all_branches if b not in branches_blacklist]
 
 
+def get_pull_requests(repo: str) -> list[str]:
+    url = f"https://api.github.com/repos/nycplanning/{repo}/pulls?state=open"
+    response = requests.get(url).json()
+    return [str(pr_info["number"]) for pr_info in response]
+
+
 def get_workflow(repo: str, name: str):
     url = f"{BASE_URL}/{repo}/actions/workflows/{name}"
     r = requests.get(url, headers=headers)

--- a/dcpy/utils/git.py
+++ b/dcpy/utils/git.py
@@ -55,12 +55,3 @@ def action_url() -> str:
     if event_name() == "local":
         return f"local_{branch}_{username}"
     return f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
-
-
-def run_name() -> str:
-    if event_name() == "pull_request":
-        prefix = "pr"
-    else:
-        prefix = "run"
-    suffix = branch().replace("-", "_")
-    return f"{prefix}_{suffix}"


### PR DESCRIPTION
resolves #307 

## approach
- compile the list of active build names: all remote branch names and all open PR numbers
  - uses `build_metadata.build_name()` to go from the branch/PR to the build name
- in all build DBs, delete all schemas that aren't in the list of active builds names

## tests
[successful action run](https://github.com/NYCPlanning/data-engineering/actions/runs/6656198668/job/18088194967) deleting stale TDB schemas
- before:
  - <img width="321" alt="Screenshot 2023-10-26 at 11 01 12 AM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/d278d209-e4af-41e6-9c0e-257cb561acc6">
- after:
  - <img width="340" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/4b12f619-6e1d-45e5-8275-81c7a23cc851">
