### PR TITLE
Add checkbook nyc script to data library

### DIFF
--- a/.github/workflows/data_library_single.yml
+++ b/.github/workflows/data_library_single.yml
@@ -59,5 +59,5 @@ jobs:
           compress: ${{ github.event.inputs.compress == 'true' && '--compress' || '' }}
         run: |
           library archive --name ${{ github.event.inputs.dataset }} -o pgdump $export $compress $latest $version
+          # library archive --name ${{ github.event.inputs.dataset }} -o shapefile $export $compress $latest $version
           library archive --name ${{ github.event.inputs.dataset }} -o csv $export $compress $latest $version
-        # library archive --name ${{ github.event.inputs.dataset }} -o shapefile $export $compress $latest $version

--- a/.github/workflows/data_library_single.yml
+++ b/.github/workflows/data_library_single.yml
@@ -59,5 +59,5 @@ jobs:
           compress: ${{ github.event.inputs.compress == 'true' && '--compress' || '' }}
         run: |
           library archive --name ${{ github.event.inputs.dataset }} -o pgdump $export $compress $latest $version
-          library archive --name ${{ github.event.inputs.dataset }} -o shapefile $export $compress $latest $version
           library archive --name ${{ github.event.inputs.dataset }} -o csv $export $compress $latest $version
+        # library archive --name ${{ github.event.inputs.dataset }} -o shapefile $export $compress $latest $version

