### PR TITLE
Fix recipes default text value bug

### DIFF
--- a/dcpy/utils/postgres.py
+++ b/dcpy/utils/postgres.py
@@ -181,7 +181,7 @@ class PostgresClient:
     ):
         q = f"ALTER TABLE {table_name} ADD COLUMN {col_name} {col_type}"
         if default_value:
-            q += f" DEFAULT {default_value}"
+            q += f" DEFAULT '{default_value}'"
         self.execute_query(q + ";")
 
     def get_table_row_count(self, table_name: str) -> int:


### PR DESCRIPTION
When I was testing, all the recipe datasets versions were numeric. This broke when it encountered '23v3'.

> ProgrammingError: (psycopg2.errors.SyntaxError) trailing junk after numeric 
literal at or near "23v"
LINE 1: ...dcp_pluto ADD COLUMN data_library_version text DEFAULT 23v3;