### PR TITLE
fix DB schema cleaning

### DIFF
--- a/dcpy/builds/clean_artifacts.py
+++ b/dcpy/builds/clean_artifacts.py
@@ -7,19 +7,27 @@ from . import BUILD_REPO, BUILD_DBS
 
 
 def get_active_build_names() -> list:
-    # all remote branches
-    branches = github.get_branches(repo=BUILD_REPO)
+    # use the hard-coded "build_" prefix from github action workflow files
+    # and the event-based prefixes from build_metadata.build_name
+    branches = github.get_branches(repo=BUILD_REPO)  # all remote branches
     branch_build_names = sorted(
-        [build_metadata.build_name("branch", branch) for branch in branches]
+        [
+            build_metadata.build_name(event="branch", source=branch)
+            for branch in branches
+        ]
+        + ["build_" + branch for branch in branches]
     )
-    logger.info(f"Valid branch build names: {branch_build_names}")
+    logger.info(f"Potential active branch build names: {branch_build_names}")
 
-    # all open PR numbers
-    pull_requests = github.get_pull_requests(repo=BUILD_REPO)
+    pull_requests = github.get_pull_requests(repo=BUILD_REPO)  # all open PR numbers
     pr_build_names = sorted(
-        [build_metadata.build_name("pull_request", pr) for pr in pull_requests]
+        [
+            build_metadata.build_name(event="pull_request", source=pr)
+            for pr in pull_requests
+        ]
+        + ["build_" + pr for pr in pull_requests]
     )
-    logger.info(f"Valid PR build names: {pr_build_names}")
+    logger.info(f"Potential active PR build names: {pr_build_names}")
 
     return pr_build_names + branch_build_names
 

--- a/dcpy/connectors/edm/build_metadata.py
+++ b/dcpy/connectors/edm/build_metadata.py
@@ -5,17 +5,18 @@ import pytz
 from dcpy.utils import git
 
 
-def build_name(event: str | None = None, branch: str | None = None) -> str:
+def build_name(event: str | None = None, source: str | None = None) -> str:
     if os.environ.get("BUILD_ENGINE_SCHEMA"):
         return os.environ["BUILD_ENGINE_SCHEMA"]
 
     event = git.event_name() if not event else event
-    branch = git.branch() if not branch else branch
     if event == "pull_request":
         prefix = "pr"
     else:
         prefix = "run"
-    suffix = branch.replace("-", "_")
+
+    source = git.branch() if not source else source
+    suffix = source.replace("-", "_")
     return f"{prefix}_{suffix}"
 
 


### PR DESCRIPTION
resolves #341 

## approach
- use all three potential schema prefixes when creating the list of DB schemas to save from deletion

## background
We currently have three DB schema prefixes (see screenshots below):
- `build_` when we have to construct the schema name before we can use `utils.postgres.PostgresClient`
  - [CPDB example](https://github.com/NYCPlanning/data-engineering/blob/kpdb-drop-comments/.github/workflows/cpdb_build.yml#L21)
  - this is true for every products except Template DB [here](https://github.com/NYCPlanning/data-engineering/blob/kpdb-drop-comments/products/template/build_scripts/__init__.py#L19) because they all use bash scripts to run SQL
- `pr_` when a pure-python build is triggered by PR tests
- `run_` when a pure-python build is triggered manually

![image](https://github.com/NYCPlanning/data-engineering/assets/7444289/bdc62fc3-f6f7-4bb8-88e8-d3ee80ec0e2c)
![image](https://github.com/NYCPlanning/data-engineering/assets/7444289/150ef2fa-4223-487f-870e-97f99d8be677)

