### PR TITLE
Add Socrata Connector and GH workflow

### DIFF
--- a/.github/workflows/socrata_publish_dataset.yml
+++ b/.github/workflows/socrata_publish_dataset.yml
@@ -3,6 +3,15 @@ run-name: "🚀 Socrata - Publish a Dataset"
 
 on:
   workflow_dispatch:
+    inputs:
+      DATASET_NAME:
+        description: "Name of the Socrata Dataset"
+        type: string
+        required: true
+      DATASET_VERSION:
+        description: "Version to push"
+        type: string
+        required: true
 jobs:
   publish:
     runs-on: ubuntu-22.04
@@ -14,3 +23,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+          AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          SOCRATA_USER: "op://Data Engineering/DCP_OpenData/username"
+          SOCRATA_PASSWORD: "op://Data Engineering/DCP_OpenData/password"
+
+      - name: Finish container setup
+        run: ./bash/docker_container_setup.sh
+
+      - name: Temp install socrata-py
+        run: python3 -m pip install socrata-py
+
+      - name: Push to Socrata
+        run: |
+          python3 -m dcpy.connectors.socrata.publish push_shp_from_s3 \
+            --dataset ${{ inputs.DATASET_NAME }} \
+            --version ${{ inputs.DATASET_VERSION }}