--- a/data-library/library/script/nycoc_checkbook.py
+++ b/data-library/library/script/nycoc_checkbook.py
@@ -1,0 +1,455 @@
+import xml.etree.ElementTree as ET
+import requests
+import pandas as pd
+import datetime as dt
+import pytz
+import calendar
+from pathlib import Path
+import shutil
+import sys
+import time
+import random
+
+from . import df_to_tempfile
+
+from typing import Literal, TypedDict, Any
+
+api_endpoint = "https://www.checkbooknyc.com/api"
+
+TYPE_OF_DATA = Literal[
+    "Contracts",
+    "Budget",
+    "Revenue",
+    "Payroll",
+    "Spending",
+    "Spending_OGE",
+    "Contracts_OGE",
+    "Spending_NYCHA",
+    "Contracts_NYCHA",
+    "Payroll_NYCHA",
+]
+
+DEFAULT_RECORDS_FROM = "1"
+DEFAULT_MAX_RECORDS = "20000"
+
+DEFAULT_DATE_FORMAT = "%Y-%m-%d"
+DEFAULT_START_PERIOD = dt.date(2010, 1, 1).strftime(DEFAULT_DATE_FORMAT)
+DEFAULT_END_PERIOD = dt.date.today().strftime(DEFAULT_DATE_FORMAT)
+
+DEFAULT_DATA_PATH = Path(__file__).resolve().parent / "capital_spending_data"
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15",
+]
+# user_agent = random.choice(USER_AGENTS)   # TODO: uncomment or remove completely
+user_agent = None
+
+
+class CriteriaValue(TypedDict):
+    name: str
+    type: Literal["value"]
+    value: str
+
+
+class CriteriaRange(TypedDict):
+    name: str
+    type: Literal["range"]
+    start: str
+    end: str
+
+
+class Scriptor:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def ingest(
+        self,
+        user_agent: str | None = None,
+        type_of_data: TYPE_OF_DATA = "Spending",
+        records_from: str = DEFAULT_RECORDS_FROM,
+        max_records: str = DEFAULT_MAX_RECORDS,
+        response_columns: list[str] | None = None,
+        search_criteria: list[CriteriaValue | CriteriaRange] | None = None,
+        num_retries: int = 3,
+        data_dir: Path = DEFAULT_DATA_PATH,
+        start_period: str = DEFAULT_START_PERIOD,
+        end_period: str = DEFAULT_END_PERIOD,
+    ) -> pd.DataFrame:
+        """Fetches data from Checkbook NYC API based on input parameters, saves it
+        locally in parquet files organized by months, and returns data in a pandas DataFrame.
+        """
+        create_data_dir(data_dir)
+
+        search_criteria = validate_search_criteria(search_criteria)
+
+        month_range = generate_monthly_ranges(start_period, end_period)
+
+        for month in month_range:
+            start, end = month
+            month_criteria: CriteriaRange = {
+                "name": "issue_date",
+                "type": "range",
+                "start": start,
+                "end": end,
+            }
+            search_criteria_modified = search_criteria + [month_criteria]
+            try:
+                df = get_data(
+                    user_agent=user_agent,
+                    type_of_data=type_of_data,
+                    records_from=records_from,
+                    max_records=max_records,
+                    response_columns=response_columns,
+                    search_criteria=search_criteria_modified,
+                    num_retries=num_retries,
+                )
+                print(f"There are {len(df)} records for period {start}-{end}.")
+            except Exception as e:
+                print(
+                    f"Unable to extract data for period: {start}-{end}...Exception: {e}"
+                )
+                df = None
+
+            if df is not None:
+                filename = f"{start}-{end}_checkbook.parquet"
+                filepath = str(data_dir / filename)
+                df.to_parquet(filepath)
+
+            # pausing before next request: we don't want to overload API
+            time.sleep(random.randint(10, 15))
+
+        try:
+            data = read_parquet_files_to_df(data_dir)
+            print("Successfully ingested data.")
+        except ValueError as e:
+            print(
+                f"No data to ingest for period {start_period}-{end_period}. Error: {e}"
+            )
+            sys.exit(1)
+
+        return data
+
+    def runner(self) -> str:
+        df = self.ingest(
+            user_agent=user_agent,
+            search_criteria=[
+                {"name": "spending_category", "type": "value", "value": "cc"}
+            ],
+        )
+        local_path = df_to_tempfile(df)
+        return local_path
+
+
+def get_data(
+    user_agent: str | None,
+    type_of_data: TYPE_OF_DATA,
+    records_from: str,
+    max_records: str,
+    response_columns: list[str] | None,
+    search_criteria: list[CriteriaValue | CriteriaRange],
+    num_retries: int,
+) -> pd.DataFrame:
+    """
+    Gets data from API and returns it in pandas dataframe. Makes multiple API calls
+    if total number of records is greater than max_records.
+    """
+    all_records = False
+    record_count = 0
+    df_list = []
+    while not all_records:
+        response = get_response(
+            user_agent=user_agent,
+            type_of_data=type_of_data,
+            records_from=records_from,
+            max_records=max_records,
+            response_columns=response_columns,
+            search_criteria=search_criteria,
+            num_retries=num_retries,
+        )
+        if response is None:
+            raise Exception("Error occurred when sending request to API.")
+        xml_response = response.text
+
+        # get total record count from response string
+        root = ET.fromstring(xml_response)
+        records_tag = root.find("./result_records/record_count")
+        if records_tag is None or records_tag.text is None:
+            raise Exception("Unable to extract total record count")
+        total_record_count = int(records_tag.text)
+        df = pd.read_xml(
+            xml_response,
+            xpath=f"./result_records/{type_of_data.lower()}_transactions/*",
+        )
+        df_list.append(df)
+        record_count += len(df)
+
+        # if all expected records are received, update all_records. Otherwise, continue making calls
+        if (record_count + int(records_from) - 1) == total_record_count:
+            all_records = True
+        else:
+            records_from = str(int(records_from) + record_count)
+            time.sleep(random.randint(10, 15))
+
+    result_df = pd.concat(df_list)
+
+    return result_df
+
+
+def get_response(
+    user_agent: str | None,
+    type_of_data: TYPE_OF_DATA,
+    records_from: str,
+    max_records: str,
+    response_columns: list[str] | None,
+    search_criteria: list[CriteriaValue | CriteriaRange],
+    num_retries: int,
+) -> requests.Response | None:
+    """
+    Makes a request call to api and returns Response object.
+    """
+    request_dict = create_request_dict(
+        type_of_data, records_from, max_records, response_columns, search_criteria
+    )
+    xml = dict_to_xml_obj(request_dict)
+    xml_string = xml_obj_to_string(xml)
+    headers = {"Content-Type": "application/xml"}
+    if user_agent:
+        headers["User-Agent"] = user_agent
+
+    for n in range(num_retries):
+        try:
+            response = requests.post(url=api_endpoint, data=xml_string, headers=headers)
+            response.raise_for_status()
+            break
+        except requests.exceptions.RequestException as e:
+            response = None
+            # user_agent = random.choice(USER_AGENTS)   # TODO: uncomment or remove completely
+            timestamp = (
+                dt.datetime.utcnow()
+                .astimezone(pytz.timezone("US/Eastern"))
+                .strftime("%Y-%m-%d %H:%M")
+            )
+            print(
+                f"Failed to get a response from api (try # {n + 1}/{num_retries}) at {timestamp}."
+                f"\nRequest body: \n{xml_string}"
+                f"\nException: {e}"
+            )
+            # pausing before next request: we don't want to overload API
+            time.sleep(random.randint(15, 20))
+
+    return response
+
+
+def create_request_dict(
+    type_of_data: TYPE_OF_DATA,
+    records_from: str,
+    max_records: str,
+    response_columns: list[str] | None,
+    search_criteria: list[CriteriaValue | CriteriaRange],
+) -> dict:
+    """
+    Creates a request body in dictionary format.
+
+    Sample output dict: {
+        'request': {
+            'type_of_data':'Spending',
+            'records_from': '1',
+            'response_columns': [
+                {'column': 'agency'},
+                {'column': 'expense_category'}
+            ]
+        }
+    }
+    """
+    request_dict: dict[str, Any] = {
+        "request": {
+            "type_of_data": type_of_data,
+            "records_from": records_from,
+            "max_records": max_records,
+        }
+    }
+    if response_columns:
+        request_dict["request"]["response_columns"] = [
+            {"column": col} for col in response_columns
+        ]
+    if search_criteria:
+        request_dict["request"]["search_criteria"] = [
+            {"criteria": criteria_item} for criteria_item in search_criteria
+        ]
+
+    return request_dict
+
+
+def dict_to_xml_obj(request_dict: dict) -> ET.Element:
+    """
+    Converts a dictionary into an xml.etree.ElementTree with a tree-like structure.
+    Input dict is expected to have a single root key.
+
+    Returns:
+        xml.etree.ElementTree.Element: The root element of the generated XML tree.
+
+    Example:
+    ```python
+    >>> sample_dict = {
+        'request': {
+            'type_of_data': 'Spending',
+            'records_from': '1',
+            'response_columns': [
+                {'column': 'agency'},
+                {'column': 'expense_category'}
+            ],
+            'search_criteria': [
+                {'criteria': {
+                    'name': 'issue_date',
+                    'type': 'range',
+                    'start': '2023-01-01',
+                    'end': '2024-01-01'
+                    }
+                }
+            ]
+        }
+    }
+    >>> xml_tree = dict_to_xml(Sample_dict)
+    >>> xml_string = ET.tostring(xml_tree, encoding='unicode', method='xml')
+    >>> print(xml_string)
+
+    <request>
+        <type_of_data>Spending</type_of_data>
+        <records_from>1</records_from>
+        <response_columns>
+            <column>agency</column>
+        </response_columns>
+        <response_columns>
+            <column>expense_category</column>
+        </response_columns>
+        <search_criteria>
+            <criteria>
+                <name>issue_date</name>
+                <type>range</type>
+                <start>2023-01-01</start>
+                <end>2024-01-01</end>
+            </criteria>
+        </search_criteria>
+    </request>
+    ```python
+    """
+    assert len(request_dict) == 1, "Request_dict must have a root."
+    parent_key = next(iter(request_dict))
+    parent_val = request_dict[parent_key]
+    parent_node = ET.Element(parent_key)
+
+    if isinstance(parent_val, str):
+        parent_node.text = parent_val
+        return parent_node
+    elif isinstance(parent_val, list):
+        for list_item in parent_val:
+            if len(list_item) != 0:
+                parent_node.append(dict_to_xml_obj(list_item))
+        return parent_node
+    else:
+        for child_key, child_val in parent_val.items():
+            if len(child_val) != 0:
+                parent_node.append(dict_to_xml_obj({child_key: child_val}))
+        return parent_node
+
+
+def xml_obj_to_string(xml_obj: ET.Element) -> str:
+    """Returns a XML string representation of python xml object."""
+    return ET.tostring(xml_obj, encoding="utf-8").decode("utf-8")
+
+
+def generate_monthly_ranges(
+    start_period: str, end_period: str, date_format: str = DEFAULT_DATE_FORMAT
+) -> list[tuple[str, str]]:
+    """
+    Generate a list of tuples representing monthly date ranges within the specified time period.
+
+    Example:
+    ```python
+    >>> result = generate_monthly_ranges("2023-07-08", "2023-08-27")
+    >>> print(result)
+    [("2023-07-08", "2023-07-30"), ("2023-08-01", "2023-08-27")]
+    ```python
+    """
+
+    start_period_dt = dt.datetime.strptime(start_period, date_format)
+    end_period_dt = dt.datetime.strptime(end_period, date_format)
+
+    # if start date is later than end date, flip them
+    if start_period_dt > end_period_dt:
+        start_period_dt, end_period_dt = end_period_dt, start_period_dt
+
+    start_month_date = start_period_dt
+    _, num_days = calendar.monthrange(start_month_date.year, start_month_date.month)
+    end_month_date = start_month_date.replace(day=num_days)
+
+    monthly_ranges = []
+
+    while end_month_date <= end_period_dt:
+        monthly_ranges.append(
+            (
+                start_month_date.strftime(date_format),
+                end_month_date.strftime(date_format),
+            )
+        )
+        start_month_date = end_month_date + dt.timedelta(days=1)
+        _, num_days = calendar.monthrange(start_month_date.year, start_month_date.month)
+        end_month_date = start_month_date.replace(day=num_days)
+
+    if end_month_date > end_period_dt:
+        monthly_ranges.append(
+            (
+                start_month_date.strftime(date_format),
+                end_period_dt.strftime(date_format),
+            )
+        )
+
+    return monthly_ranges
+
+
+def create_data_dir(data_path: Path = DEFAULT_DATA_PATH) -> None:
+    """Creates a local data directory."""
+    if data_path.exists():
+        shutil.rmtree(data_path)
+    try:
+        data_path.mkdir(parents=False, exist_ok=False)
+    except Exception as err:
+        print(f"❌ Unable to create data directory.")
+        raise err
+
+
+def read_parquet_files_to_df(data_dir: Path) -> pd.DataFrame:
+    """
+    Reads Parquet files from a given data directory and concatenates
+    them into a single pandas DataFrame.
+    """
+    df = pd.concat(
+        pd.read_parquet(parquet_file) for parquet_file in data_dir.glob("*.parquet")
+    )
+
+    return df
+
+
+def validate_search_criteria(
+    search_criteria: list[CriteriaValue | CriteriaRange] | None,
+) -> list[CriteriaValue | CriteriaRange]:
+    """Validate search criteria. If it is None, return search_criteria = []."""
+
+    if not search_criteria:
+        search_criteria = []
+    else:
+        for criteria_dict in search_criteria:
+            if (
+                criteria_dict["type"] == "range"
+                and criteria_dict["name"] == "issue_date"
+            ):
+                raise Exception(
+                    "issue_date criteria was found in search_criteria. Use start_period and end_period instead."
+                )
+    return search_criteria

