### PR TITLE
add action to compile python requirements

### DIFF
--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -3,6 +3,7 @@ on:
   schedule: 
     - cron: 00 00 * * *
   workflow_dispatch:
+  push:
 
 jobs:
   compile_requirements:
@@ -30,4 +31,4 @@ jobs:
           commit-message: automated compiling of python requirements
           add-paths: python/
           title: Compile python requirements
-          author: GitHub <noreply@github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -1,0 +1,33 @@
+name: Compile python requirements
+on:
+  schedule: 
+    - cron: 00 00 * * *
+  workflow_dispatch:
+
+jobs:
+  compile_requirements:
+    name: Compile requirements and commit changes
+    runs-on: ubuntu-22.04
+    container:
+      image: python:3.11-slim
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install latest gdal to pin python version, setup git
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update && apt-get -y install libgdal-dev git
+
+      - uses: actions/checkout@v4
+
+      - name: Compile requirements
+        run: ./bash/compile_python_packages.sh
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: automated compiling of python requirements
+          add-paths: python/
+          title: Compile python requirements
+          author: GitHub <noreply@github.com>

--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -3,7 +3,6 @@ on:
   schedule: 
     - cron: 00 00 * * *
   workflow_dispatch:
-  push:
 
 jobs:
   compile_requirements:

--- a/bash/compile_python_packages.sh
+++ b/bash/compile_python_packages.sh
@@ -2,7 +2,7 @@
 #
 # Dev script to compile python packages from a requirements.in file to a requirements.txt file.
 set -e
-path_to_requirements="${1:-"."}"
+path_to_requirements="python"
 RELATIVE_SCRIPTPATH=$(realpath --relative-to="${PWD}" "$0")
 
 # Update and install packages used to compile requirements


### PR DESCRIPTION
#320, brought up again in @alexrichey 's comment [here](https://github.com/NYCPlanning/data-engineering/pull/320#pullrequestreview-1700032458)

Doing PR rather than direct commit because testing is nice, especially if we eventually unpin more packages as described in #320. See #324, created by [this action](https://github.com/NYCPlanning/data-engineering/actions/runs/6657880581). Currently set to run nightly, so we can just hit a button in the morning if it looks good

Speaking of which... should I unpin packages as part of this? I'm down to move to more bleeding edge stuff.