### PR TITLE
Get Pluto Building

### DIFF
--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Set versions env vars
         working-directory: products/pluto
         run: |
-          echo VERSION=$(yq .version recipe.lock.yml) >> "$GITHUB_ENV" && \
-          echo VERSION_PREV=$(yq '.inputs.datasets.[] | select(.name == "dcp_pluto") | .version' recipe.lock.yml) >> "$GITHUB_ENV"
+          echo VERSION=$(yq .version ${{ inputs.recipe_file }}.lock.yml) >> "$GITHUB_ENV" && \
+          echo VERSION_PREV=$(yq '.inputs.datasets.[] | select(.name == "dcp_pluto") | .version' ${{ inputs.recipe_file }}.lock.yml) >> "$GITHUB_ENV"
 
       - name: Load Local Data
         run: ./01_load_local_csvs.sh

--- a/apps/qa/src/pluto/components/expected_value_differences_report.py
+++ b/apps/qa/src/pluto/components/expected_value_differences_report.py
@@ -60,7 +60,7 @@ class ExpectedValueDifferencesReport:
         st.dataframe(
             FIELDS_OF_INTEREST,
             column_config={
-                "relevant fields": st.column_config.listColumn(
+                "relevant fields": st.column_config.ListColumn(
                     width="large",
                 ),
             },
@@ -87,7 +87,7 @@ class ExpectedValueDifferencesReport:
                 st.dataframe(
                     value_differences,
                     column_config={
-                        "relevant fields": st.column_config.listColumn(
+                        "relevant fields": st.column_config.ListColumn(
                             width="large",
                         ),
                     },

--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -29,8 +29,7 @@ def load_source_data(recipe_path: Path):
     setup_build_environments(pg_client)
 
     pg_client.create_table_from_csv(
-        "source_data_versions",
-        recipe_lock_path.parent / "source_data_versions.csv",
+        recipe_lock_path.parent / "source_data_versions.csv"
     )
 
     [recipes.import_dataset(dataset, pg_client) for dataset in recipe.inputs.datasets]

--- a/products/pluto/pluto_build/05_qaqc.sh
+++ b/products/pluto/pluto_build/05_qaqc.sh
@@ -2,14 +2,11 @@
 source ./bash/config.sh
 set_error_traps
 
-# Download Existing QAQC from DO
-# HACK due to change in build DB, dm_temp_for_edm_db must be used rather than latest
-# until PLUTO 23v3 is published
-import_qaqc qaqc_expected dm_temp_for_edm_db
-import_qaqc qaqc_aggregate dm_temp_for_edm_db
-import_qaqc qaqc_mismatch dm_temp_for_edm_db
-import_qaqc qaqc_null dm_temp_for_edm_db
-import_qaqc qaqc_outlier dm_temp_for_edm_db
+import_qaqc qaqc_expected $VERSION_PREV
+import_qaqc qaqc_aggregate $VERSION_PREV
+import_qaqc qaqc_mismatch $VERSION_PREV
+import_qaqc qaqc_null $VERSION_PREV
+import_qaqc qaqc_outlier $VERSION_PREV
 
 wait
 

--- a/products/pluto/pluto_build/05_qaqc.sh
+++ b/products/pluto/pluto_build/05_qaqc.sh
@@ -14,37 +14,34 @@ wait
 run_sql_file sql/qaqc_expected.sql -v VERSION=${VERSION}
 
 function set_condition {
-  mapped=${1} 
-  condo=${2}
-  if [ "${mapped}" = true ] && [ "${condo}" = true ] ; then
-    export condition="WHERE right(a.bbl::bigint::text, 4) LIKE '75%%' AND a.geom IS NOT NULL"
-  elif [ "${mapped}" = true ] && [ "${condo}" = false ] ; then
-    export condition="WHERE a.geom IS NOT NULL"
-  elif [ "${mapped}" = false ] && [ "${condo}" = true ] ; then
-    export condition="WHERE right(a.bbl::bigint::text, 4) LIKE '75%%'"
-  elif [ "${mapped}" = false ] && [ "${condo}" = false ] ; then
-    export condition=""
-  fi
+    mapped=${1} 
+    condo=${2}
+    if [ "${mapped}" = true ] && [ "${condo}" = true ] ; then
+        export condition="WHERE right(a.bbl::bigint::text, 4) LIKE '75%%' AND a.geom IS NOT NULL"
+    elif [ "${mapped}" = true ] && [ "${condo}" = false ] ; then
+        export condition="WHERE a.geom IS NOT NULL"
+    elif [ "${mapped}" = false ] && [ "${condo}" = true ] ; then
+        export condition="WHERE right(a.bbl::bigint::text, 4) LIKE '75%%'"
+    elif [ "${mapped}" = false ] && [ "${condo}" = false ] ; then
+        export condition=""
+    fi
 }
 
 function QAQC {
-  echo "Running ${1}"
-  file=${1}
-  mapped=${2}
-  condo=${3}
-  set_condition ${mapped} ${condo}
-  run_sql_file ${file} -v VERSION=${VERSION} -v VERSION_PREV=${VERSION_PREV} -v CONDO=${condo} \
-  -v MAPPED=${mapped}  -v CONDITION="${condition}"
+    sqlfile=sql/${1}.sql
+    echo "Running ${sqlfile}"
+    mapped=${2}
+    condo=${3}
+    set_condition ${mapped} ${condo}
+    run_sql_file ${sqlfile} -v VERSION=${VERSION} -v VERSION_PREV=${VERSION_PREV} -v CONDO=${condo} \
+    -v MAPPED=${mapped}  -v CONDITION="${condition}"
 }
 
 # QAQC MISMATCH ANALYSIS
-for file in sql/qaqc_aggregate.sql sql/qaqc_mismatch.sql sql/qaqc_null.sql sql/qaqc_outlier.sql
-do
-  for mapped in true false
-  do
-    for condo in true false 
-    do
-      QAQC ${file} ${mapped} ${condo}
-    done
-  done 
+for file in qaqc_aggregate qaqc_mismatch qaqc_null qaqc_outlier; do
+    for mapped in true false; do
+        for condo in true false; do
+            QAQC ${file} ${mapped} ${condo}
+        done
+    done 
 done 

--- a/products/pluto/pluto_build/06_export.sh
+++ b/products/pluto/pluto_build/06_export.sh
@@ -43,44 +43,40 @@ wait
 echo "Exporting pluto csv"
 
 # Pluto
-mkdir -p pluto &&
-  (cd pluto
+mkdir -p pluto && (
+    cd pluto
     rm -f pluto.zip
     run_sql_command "\COPY ( 
-          SELECT * FROM export_pluto
+            SELECT * FROM export_pluto
         ) TO STDOUT DELIMITER ',' CSV HEADER;" > pluto.csv
     echo "${VERSION}" > version.txt
     echo "$(wc -l pluto.csv)" >> version.txt
     zip pluto.zip *
     ls | grep -v pluto.zip | xargs rm
-  )
+)
 
 echo "Exporting DOF"
 # BBL and Council info for DOF
-mkdir -p dof && 
-  (cd dof
+mkdir -p dof && (
+    cd dof
     rm -f bbl_council.zip
     run_sql_command "\COPY ( 
-          SELECT bbl, council FROM export_pluto
-          WHERE bbl is not null
+            SELECT bbl, council FROM export_pluto
+            WHERE bbl is not null
         ) TO STDOUT DELIMITER ',' CSV HEADER;" > bbl_council.csv
     echo "${VERSION}" > version.txt
     zip bbl_council.zip *
     ls | grep -v bbl_council.zip | xargs rm
-  )
+)
 
 echo "Exporting QAQC"
-mkdir -p qaqc && 
-  (cd qaqc
+mkdir -p qaqc && (
+    cd qaqc
     for table in qaqc_aggregate qaqc_expected qaqc_mismatch qaqc_null qaqc_outlier
     do
-      run_sql_command "\COPY ( 
-          SELECT * FROM ${table}
-        ) TO STDOUT DELIMITER ',' CSV HEADER;" > ${table}.csv
-      pg_dump --no-owner -d ${BUILD_ENGINE} -t ${table} -f ${table}.sql
+        csv_export $table
     done
-
-  )
+)
 
 wait 
 cd ..

--- a/products/pluto/pluto_build/bash/config.sh
+++ b/products/pluto/pluto_build/bash/config.sh
@@ -13,17 +13,17 @@ function import_qaqc {
     DO_folder=${2}
     target_dir=./.library/qaqc
     qaqc_do_url=https://nyc3.digitaloceanspaces.com/edm-publishing/db-pluto/publish/${DO_folder}/qaqc
-    if [ -f ${target_dir}/${name}.sql ]; then
-      echo "✅ ${name}.sql exists in cache"
+    if [ -f ${target_dir}/${name}.csv ]; then
+        echo "✅ ${name}.csv exists in cache"
     else
-      echo "🛠 ${name}.sql doesn't exists in cache, downloading ..."
-      mkdir -p ${target_dir} && (
-        cd ${target_dir}
-        curl -ss -O ${qaqc_do_url}/${name}.sql
-      )
+        echo "🛠 ${name}.csv doesn't exists in cache, downloading ..."
+        mkdir -p ${target_dir} && (
+            cd ${target_dir}
+            curl -ss -O ${qaqc_do_url}/${name}.csv
+        )
     fi
     run_sql_command "DROP TABLE IF EXISTS ${name}"
-    run_sql_file ${target_dir}/${name}.sql
+    python3 -m dcpy.utils.postgres import_csv ${target_dir}/${name}.csv
 }
 
 function shp_export_pluto {

--- a/products/pluto/pluto_build/sql/qaqc_outlier.sql
+++ b/products/pluto/pluto_build/sql/qaqc_outlier.sql
@@ -1,11 +1,3 @@
--- -v VERSION=$VERSION
-CREATE TABLE IF NOT EXISTS qaqc_outlier (
-    v character varying,
-    condo character varying,
-    mapped character varying,
-    outlier character varying
-);
-
 DELETE FROM qaqc_outlier
 WHERE
     v = :'VERSION'

--- a/products/pluto/recipe-minor.yml
+++ b/products/pluto/recipe-minor.yml
@@ -22,3 +22,6 @@ inputs:
       version: latest
     - name: dcp_zoningmapindex
       version: latest
+    - name: dcp_pluto
+      version: latest
+      import_as: previous_pluto


### PR DESCRIPTION
- Remove the temp fix for importing qa data
- Look for the right filename for lock file to set version env vars
- fix a bug in qa app - somehow a few months ago while mypy-ing qa, I renamed a function to one that does not exist. 🤷 
- get a longer term solution to the pg_dumps for the pluto qa stuff. Currently the process during a build is
  - pull in qa outputs from last build (sql dumps. And by "last build" I mean the published pluto which has version = bash variable `VERSION_PREV` which is set by a step in the pluto build github action)
  - import them
  - append to them (and replace data if there's already data for the current "version" somehow
  - pg_dump/csv export them, include them in export
Main issue is the pg dumps include the schema, and using the pg_dump cli there's no way to avoid this. Currently added some text processing of the sql file, might make sense to just have this logic rely on csvs instead of sql dumps to really keep things "data only"

Also going to clean up #405 