--- a/data-library/library/templates/nycoc_checkbook.yml
+++ b/data-library/library/templates/nycoc_checkbook.yml
@@ -1,34 +1,27 @@
 dataset:
   name: &name nycoc_checkbook
   version: "{{ version }}"
-  acl: public-read 
-  
+  acl: public-read
+
   source:
-    url:
-      path: .library/datasources/checkbook_citywide_agencies.csv
-      subpath: ""
-
-    geometry:
-      SRS: null
-      type: NONE
-
+    script: *name
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
-
-  destination: 
-    name: *name
-
     geometry:
       SRS: null
       type: NONE
 
-    options: 
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    options:
       - "OVERWRITE=YES"
       - "PRECISION=NO"
-
     fields: []
-    sql: null 
+    sql: null
 
   info:
     description: |

--- a/data-library/pyproject.toml
+++ b/data-library/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "urllib3",
     "usaddress",
     "xlrd",
+    "pyarrow",
 ]
 
 [project.scripts]

--- a/data-library/tests/library/script/test_nycoc_checkbook.py
+++ b/data-library/tests/library/script/test_nycoc_checkbook.py
@@ -1,0 +1,107 @@
+import pytest
+from library.script import nycoc_checkbook
+
+
+@pytest.mark.parametrize(
+    "input_params, expected_output",
+    [
+        (
+            {
+                "type_of_data": "Spending_OGE",
+                "max_records": "100",
+                "records_from": "1",
+                "response_columns": None,
+                "search_criteria": None,
+            },
+            {
+                "request": {
+                    "type_of_data": "Spending_OGE",
+                    "records_from": "1",
+                    "max_records": "100",
+                }
+            },
+        ),
+        (
+            {
+                "type_of_data": "Spending",
+                "max_records": "20000",
+                "records_from": "100",
+                "response_columns": ["column1", "column2"],
+                "search_criteria": [
+                    {"name": "column1", "type": "value", "value": "100"},
+                    {"name": "column2", "type": "range", "start": "1", "end": "100"},
+                ],
+            },
+            {
+                "request": {
+                    "type_of_data": "Spending",
+                    "records_from": "100",
+                    "max_records": "20000",
+                    "response_columns": [{"column": "column1"}, {"column": "column2"}],
+                    "search_criteria": [
+                        {
+                            "criteria": {
+                                "name": "column1",
+                                "type": "value",
+                                "value": "100",
+                            }
+                        },
+                        {
+                            "criteria": {
+                                "name": "column2",
+                                "type": "range",
+                                "start": "1",
+                                "end": "100",
+                            }
+                        },
+                    ],
+                }
+            },
+        ),
+    ],
+)
+def test_create_request_dict(input_params, expected_output):
+    actual_output = nycoc_checkbook.create_request_dict(**input_params)
+    assert actual_output == expected_output
+
+
+def test_dict_to_xml_obj():
+    request_dict = {
+        "request": {
+            "type_of_data": "Spending",
+            "records_from": "100",
+            "max_records": "20000",
+            "response_columns": [{"column": "column1"}, {"column": "column2"}],
+            "search_criteria": [
+                {
+                    "criteria": {
+                        "name": "column2",
+                        "type": "range",
+                        "start": "1",
+                        "end": "100",
+                    }
+                }
+            ],
+        }
+    }
+    xml_obj = nycoc_checkbook.dict_to_xml_obj(request_dict)
+
+    assert "request" == xml_obj.tag
+    assert len(request_dict["request"]) == len(xml_obj.findall("*"))
+    assert len(request_dict["request"]["response_columns"]) == len(
+        xml_obj.findall("./response_columns/")
+    )
+
+
+# TODO make this function more robust by testing for input/output date formats
+def test_generate_monthly_ranges():
+    assert nycoc_checkbook.generate_monthly_ranges("2023-2-1", "2023-2-7") == [
+        ("2023-02-01", "2023-02-07")
+    ]
+    assert nycoc_checkbook.generate_monthly_ranges("2023-3-1", "2023-04-28") == [
+        ("2023-03-01", "2023-03-31"),
+        ("2023-04-01", "2023-04-28"),
+    ]
+    assert nycoc_checkbook.generate_monthly_ranges("2023-2-8", "2023-2-1") == [
+        ("2023-02-01", "2023-02-08")
+    ]

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -6,7 +6,7 @@
 #
 affine==2.4.0
     # via rasterio
