### PR TITLE
compile python requirements only weekly

### DIFF
--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -1,7 +1,7 @@
 name: Compile python requirements
 on:
   schedule: 
-    - cron: 00 00 * * *
+    - cron: 0 5 * * SAT
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,8 @@ jobs:
           echo "path filters with changed files: ${{ steps.filter.outputs.changes }}"
           if [[ -z "${{ steps.filter.outputs.changes }}" ]]; then
             matrix=$(cat .github/workflows/data/pytest.json | jq -cr)
+          elif [[ "[]" = "${{ steps.filter.outputs.changes }}" ]]; then
+            matrix="[]"
           else
             filter=$(echo '${{ steps.filter.outputs.changes }}' | sed 's/[][]//g' | sed -r 's/([\w-]+)(,|$)/"\1"\2/g')
             matrix=$(cat .github/workflows/data/pytest.json | jq -cr "map(. | select(.name|IN(${filter})))")


### PR DESCRIPTION
The nightly boto updates seem like maybe a bit much - figure we can do this once per week, come in and check it out Monday.

It could be good to address #295 in some way, and have the test for this PR actually use whatever python versions are specified in the action. If we feel like that'd be worth it, happy to work on that this week