### PR TITLE
move Tax Block to appropriate position

### DIFF
--- a/products/zoningtaxlots/sql/export.sql
+++ b/products/zoningtaxlots/sql/export.sql
@@ -1,22 +1,21 @@
 -- export zoning tax lot database with desired headings
 DROP TABLE IF EXISTS dcp_zoning_taxlot_export;
-CREATE TABLE dcp_zoning_taxlot_export AS (
-    SELECT
-        boroughcode AS "Borough Code",
-        taxlot AS "Tax Lot",
-        bbl AS "BBL",
-        zoningdistrict1 AS "Zoning District 1",
-        zoningdistrict2 AS "Zoning District 2",
-        zoningdistrict3 AS "Zoning District 3",
-        zoningdistrict4 AS "Zoning District 4",
-        commercialoverlay1 AS "Commercial Overlay 1",
-        commercialoverlay2 AS "Commercial Overlay 2",
-        specialdistrict1 AS "Special District 1",
-        specialdistrict2 AS "Special District 2",
-        specialdistrict3 AS "Special District 3",
-        limitedheightdistrict AS "Limited Height District",
-        zoningmapnumber AS "Zoning Map Number",
-        zoningmapcode AS "Zoning Map Code",
-        trunc(taxblock::numeric) AS "Tax Block"
-    FROM dcp_zoning_taxlot
-);
+CREATE TABLE dcp_zoning_taxlot_export AS
+SELECT
+    boroughcode AS "Borough Code",
+    trunc(taxblock::numeric) AS "Tax Block",
+    taxlot AS "Tax Lot",
+    bbl AS "BBL",
+    zoningdistrict1 AS "Zoning District 1",
+    zoningdistrict2 AS "Zoning District 2",
+    zoningdistrict3 AS "Zoning District 3",
+    zoningdistrict4 AS "Zoning District 4",
+    commercialoverlay1 AS "Commercial Overlay 1",
+    commercialoverlay2 AS "Commercial Overlay 2",
+    specialdistrict1 AS "Special District 1",
+    specialdistrict2 AS "Special District 2",
+    specialdistrict3 AS "Special District 3",
+    limitedheightdistrict AS "Limited Height District",
+    zoningmapnumber AS "Zoning Map Number",
+    zoningmapcode AS "Zoning Map Code"
+FROM dcp_zoning_taxlot;


### PR DESCRIPTION
Originally changed by sqlfluff [here](https://github.com/NYCPlanning/data-engineering/commit/7f5b46e9a73626b82e3efc9a9e3ed62abffb9015#diff-3fce2a0ab0be7926d4b61a87a3b1136da5eb2a7ea8478d6b5c33f1eb3d600282). My fault for not catching the reordered columns in export