-altair==5.1.2
+altair==5.2.0
     # via streamlit
 annotated-types==0.6.0
     # via pydantic
@@ -26,20 +26,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.29.6
+boto3==1.33.1
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs==1.29.6
+boto3-stubs==1.29.7
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.32.6
+botocore==1.33.1
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.32.6
+botocore-stubs==1.33.1
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -96,7 +96,7 @@ coverage==7.3.2
     # via
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   moto
     #   msal
@@ -153,7 +153,7 @@ iniconfig==2.0.0
     # via pytest
 ipykernel==6.22.0
     # via -r python/requirements.in
-ipython==8.18.0
+ipython==8.18.1
     # via ipykernel
 jedi==0.19.1
     # via ipython
@@ -221,7 +221,7 @@ mypy==1.5.1
     # via
     #   -r python/requirements.in
     #   sqlalchemy-stubs
-mypy-boto3-s3==1.29.5
+mypy-boto3-s3==1.29.7
     # via boto3-stubs
 mypy-extensions==1.0.0
     # via
@@ -312,7 +312,9 @@ pure-eval==0.2.2
 py-partiql-parser==0.4.2
     # via moto
 pyarrow==14.0.1
-    # via streamlit
+    # via
+    #   -r python/requirements.in
+    #   streamlit
 pycparser==2.21
     # via cffi
 pydantic==2.3.0
