### PR TITLE
Assign PRs to us when compiling requirements

### DIFF
--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -31,3 +31,4 @@ jobs:
           add-paths: python/
           title: Compile python requirements
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          assignees: fvankrieken, damonmcc, alexrichey, sf-dcp


### PR DESCRIPTION
Per @alexrichey's comment [here](https://github.com/NYCPlanning/data-engineering/pull/321#discussion_r1373579031). 

See #325 as example generated PR. 

"Assignee" seemed more right in theme than "Reviewer"