--- a/dcpy/connectors/socrata/metadata.py
+++ b/dcpy/connectors/socrata/metadata.py
@@ -1,0 +1,148 @@
+"""A first pass at metadata we'd sync to socrata.
+
+Data format:
+`mih_test.metadata` entry is in the format expected by their publishing API.
+`mih_test.columns` is as well, but must be passed to a different endpoint.
+(so while they're both metadata, we have to separate them.)
+
+This should eventually be generated from pure DCP product metadata, as many of
+the fields, especially those at column level, would be quite helpful at all
+stages of the build.
+
+FYI, the mih_test dataset is private, and will remain so.
+"""
+
+datasets = {
+    "mih_test": {
+        "four_four": "p6cc-cxkc",  # A `four_four` is the ID for a socrata dataset
+        "attachments": ["nycmih_metadata.pdf"],
+        "columns": [
+            {
+                "display_name": "the_geom",
+                "datatype_name": "multipolygon",
+                "description": "Geometry type, changed",
+                "field_name": "the_geom",
+            },
+            {
+                "display_name": "Boro",
+                "datatype_name": "text",
+                "description": "The NYC Borough where the Mandatory Inclusionary Housing (MIH) area is mapped. The boro code is a single digit identifier, indicating a particular borough (1 = Manhattan, 2 = Bronx, 3 = Brooklyn, 4 = Queens, 5 = Staten Island).",
+                "field_name": "boro",
+            },
+            {
+                "display_name": "Status",
+                "datatype_name": "text",
+                "description": "Status of the ULURP text amendment application (Adopted = final approval, Pipeline = awaiting approval)",
+                "field_name": "status",
+            },
+            {
+                "display_name": "Project Name",
+                "datatype_name": "text",
+                "description": "Project Name of the Mandatory Inclusionary Housing (MIH) area.",
+                "field_name": "projectnam",
+            },
+            {
+                "display_name": "Date Adopted",
+                "datatype_name": "calendar_date",
+                "description": "The date the ULURP text amendment application was adopted.",
+                "field_name": "dateadopte",
+            },
+            {
+                "display_name": "ZR_ULURP Number",
+                "datatype_name": "text",
+                "description": "The ULURP number of the ULURP text amendment application.",
+                "field_name": "zr_ulurpno",
+            },
+            {
+                "display_name": "ZR_Map",
+                "datatype_name": "text",
+                "description": "The map number referenced in Appendix F of the Zoning Resolution for the mapped Mandatory Inclusionary Housing (MIH) area.",
+                "field_name": "zr_map",
+            },
+            {
+                "display_name": "CD",
+                "datatype_name": "text",
+                "description": "Community District where the Mandatory Inclusionary Housing (MIH) area is mapped.",
+                "field_name": "cd",
+            },
+            {
+                "display_name": "MIH_Option",
+                "datatype_name": "text",
+                "description": "Level of affordability and options applied to the mapped Mandatory Inclusionary Housing (MIH) area.",
+                "field_name": "mih_option",
+            },
+            {
+                "display_name": "Zoning_Map",
+                "datatype_name": "text",
+                "description": "Zoning Map index number where the Mandatory Inclusionary Housing (MIH) area is mapped.",
+                "field_name": "zoning_map",
+            },
+            {
+                "display_name": "Project_ID",
+                "datatype_name": "text",
+                "description": "Zoning Application Portal (ZAP) project id. ZAP is a DCP project tracking database.",
+                "field_name": "project_id",
+            },
+            {
+                "display_name": "Shape_Length",
+                "datatype_name": "number",
+                "description": "Length of feature in feet.",
+                "field_name": "shape_leng",
+            },
+            {
+                "display_name": "Shape_Area",
+                "datatype_name": "number",
+                "description": "Area of feature in internal squared feet.",
+                "field_name": "shape_area",
+            },
+        ],
+        "metadata": {
+            "name": "MIH_Test",
+            "resourceName": "MIH_TEST",
+            "tags": ["housing", "house", "building", "development"],
+            "privateMetadata": {
+                "custom_fields": {
+                    "Legislative Compliance": {
+                        "Removed Records?": "Yes",
+                        "Original Scheduled Publication Date": "whenver",
+                        "Most Recent Scheduled Publication Date": "whenver a while ago",
+                        "Has Data Dictionary?": "Yes",
+                        "Geocoded?": "Yes",
+                        "Follows Template?": "Yes",
+                        "Externally Updated- When?": "now",
+                        "External Frequency (LL 110/2015)": "Historical",
+                        "Exists Externally? (LL 110/2015)": "Yes",
+                        "DoITT Geocoded- How?": "Manually",
+                        "DoITT Geocoded- Fields?": "All of 'em",
+                        "Dataset from the Open Data Plan?": "No",
+                        "Contains Address?": "Yes",
+                        "Can Dataset Feasibly Be Automated?": "Yes",
+                        "Address Layout?": "Parsed",
+                    }
+                },
+                "contactEmail": "a@a.com",
+            },
+            "metadata": {
+                "rowLabel": "A Mandatorily Included House",
+                "custom_fields": {
+                    "Update": {
+                        "Update Frequency Details": "never",
+                        "Update Frequency": "As needed",
+                        "Date Made Public": "never",
+                        "Data Change Frequency": "always",
+                        "Automation": "Yes",
+                    }
+                },
+                "availableDisplayTypes": ["table", "fatrow", "page"],
+            },
+            "licenseId": "ODC_BY",
+            "license": {
+                "termsLink": "http://opendatacommons.org/licenses/by/1.0/",
+                "name": "Open Data Commons Attribution License",
+            },
+            "description": "Description for Mandatory Inclusionary Housing",
+            "category": "Housing & Development",
+            "attribution": "DCP",
+        },
+    }
+}

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -1,0 +1,350 @@
+"""DCP Socrata Connector to bridge the gaps between various Socrata APIs/SDKs.
+
+The publishing API documentation is here:
+https://dev.socrata.com/docs/other/publishing.html#?route=overview
+
+Additionally, when it's mysterious about which endpoint to hit, or what the
+arguments should be, opening the web interface and watching the requests is
+quite informative.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import requests
+from socrata.authorization import Authorization
+from socrata import Socrata as SocrataPy
+import typer
+from typing import TypedDict, Literal
+
+from .metadata import datasets
+
+from dcpy.utils.logging import logger
+
+from dcpy.utils import s3
+
+SOCRATA_USER = os.getenv("SOCRATA_USER")
+SOCRATA_PASSWORD = os.getenv("SOCRATA_PASSWORD")
+
+SOCRATA_DOMAIN = "data.cityofnewyork.us"
+SOCRATA_API_EP = f"https://{SOCRATA_DOMAIN}/api"
+_revisions_root = f"{SOCRATA_API_EP}/publishing/v1/revision"
+_views_root = f"{SOCRATA_API_EP}/views"
+
+DISTRIBUTIONS_BUCKET = "edm-distributions"
+
+
+def _simple_auth():
+    return (SOCRATA_USER, SOCRATA_PASSWORD)
+
+
+def _socrata_request(
+    url,
+    method: Literal["GET", "PUT", "POST", "PATCH", "DELETE"],
+    **kwargs,
+) -> dict:
+    """Request wrapper to add auth, and raise exceptions on error."""
+    request_fn = getattr(requests, method.lower())
+    resp = request_fn(url, auth=_simple_auth(), **kwargs)
+    if not resp.ok:
+        raise Exception(resp.text)
+    return resp.json()
+
+
+class Socrata:
+    """Helper classes for working with responses from/inputs to the Socrata Rest APIs.
+
+    Some classes, e.g. the TypedDict subclasses, are here more as documentation.
+    """
+
+    class Inputs:
+        """Helper classes to model inputs to the Socrata API."""
+
+        class Attachment(TypedDict):
+            name: str
+            filename: str
+            asset_id: str
+            blob_id: str | None
+
+    class Responses:
+        """Helper classes to model responses from the Socrata API."""
+
+        class Revision:
+            def __init__(self, data):
+                self._data = data
+                self._raw_resource_data = data["resource"]
+                self.revision_num = self._raw_resource_data["revision_seq"]
+                self.four_four = self._raw_resource_data["fourfour"]
+                self.metadata = self._raw_resource_data["metadata"]
+                self.attachments = self._raw_resource_data["attachments"]
+
+        class RevisionDataSource:
+            def __init__(self, socrata_source):
+                self.socrata_source = socrata_source
+
+                # AR Note: It's not clear to me why/when you would have multiple schemas/output
+                # schemas for any one datasource. In any case, I haven't yet encountered it,
+                # and for our use case (single dataset upload per product) I don't expect we will
+                self.soc_output_columns = socrata_source.attributes["schemas"][0][
+                    "output_schemas"
+                ][0]["output_columns"]
+
+            @property
+            def _column_update_endpoint(self):
+                return (
+                    f"https://{SOCRATA_DOMAIN}"
+                    + self.socrata_source.input_schemas[0].links["transform"]
+                )
+
+            @property
+            def column_names(self) -> set[str]:
+                return {c["field_name"] for c in self.soc_output_columns}
+
+            def update_column_metadata(self, dcp_cols):
+                # TODO: changing column types. Not strictly required yet, and could be tricky
+                logger.info(f"Updating Columns at {self._column_update_endpoint}")
+
+                dcp_cols_by_name = {c["field_name"]: c for c in dcp_cols}
+                dcp_col_names = [c["field_name"] for c in dcp_cols]
+
+                assert (
+                    dcp_cols_by_name.keys() == self.column_names
+                ), "The field names in the uploaded source must match \
+                    those in our metadata"
+
+                for col in self.soc_output_columns:
+                    # Input columns need to be matched to what's been uploaded,
+                    # via the `initial_output_column_id`. Otherwise update
+                    # requests are ignored.
+                    col["initial_output_column_id"] = col["id"]
+                    col["position"] = dcp_col_names.index(col["field_name"]) + 1
+
+                    dcp_col = dcp_cols_by_name[col["field_name"]]
+
+                    col["is_primary_key"] = dcp_col.get("is_primary_key") or False
+                    col["display_name"] = dcp_col["display_name"]
+                    col["description"] = dcp_col["description"]
+
+                return _socrata_request(
+                    self._column_update_endpoint,
+                    "POST",
+                    json={"output_columns": self.soc_output_columns},
+                )
+
+
+@dataclass(frozen=True)
+class Dataset:
+    four_four: str
+
+    @property
+    def revisions_endpoint(self):
+        return f"{_revisions_root}/{self.four_four}"
+
+    def fetch_metadata(self):
+        """Fetch metadata (e.g. dataset name, tags) for a dataset."""
+        return _socrata_request(f"{_views_root}/{self.four_four}.json", "GET")
+
+    def fetch_open_revisions(self) -> list[Revision]:
+        """Fetch all open revisions for a given dataset."""
+        revs = _socrata_request(
+            self.revisions_endpoint,
+            "GET",
+            params={"open": "true"},
+        )
+        return list(
+            [Revision(r["resource"]["revision_seq"], self.four_four) for r in revs]
+        )
+
+    def discard_open_revisions(self):
+        open_revs = self.fetch_open_revisions()
+        logger.info(f"Discarding revisions: {[r.revision_num for r in open_revs]}")
+        for r in open_revs:
+            r.discard()
+
+    def create_replace_revision(self) -> Revision:
+        """Create a revision that will replace/overwrite the existing dataset, rather than upserting."""
+        logger.info(f"Creating a revision at: {self.revisions_endpoint}")
+        resp = _socrata_request(
+            self.revisions_endpoint, "POST", json={"action": {"type": "replace"}}
+        )["resource"]
+        revision = Revision(revision_num=resp["revision_seq"], four_four=self.four_four)
+
+        logger.info(
+            f"Revision {revision.revision_num} created for {revision.four_four}"
+        )
+        return revision
+
+
+@dataclass(frozen=True)
+class Revision:
+    revision_num: str
+    four_four: str
+
+    @property
+    def revision_endpoint(self):
+        return f"{_revisions_root}/{self.four_four}/{self.revision_num}"
+
+    def apply(self):
+        """Apply the revision to the dataset, closing the revision."""
+        return _socrata_request(f"{self.revision_endpoint}/apply", "put")
+
+    def discard(self):
+        """Discard this revision."""
+        return _socrata_request(self.revision_endpoint, "delete")
+
+    def fetch_default_metadata(self) -> Socrata.Responses.Revision:
+        """Fetch default metadata for a revision.
+
+        AR Note: This doesn't return revision metadata that you've patched.
+        e.g. If you patch an update to `contact email` for this revision, that change will not
+        be reflected in the revision you fetch here, nor on the Socrata revision page.
+        """
+        return Socrata.Responses.Revision(
+            _socrata_request(self.revision_endpoint, "GET")
+        )
+
+    def patch_metadata(
+        self, metadata: dict, attachments: list[Socrata.Inputs.Attachment]
+    ):
+        return Socrata.Responses.Revision(
+            _socrata_request(
+                self.revision_endpoint,
+                "PATCH",
+                # TODO: should this header be a default?
+                headers={
+                    "Content-Type": "application/json",
+                },
+                data=json.dumps(
+                    {
+                        "attachments": attachments,
+                        "metadata": metadata,
+                    }
+                ),
+            )
+        )
+
+    def push_shp(
+        self, path: Path, *, dest_filename: str | None = None
+    ) -> Socrata.Responses.RevisionDataSource:
+        # This is the only use of socrata-py. The data syncing utilities are nice.
+        _socratapy_client = SocrataPy(
+            Authorization(SOCRATA_DOMAIN, SOCRATA_USER, SOCRATA_PASSWORD)
+        )
+        view = _socratapy_client.views.lookup(self.four_four)
+        rev = view.revisions.lookup(self.revision_num)
+        with open(path, "rb") as shp_zip:
+            logger.info(
+                f"Pushing shapefiles at {path} to {self.four_four} - rev: {self.revision_num}"
+            )
+            push_resp = (
+                rev.create_upload(dest_filename or shp_zip.name)
+                .shapefile(shp_zip)
+                .wait_for_finish()
+            )
+        error_details: dict | None = push_resp.attributes["failure_details"]
+        if error_details:
+            logger.error(f"Shapefile upload failed with {error_details}")
+            raise Exception()
+        return Socrata.Responses.RevisionDataSource(push_resp)
+
+    def upload_attachment(
+        self, path: Path, *, file_name: str | None = None
+    ) -> Socrata.Inputs.Attachment:
+        """Upload an attachment to a revision.
+
+        Note: uploading an attachment isn't enough to truly attach it to a revision.
+        It must also be patched into the metadata revision. Unfortunately, subsequent
+        patches seem to wipe out the attachment metadata, everything must be gathered
+        up into one patch.
+        """
+        # TODO: check other attachment types, e.g. xlsx
+        content_types = {".csv": "text/csv", ".pdf": "application/pdf"}
+
+        with open(path, "rb") as f:
+            attachment_md_raw = _socrata_request(
+                f"{self.revision_endpoint}/attachment",
+                "POST",
+                headers={
+                    "X-File-Name": file_name or path.name,
+                    "Content-type": content_types[path.suffix],
+                },
+                data=f,
+            )
+        return Socrata.Inputs.Attachment(
+            # TODO: diff between name and filename? and what about blob_id?
+            name=attachment_md_raw["filename"],
+            filename=attachment_md_raw["filename"],
+            asset_id=attachment_md_raw["file_id"],
+            blob_id=None,
+        )
+
+
+def push_shp_from_s3(dataset_name: str, version: str):
+    """Push Shapefile from the distributions bucket to Socrata, and sync metadata."""
+    dataset_metadata: dict = datasets[dataset_name]
+    four_four: str = dataset_metadata["four_four"]
+    socrata_metadata = dataset_metadata["metadata"]
+    logger.info(
+        f"Syncing shapefile and metadata for {dataset_name}/{version} to Socrata {four_four}"
+    )
+
+    download_root_path = Path(".library")
+    dataset_path = download_root_path / dataset_name / version
+    logger.info(
+        f"Downloading shapefile from s3 dataset: {dataset_name} to {dataset_path.absolute()}"
+    )
+
+    s3.download_folder(
+        DISTRIBUTIONS_BUCKET, f"{dataset_name}/{version}/", download_root_path
+    )
+
+    dataset = Dataset(four_four=four_four)
+    dataset.discard_open_revisions()
+
+    rev = dataset.create_replace_revision()
+
+    data_source = rev.push_shp(path=dataset_path / "shapefile.zip")
+    data_source.update_column_metadata(dcp_cols=dataset_metadata["columns"])
+
+    attachments_metadata = [
+        rev.upload_attachment(dataset_path / "attachments" / attachment)
+        for attachment in dataset_metadata["attachments"]
+    ]
+
+    rev.patch_metadata(attachments=attachments_metadata, metadata=socrata_metadata)
+    rev.apply()
+    logger.info("Finished syncing product to Socrata")
+
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command("push_shp_from_s3")
+def _push_shp_from_s3_cli(
+    dataset: str = typer.Option(
+        None,
+        "-d",
+        "--dataset",
+        help="Dataset name",
+    ),
+    version: str = typer.Option(
+        None,
+        "-v",
+        "--version",
+        help="Dataset version",
+    ),
+):
+    return push_shp_from_s3(dataset, version)
+
+
+@app.command("placeholder")
+def _placeholder():
+    # Adding a second command. If you only have one command defined,
+    # typer ignores the specified command name.
+    assert False, "Please don't invoke me."
+
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ ignore = ["D100", "D101", "D102", "D107", "D104", "D213", "D407", "D413"]
 [tool.black]
 
 [[tool.mypy.overrides]]
-module = "geopandas.*,geosupport.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*,moto.*,matplotlib.axes,contextily,leafmap.*,shapely" # no stubs available
+module = "geopandas.*,geosupport.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*,moto.*,matplotlib.axes,contextily,leafmap.*,shapely,socrata.*" # no stubs available
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -28,20 +28,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.34.3
+boto3==1.34.7
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs==1.34.3
+boto3-stubs==1.34.7
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.34.3
+botocore==1.34.7
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.34.3
+botocore-stubs==1.34.7
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -102,7 +102,7 @@ contextily==1.3.0
     # via -r python/requirements.in
 contourpy==1.2.0
     # via matplotlib
-coverage==7.3.3
+coverage==7.3.4
     # via
     #   coverage
     #   pytest-cov
@@ -162,7 +162,7 @@ graphviz==0.20.1
     # via
     #   -r python/requirements.in
     #   diagrams
-greenlet==3.0.2
+greenlet==3.0.3
     # via sqlalchemy
 idna==3.6
     # via requests
@@ -180,7 +180,7 @@ ipykernel==6.22.0
     # via -r python/requirements.in
 ipyleaflet==0.18.1
     # via leafmap
-ipython==8.18.1
+ipython==8.19.0
     # via
     #   ipykernel
     #   ipywidgets
@@ -223,11 +223,11 @@ jsonschema==4.20.0
     # via
     #   altair
     #   pystac
-jsonschema-specifications==2023.11.2
+jsonschema-specifications==2023.12.1
     # via jsonschema
 jupyter-client==8.6.0
     # via ipykernel
-jupyter-core==5.5.1
+jupyter-core==5.6.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -235,7 +235,7 @@ jupyterlab-widgets==3.0.9
     # via ipywidgets
 kiwisolver==1.4.5
     # via matplotlib
-leafmap==0.29.7
+leafmap==0.30.0
     # via -r python/requirements.in
 lxml==4.9.4
     # via -r python/requirements.in
@@ -449,7 +449,7 @@ referencing==0.32.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2023.10.3
+regex==2023.12.25
     # via sqlfluff
 requests==2.31.0
     # via
@@ -460,6 +460,7 @@ requests==2.31.0
     #   msal
     #   pystac-client
     #   responses
+    #   socrata-py
     #   streamlit
 responses==0.24.1
     # via moto
@@ -471,7 +472,7 @@ rpds-py==0.15.2
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.9.0
+s3transfer==0.10.0
     # via boto3
 scikit-learn==1.3.2
     # via mapclassify
@@ -493,6 +494,8 @@ smmap==5.0.1
     # via gitdb
 snuggs==1.4.7
     # via rasterio
+socrata-py==1.1.13
+    # via -r python/requirements.in
 soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.15
@@ -512,7 +515,7 @@ streamlit==1.29.0
     #   streamlit-folium
 streamlit-aggrid==0.3.4.post3
     # via -r python/requirements.in
-streamlit-folium==0.17.4
+streamlit-folium==0.18.0
     # via -r python/requirements.in
 tabulate==0.9.0
     # via -r python/requirements.in
@@ -573,7 +576,7 @@ types-pyyaml==6.0.12.12
     # via -r python/requirements.in
 types-requests==2.31.0.10
     # via -r python/requirements.in
-types-s3transfer==0.9.0
+types-s3transfer==0.10.0
     # via boto3-stubs
 types-setuptools==69.0.0.0
     # via -r python/requirements.in

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -37,6 +37,7 @@ pytz>=2023.3
 PyYAML>=6.0.1
 types-PyYAML>=6.0.1
 rich>=13.4.2
+socrata-py==1.1.13
 sqlalchemy-stubs==0.4
 sqlalchemy==2.0.15
 sqlfluff @ git+https://github.com/fvankrieken/sqlfluff@main

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -28,20 +28,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.34.3
+boto3==1.34.7
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs[s3]==1.34.3
+boto3-stubs[s3]==1.34.7
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.34.3
+botocore==1.34.7
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.34.3
+botocore-stubs==1.34.7
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -102,7 +102,7 @@ contextily==1.3.0
     # via -r python/requirements.in
 contourpy==1.2.0
     # via matplotlib
-coverage[toml]==7.3.3
+coverage[toml]==7.3.4
     # via
     #   coverage
     #   pytest-cov
@@ -162,7 +162,7 @@ graphviz==0.20.1
     # via
     #   -r python/requirements.in
     #   diagrams
-greenlet==3.0.2
+greenlet==3.0.3
     # via sqlalchemy
 idna==3.6
     # via requests
@@ -180,7 +180,7 @@ ipykernel==6.22.0
     # via -r python/requirements.in
 ipyleaflet==0.18.1
     # via leafmap
-ipython==8.18.1
+ipython==8.19.0
     # via
     #   ipykernel
     #   ipywidgets
@@ -223,11 +223,11 @@ jsonschema==4.20.0
     # via
     #   altair
     #   pystac
-jsonschema-specifications==2023.11.2
+jsonschema-specifications==2023.12.1
     # via jsonschema
 jupyter-client==8.6.0
     # via ipykernel
-jupyter-core==5.5.1
+jupyter-core==5.6.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -235,7 +235,7 @@ jupyterlab-widgets==3.0.9
     # via ipywidgets
 kiwisolver==1.4.5
     # via matplotlib
-leafmap==0.29.7
+leafmap==0.30.0
     # via -r python/requirements.in
 lxml==4.9.4
     # via -r python/requirements.in
@@ -449,7 +449,7 @@ referencing==0.32.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2023.10.3
+regex==2023.12.25
     # via sqlfluff
 requests[socks]==2.31.0
     # via
@@ -460,6 +460,7 @@ requests[socks]==2.31.0
     #   msal
     #   pystac-client
     #   responses
+    #   socrata-py
     #   streamlit
 responses==0.24.1
     # via moto
@@ -471,7 +472,7 @@ rpds-py==0.15.2
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.9.0
+s3transfer==0.10.0
     # via boto3
 scikit-learn==1.3.2
     # via mapclassify
@@ -493,6 +494,8 @@ smmap==5.0.1
     # via gitdb
 snuggs==1.4.7
     # via rasterio
+socrata-py==1.1.13
+    # via -r python/requirements.in
 soupsieve==2.5
     # via beautifulsoup4
 sqlalchemy==2.0.15
@@ -512,7 +515,7 @@ streamlit==1.29.0
     #   streamlit-folium
 streamlit-aggrid==0.3.4.post3
     # via -r python/requirements.in
-streamlit-folium==0.17.4
+streamlit-folium==0.18.0
     # via -r python/requirements.in
 tabulate==0.9.0
     # via -r python/requirements.in
@@ -573,7 +576,7 @@ types-pyyaml==6.0.12.12
     # via -r python/requirements.in
 types-requests==2.31.0.10
     # via -r python/requirements.in
-types-s3transfer==0.9.0
+types-s3transfer==0.10.0
     # via boto3-stubs
 types-setuptools==69.0.0.0
     # via -r python/requirements.in


### PR DESCRIPTION
This adds a Socrata Connector that will 
- Open a Revision on a dataset
- Push a shapefile
- Push attachments
- Rename/reorder columns
- And, finally, close the revision

Additionally, there's a Github action that will push from the `edm-distributions` bucket to Socrata, taking a dataset name and version.

For review, I'd probably start at the bottom of `publish.py` and work upwards. 

As the comment in Metadata says, I'd checked in some metadata for MIH_TEST. It's in the format that Socrata expects, and we'll need to work backwards to create a DCP base metadata

Adding Casey and Jack for visiblity - no pressure to fisk the code