@@ -399,7 +401,7 @@ rpds-py==0.13.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.7.0
+s3transfer==0.8.0
     # via boto3
 scikit-learn==1.3.2
     # via mapclassify
@@ -462,7 +464,7 @@ tqdm==4.66.1
     # via
     #   -r python/requirements.in
     #   sqlfluff
-traitlets==5.13.0
+traitlets==5.14.0
     # via
     #   comm
     #   ipykernel
@@ -480,7 +482,7 @@ types-beautifulsoup4==4.12.0.7
     # via -r python/requirements.in
 types-html5lib==1.1.11.15
     # via types-beautifulsoup4
-types-psycopg2==2.9.21.17
+types-psycopg2==2.9.21.18
     # via -r python/requirements.in
 types-python-dateutil==2.8.19.14
     # via -r python/requirements.in

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -26,6 +26,7 @@ pandas-stubs==1.5.3.230321
 plotly==5.*
 psycopg2-binary==2.9.5
 types-psycopg2
+pyarrow
 pydantic==2.3.0
 pytest==7.3.0
 pytest-cov==4.0.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@
 #
 affine==2.4.0
     # via rasterio
-altair==5.1.2
+altair==5.2.0
     # via streamlit
 annotated-types==0.6.0
     # via pydantic
@@ -26,20 +26,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.29.6
+boto3==1.33.1
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs[s3]==1.29.6
+boto3-stubs[s3]==1.29.7
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.32.6
+botocore==1.33.1
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.32.6
+botocore-stubs==1.33.1
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -96,7 +96,7 @@ coverage[toml]==7.3.2
     # via
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   moto
     #   msal
