### PR TITLE
Fix Failing ZTL -> Pluto Minor build

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -70,4 +70,4 @@ jobs:
     with:
       run_export: true
       create_issue: true
-      recipe_file: recipe-minor.yml
+      recipe_file: recipe-minor


### PR DESCRIPTION
The recipe file for automated pluto minors is erroring with: `FileNotFoundError: [Errno 2] No such file or directory: 'recipe-minor.yml.yml'`

because
`python3 -m dcpy.builds.load --recipe_path ./${{ inputs.recipe_file }}.yml`

Resolves #337 