### PR TITLE
Fix path issues in data library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,10 +63,7 @@ jobs:
               - python/**
             data-library:
               - .github/workflows/data_library_test.yml
-              - data-library/**.py
-              - data-library/**.toml
-              - data-library/**.yml
-              - docker/**
+              - data-library/**
               - python/**
             qa:
               - apps/qa/**

--- a/data-library/Dockerfile
+++ b/data-library/Dockerfile
@@ -1,10 +1,14 @@
 FROM python:3.11-slim
 
-COPY . /library/
+COPY . /library
 
-WORKDIR /library/
+WORKDIR /library
 
 RUN ./library.sh setup
+
+WORKDIR /
+
+RUN rm -rf library
 
 # GDAL for python required env variables
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal

--- a/data-library/library.sh
+++ b/data-library/library.sh
@@ -21,7 +21,7 @@ function setup {
     apt-get install -y python3-pip python3-distutils gdal-bin libgdal-dev curl git unzip
     apt-get -y install --reinstall build-essential
     
-    pip install -e . -c ${1:-constraints.txt}
+    pip install . -c ${1:-constraints.txt}
 
     export CPLUS_INCLUDE_PATH=/usr/include/gdal
     export C_INCLUDE_PATH=/usr/include/gdal

--- a/data-library/library/archive.py
+++ b/data-library/library/archive.py
@@ -78,20 +78,19 @@ class Archive:
         ```
         """
 
-        _path = f"{Path(__file__).parent}/templates/{name}.yml"
-        if name:
-            name = name
-            path = _path
-        elif path:
-            name = os.path.basename(path).split(".")[0]
-            path = path
+        if path:
+            name = name or os.path.basename(path).split(".")[0]
+        elif name:
+            path = f"{Path(__file__).parent}/templates/{name}.yml"
         else:
             raise Exception(
                 "Please specify either name of the dataset or path to the config file"
             )
 
         if not os.path.isfile(path):
-            raise FileNotFoundError(f'Template file "{path}" not found.')
+            raise FileNotFoundError(
+                f"Template file '{path}' not found. Try providing path explicitly if you've only provided name"
+            )
 
         # Get ingestor by format
         ingestor_of_format = getattr(self.ingestor, output_format)

--- a/data-library/pyproject.toml
+++ b/data-library/pyproject.toml
@@ -30,3 +30,6 @@ library = "library.cli:run"
 
 [tool.setuptools.packages.find]
 include = ["library*"]
+
+[tool.setuptools.package-data]
+library = ["templates/*.yml"]


### PR DESCRIPTION
## Path issue

So I caused a little issue in #316 

You can either provide the name of a dataset, the path to a yml file, or both.

The logic before was
- check if name is provided AND there exists a template within data library, use that
- if no name provided, but path provided, use path provided

I interpreted this as either a name or a path should be provided, and "cleaned up" the if/else clause. However, this caused an issue if both were provided, as the ordering tries "name" first and assumes provided "path" isn't used in that case.

So logic is now as it should be - if path is provided, use that. If it isn't and a name is provided, attempt to use a yml provided by data-library in the templates folder

## Use of templates at runtime
I also wanted to clean up referencing yml files that exist within data library when its installed. So I removed the editable flag from the installs for the docker images and modified pyproject.toml so that the yml files are packaged when it's installed

[Passing single run (not using docker image, just local install/code)](https://github.com/NYCPlanning/data-engineering/actions/runs/6695152691)

[Passing publishing of docker image](https://github.com/NYCPlanning/data-engineering/actions/runs/6695233536)

[Passing run using staging docker image](https://github.com/NYCPlanning/data-engineering/actions/runs/6694243158)