@@ -153,7 +153,7 @@ iniconfig==2.0.0
     # via pytest
 ipykernel==6.22.0
     # via -r python/requirements.in
-ipython==8.18.0
+ipython==8.18.1
     # via ipykernel
 jedi==0.19.1
     # via ipython
@@ -221,7 +221,7 @@ mypy==1.5.1
     # via
     #   -r python/requirements.in
     #   sqlalchemy-stubs
-mypy-boto3-s3==1.29.5
+mypy-boto3-s3==1.29.7
     # via boto3-stubs
 mypy-extensions==1.0.0
     # via
@@ -312,7 +312,9 @@ pure-eval==0.2.2
 py-partiql-parser==0.4.2
     # via moto
 pyarrow==14.0.1
-    # via streamlit
+    # via
+    #   -r python/requirements.in
+    #   streamlit
 pycparser==2.21
     # via cffi
 pydantic==2.3.0
@@ -399,7 +401,7 @@ rpds-py==0.13.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.7.0
+s3transfer==0.8.0
     # via boto3
 scikit-learn==1.3.2
     # via mapclassify
@@ -462,7 +464,7 @@ tqdm==4.66.1
     # via
     #   -r python/requirements.in
     #   sqlfluff
-traitlets==5.13.0
+traitlets==5.14.0
     # via
     #   comm
     #   ipykernel
