### PR TITLE
fix duplicate KPDB records

### DIFF
--- a/.github/workflows/knownprojects_build.yml
+++ b/.github/workflows/knownprojects_build.yml
@@ -18,6 +18,8 @@ jobs:
         shell: bash
         working-directory: ./products/knownprojects
     env:
+      BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
+      BUILD_ENGINE_DB: kpdb
       BUILD_ENGINE_DATABASE: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}/kpdb
       BUILD_ENGINE_SCHEMA: build_${{ github.event.pull_request.number || github.ref_name }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
@@ -34,18 +36,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
 
-      - name: Set build environment variables
-        run: |
-          # # replace dashes with underscores to create a valid postgres schema name
-          BUILD_ENGINE_SCHEMA=$(echo ${BUILD_ENGINE_SCHEMA} | tr - _)
-          echo "BUILD_ENGINE_SCHEMA=$BUILD_ENGINE_SCHEMA" >> "$GITHUB_ENV"
-          # set postgres schema search path to prioritize BUILD_ENGINE_SCHEMA
-          BUILD_ENGINE=${BUILD_ENGINE_DATABASE}?options=--search_path%3D${BUILD_ENGINE_SCHEMA},public
-          echo "BUILD_ENGINE=$BUILD_ENGINE" >> "$GITHUB_ENV"
-
-      - name: Setup build environment
+      - name: Finish container setup
         working-directory: ./
         run: ./bash/docker_container_setup.sh
+
+      - name: Set build environment variables
+        working-directory: ./
+        run: ./bash/build_env_setup.sh
 
       - name: dataloading ..
         run: ./bash/01_dataloading.sh

--- a/dcpy/utils/logging.py
+++ b/dcpy/utils/logging.py
@@ -1,6 +1,23 @@
 import logging
 
-logging.basicConfig()
+
+class LoggingHandler(logging.StreamHandler):
+    def __init__(self):
+        super(LoggingHandler, self).__init__()
+
+    def emit(self, record):
+        # Ensure multi-line logs have consistent log formatting
+        messages = record.msg.split("\n")
+        for message in messages:
+            record.msg = message
+            super(LoggingHandler, self).emit(record)
+
+
 logging.root.setLevel(logging.INFO)
 
+handler = LoggingHandler()
+formatter = logging.Formatter(logging.BASIC_FORMAT)
+handler.setFormatter(formatter)
+
 logger = logging.getLogger("dcpy")
+logger.addHandler(handler)

--- a/products/knownprojects/bash/02_build.sh
+++ b/products/knownprojects/bash/02_build.sh
@@ -31,14 +31,17 @@ run_sql_file sql/review_dob.sql
 run_sql_file sql/project_record_ids.sql 
 run_sql_command "VACUUM ANALYZE project_record_ids;"
 
-# Dedup units
+# Duplicate units
 python3 -m python.dedup_units
 run_sql_command "CALL apply_correction('${BUILD_ENGINE_SCHEMA}', 'deduped_units', 'corrections_main');"
 run_sql_command "VACUUM ANALYZE deduped_units;"
 
-# Join to boro, clean duplicates
+# Join to boro
 run_sql_file sql/join_boroughs.sql
 run_sql_command "CALL apply_correction('${BUILD_ENGINE_SCHEMA}', 'combined', 'corrections_borough');"
 
 # Create KPDB
 run_sql_file sql/create_kpdb.sql
+
+# Duplicate projects
+python3 -m python.dedup_projects

--- a/products/knownprojects/bash/04_export.sh
+++ b/products/knownprojects/bash/04_export.sh
@@ -32,7 +32,6 @@ mkdir -p output
         csv_export review_dob &
         csv_export corrections_applied &
         csv_export corrections_not_applied &
-        # csv_export corrections_zap &
         csv_export corrections_dob_match &
         csv_export corrections_project &
         csv_export corrections_main

--- a/products/knownprojects/python/__init__.py
+++ b/products/knownprojects/python/__init__.py
@@ -39,7 +39,7 @@ DCP_HOUSING_CORRECTIONS_FILENAMES = {
     "corrections_main": "corrections_main.csv",
     "corrections_project": "corrections_project.csv",
     # "corrections_zap": "corrections_zap_20231002.csv",
-    "zap_record_ids": "zap_record_ids_20231005.csv",
+    "zap_record_ids": "zap_record_ids.csv",
 }
 
 # Load environmental variables

--- a/products/knownprojects/python/__init__.py
+++ b/products/knownprojects/python/__init__.py
@@ -38,7 +38,6 @@ DCP_HOUSING_CORRECTIONS_FILENAMES = {
     "corrections_dob": "corrections_dob.csv",
     "corrections_main": "corrections_main.csv",
     "corrections_project": "corrections_project.csv",
-    # "corrections_zap": "corrections_zap_20231002.csv",
     "zap_record_ids": "zap_record_ids.csv",
 }
 

--- a/products/knownprojects/python/dedup_projects.py
+++ b/products/knownprojects/python/dedup_projects.py
@@ -1,0 +1,38 @@
+from dcpy.utils import postgres
+from dcpy.utils.logging import logger
+
+from . import BUILD_ENGINE_SCHEMA
+
+FINAL_TABLE_NAME = "_kpdb"
+INTERMEDIATE_TABLE_NAME = "_kpdb_before_deduplication"
+
+PRIMARY_KEY = "project_id"
+
+if __name__ == "__main__":
+    logger.info(f"Starting KPDB project deduplication")
+    pg_client = postgres.PostgresClient(schema=BUILD_ENGINE_SCHEMA)
+
+    logger.info(f"Getting data from table '{FINAL_TABLE_NAME}' ...")
+    kpdb = pg_client.get_table(FINAL_TABLE_NAME)
+    logger.info(f"Shape of data:\n\t{kpdb.shape}")
+    logger.info(f"Columns:\n\t{kpdb.columns.to_list()}")
+
+    logger.info(
+        f"Excluding the primary key '{PRIMARY_KEY}' from the columns used to identify duplicates"
+    )
+    columns_to_consider = [col for col in kpdb.columns.to_list() if col != PRIMARY_KEY]
+
+    # use DataFrame.astype(str) to avoid error from data of type list
+    kpdb_no_duplicates = kpdb.loc[
+        kpdb.astype(str).drop_duplicates(subset=columns_to_consider).index
+    ]
+    logger.info(f"Shape of deduplicated data:\n\t{kpdb_no_duplicates.shape}")
+
+    records_dropped_count = kpdb.shape[0] - kpdb_no_duplicates.shape[0]
+    logger.info(f"# of duplicate records removed:\n\t{records_dropped_count}")
+
+    logger.info(f"Saving original data as '{INTERMEDIATE_TABLE_NAME}' ...")
+    pg_client.insert_dataframe(df=kpdb, table_name=INTERMEDIATE_TABLE_NAME)
+
+    logger.info(f"Updating final table '{FINAL_TABLE_NAME}' ...")
+    pg_client.insert_dataframe(df=kpdb_no_duplicates, table_name=FINAL_TABLE_NAME)

--- a/products/knownprojects/python/dedup_projects.py
+++ b/products/knownprojects/python/dedup_projects.py
@@ -31,8 +31,8 @@ if __name__ == "__main__":
     records_dropped_count = kpdb.shape[0] - kpdb_no_duplicates.shape[0]
     logger.info(f"# of duplicate records removed:\n\t{records_dropped_count}")
 
-    logger.info(f"Saving original data as '{INTERMEDIATE_TABLE_NAME}' ...")
-    pg_client.insert_dataframe(df=kpdb, table_name=INTERMEDIATE_TABLE_NAME)
+    # logger.info(f"Saving original data as '{INTERMEDIATE_TABLE_NAME}' ...")
+    # pg_client.insert_dataframe(df=kpdb, table_name=INTERMEDIATE_TABLE_NAME)
 
-    logger.info(f"Updating final table '{FINAL_TABLE_NAME}' ...")
-    pg_client.insert_dataframe(df=kpdb_no_duplicates, table_name=FINAL_TABLE_NAME)
+    # logger.info(f"Updating final table '{FINAL_TABLE_NAME}' ...")
+    # pg_client.insert_dataframe(df=kpdb_no_duplicates, table_name=FINAL_TABLE_NAME)

--- a/products/knownprojects/python/dedup_projects.py
+++ b/products/knownprojects/python/dedup_projects.py
@@ -1,5 +1,6 @@
 from dcpy.utils import postgres
 from dcpy.utils.logging import logger
+from psycopg2.extensions import AsIs
 
 from . import BUILD_ENGINE_SCHEMA
 
@@ -33,3 +34,14 @@ if __name__ == "__main__":
 
     logger.info(f"Creating table '{OUTPUT_TABLE}' ...")
     pg_client.insert_dataframe(df=kpdb_no_duplicates, table_name=OUTPUT_TABLE)
+    pg_client.execute_query(
+        """
+        ALTER TABLE :table_name
+        ALTER COLUMN :geometry_col type Geometry
+        USING ST_SetSRID(:geometry_col, 4326);
+        """,
+        placeholders={
+            "table_name": AsIs(OUTPUT_TABLE),
+            "geometry_col": AsIs("geom"),
+        },
+    )

--- a/products/knownprojects/sql/create_corrections.sql
+++ b/products/knownprojects/sql/create_corrections.sql
@@ -36,18 +36,6 @@ CREATE TABLE corrections_main (
 -- side effects on a short timeline
 SELECT * INTO corrections_borough FROM corrections_main WHERE field = 'borough';
 
--- -- corrections zap table -> indicating if each record should be added / removed from kpdb
--- DROP TABLE IF EXISTS corrections_zap;
--- CREATE TABLE corrections_zap (
---     record_id text,
---     action text,
---     editor text,
---     date text,
---     notes text
--- );
-
--- \COPY corrections_zap FROM 'data/corrections/corrections_zap.csv' DELIMITER ',' CSV HEADER;
-
 DROP TABLE IF EXISTS zap_record_ids;
 CREATE TABLE zap_record_ids (
     record_id text

--- a/products/knownprojects/sql/create_kpdb.sql
+++ b/products/knownprojects/sql/create_kpdb.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS _kpdb;
+DROP TABLE IF EXISTS _kpdb_projects_projects;
 SELECT
     a.*,
     b.project_id,
@@ -13,13 +14,13 @@ SELECT
     ROUND(
         COALESCE(a.prop_after_10_years::decimal, 0) * b.units_net::decimal
     ) AS after_10_years
-INTO _kpdb
+INTO _kpdb_projects
 FROM combined AS a
 LEFT JOIN deduped_units AS b
     ON a.record_id = b.record_id
 WHERE a.no_classa = '0' OR a.no_classa IS NULL;
 
-UPDATE _kpdb a
+UPDATE _kpdb_projects a
 SET
     borough
     = CASE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ ignore = ["D100", "D101", "D102", "D107", "D104", "D213", "D407", "D413"]
 [tool.black]
 
 [[tool.mypy.overrides]]
-module = "geopandas.*,geosupport.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*,moto.*" # no stubs available
+module = "geopandas.*,geosupport.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*,moto.*,geoalchemy2.*" # no stubs available
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
resolves #309 

- [x] ensure deduplicated data still has geometry data as geometry type rather than text
- [ ] ensure project deduplication doesn't have to take place before unit deduplication

## approach
- use python to deduplicate records at the end of the build stage
- only drop extra records if the values in every column are identical (other than the primary key)
  - `DataFrame.drop_duplicates(subset=columns_to_consider)`

## tests
- [build logs](https://github.com/NYCPlanning/data-engineering/actions/runs/6818960177/job/18545523794#step:8:152) showing removal of duplicate records
- SQL queries to see effects of changes
  - from schema `kpdb.build_240` without these changes
    - results of ["duplicate records" query](https://github.com/NYCPlanning/data-engineering/issues/309#issuecomment-1804267601)
      - <img width="1032" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/46491123-2de6-4a02-861e-3227fd09c460">
    - records with example record_id `B00520132`
      - <img width="977" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/7835556c-d500-4215-9a79-62174c7d6232">
  - from schema `kpdb.build_354` with these changes
    - results of ["duplicate records" query](https://github.com/NYCPlanning/data-engineering/issues/309#issuecomment-1804267601)
      - <img width="1031" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/b05f46ed-901b-4b61-a2d5-dc6873e5a524">
    - records with example record_id `B00520132`
      - <img width="861" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/f6a7f5c6-6d85-42e6-98bc-5736f7c69e81">