@@ -480,7 +482,7 @@ types-beautifulsoup4==4.12.0.7
     # via -r python/requirements.in
 types-html5lib==1.1.11.15
     # via types-beautifulsoup4
-types-psycopg2==2.9.21.17
+types-psycopg2==2.9.21.18
     # via -r python/requirements.in
 types-python-dateutil==2.8.19.14
     # via -r python/requirements.in


### PR DESCRIPTION
Resolves #312.

## Notes: 

* Various links: 

> Checkbook [API](https://github.com/NYCComptroller/Checkbook/tree/master)
> Checkbook NYC Github [link](https://github.com/NYCComptroller/Checkbook/tree/master)
> Checkbook NYC [forum](https://groups.google.com/g/checkbooknyc).

* API receives requests and sends responses in XML format.
* As noted in [here](https://github.com/NYCPlanning/data-engineering/issues/312#issuecomment-1795347678), there are multiple domains such as `Spending` & `Budget`. Response bodies slightly differ among the domains. For example, the tag name for `Spending` transactions in the xml response body is `spending_transactions` and for `Budget` - `budget_transactions`.
* There are about 37 million records in Spending checkbook API. Out of 37 million, ~2 million records are capital projects. The max number of records API returns is 20,000. This limitation needs to be accounted for when choosing an approach to query records. 
* It doesn't seem that the order of records at the source is deterministic; therefore, can't rely on `records_from` field to extract all records. This assumption is based on a call to API with `records_from = 1` parameter (see response result in the csv below). There are transactions from different years; if there was a deterministic order, we wouldn't see recent transactions in the first 20,000 records out of ~2 million total. 
[capital_spending_test.csv](https://github.com/NYCPlanning/data-engineering/files/13340569/capital_spending_test.csv)


## Proposed approach in this PR:
1. create a dictionary with request body to be sent to API. Creating a dictionary hopefully makes code more maintainable and easier to read when creating API requests. The request body may contain criteria to query on (for example, filter for capital project transactions only). 
2. Convert the request dictionary into XML string. 
3. Create a local directory for the data.
4. Query api with `spending_category = “cc”` criteria (cc - capital contracts) and make one call per one month. One month is an arbitrary time period discussed with Damon & Finn which should return under 20k records and not too few. 
5. Save monthly data from each call to a parquet files. 
6. Read in the resulting parquet files into one pandas data frame. 


## Current limitations/possible future improvements:
1. Current logic assumes there are no more than 20k records in any given month. If there are, we will only get the first 20k instead of all records in a month. <--- [ISSUE ADDRESSED]
2. Current logic scrapes the data by month-year, saves it locally into parquet files, and then reads them into a pandas df. If there is not enough disk space for data, the script will probably crash. 
3. Need to write more tests. 
4. We may want to implement incremental approach in updating checkbook data. 
5. Need to test cases where invalid criteria is provided (example, non-existent field).
6. Issues with getting a response from API (see my email to the team [here](https://groups.google.com/g/checkbooknyc/c/hgU1niDG00Y)). Latest GHA run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/6915660322/job/18814835720).

## Other discovered issues:
* The current data-library single runner template `data_library_single.yml` creates a bunch of different output formats. However, if the data doesn't have a geometry column, the GH action fails. [Link](https://github.com/NYCPlanning/data-engineering/actions/runs/6908745294/job/18798663555#step:6:110) to such example. 