### PR TITLE
Ar add parquet recipe support

### DIFF
--- a/.github/workflows/colp_build.yml
+++ b/.github/workflows/colp_build.yml
@@ -63,7 +63,7 @@ jobs:
       run: ./bash/build_env_setup.sh
 
     - name: Dataloading ...
-      run: python -m dcpy.builds.load
+      run: python -m dcpy.builds.load recipe
 
     - name: Build COLP ...
       run: ./colp.sh build

--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -67,7 +67,7 @@ jobs:
         run: python -m facdb.cli init
 
       - name: Dataloading
-        run: python -m dcpy.builds.load
+        run: python -m dcpy.builds.load recipe
 
       - name: Run Pipelines
         run: python -m facdb.cli run --sql

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Load data
         working-directory: products/pluto
         run: |
-          python3 -m dcpy.builds.load --recipe_path ./${{ inputs.recipe_file }}.yml
+          python3 -m dcpy.builds.load recipe --recipe_path ./${{ inputs.recipe_file }}.yml
 
       - name: Set versions env vars
         working-directory: products/pluto

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Load
         run: |
-          python3 -m dcpy.builds.load --recipe_path ./${{ inputs.recipe_file }}.yml
+          python3 -m dcpy.builds.load recipe --recipe_path ./${{ inputs.recipe_file }}.yml
 
       - name: Transform
         run: |

--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -41,7 +41,7 @@ def load_source_data(recipe_path: Path):
 app = typer.Typer(add_completion=False)
 
 
-@app.command("load")
+@app.command("recipe")
 def _cli_wrapper_load(
     recipe_path: Path = typer.Option(
         "./recipe.yml",
@@ -51,6 +51,39 @@ def _cli_wrapper_load(
     ),
 ):
     load_source_data(recipe_path)
+
+
+@app.command("dataset")
+def _import_dataset(
+    dataset_name: str = typer.Option(
+        None,
+        "-n",
+        "--dataset_name",
+        help="Name of the dataset",
+    ),
+    version: str = typer.Option(
+        None,
+        "-v",
+        "--version",
+        help="Dataset version to import",
+    ),
+    dataset_type: recipes.DatasetType = typer.Option(
+        recipes.DatasetType.pg_dump,
+        "-t",
+        "--type",
+        help="Dataset type",
+    ),
+    database_schema: str = typer.Option(
+        "postgres",
+        "-s",
+        "--schema",
+        help="Database Schema",
+    ),
+):
+    recipes.import_dataset(
+        recipes.Dataset(name=dataset_name, version=version, file_type=dataset_type),
+        postgres.PostgresClient(schema=database_schema),
+    )
 
 
 if __name__ == "__main__":

--- a/dcpy/test/connectors/edm/recipes/test_recipes.py
+++ b/dcpy/test/connectors/edm/recipes/test_recipes.py
@@ -90,9 +90,15 @@ def _mock_preprocessor(name, df):
     return df
 
 
-def _mock_fetch_dataset(ds, _):
+def _mock_fetch_csv(ds, _):
     out_path = TEMP_DATA_PATH / f"{ds.name}.csv"
     _test_df.to_csv(out_path, index=False)
+    return out_path
+
+
+def _mock_fetch_parquet(ds, _):
+    out_path = TEMP_DATA_PATH / f"{ds.name}.parquet"
+    _test_df.to_parquet(out_path, index=False)
     return out_path
 
 
@@ -100,14 +106,10 @@ def _mock_fetch_dataset(ds, _):
 class TestImportDatasets(TestCase):
     # TODO: move this functionality into an integration test with an actual database
 
-    def set_mocks(self):
-        # Mock out fetch_dataset to download a mocked csv
-        recipes.fetch_dataset = MagicMock(side_effect=_mock_fetch_dataset)
-        # Mocking out a preprocessor for our datasets. Sticking it on `dcpy` for ease
-        dcpy.preproc = MagicMock(side_effect=_mock_preprocessor)  # type: ignore
+    def test_import_csv(self):
+        recipes.fetch_dataset = MagicMock(side_effect=_mock_fetch_csv)
 
-    def test_import_dataset(self):
-        self.set_mocks()
+        dcpy.preproc = MagicMock(side_effect=_mock_preprocessor)  # type: ignore
         pg_mock = MagicMock()
         ds = recipes.Dataset(
             name="test",
@@ -131,7 +133,9 @@ class TestImportDatasets(TestCase):
         assert table_insert_name_actual == ds.import_as
 
     def test_import_parquet(self):
-        self.set_mocks()
+        recipes.fetch_dataset = MagicMock(side_effect=_mock_fetch_parquet)
+
+        dcpy.preproc = MagicMock(side_effect=_mock_preprocessor)  # type: ignore
         pg_mock = MagicMock()
         ds = recipes.Dataset(
             name="test",
@@ -140,11 +144,6 @@ class TestImportDatasets(TestCase):
             file_type=recipes.DatasetType.parquet,
             preprocessor=recipes.DataPreprocessor(module="dcpy", function="preproc"),
         )
-
-        def _mock_fetch_parquet(ds, _):
-            out_path = TEMP_DATA_PATH / f"{ds.name}.parquet"
-            _test_df.to_parquet(out_path, index=False)
-            return out_path
 
         recipes.fetch_dataset = MagicMock(side_effect=_mock_fetch_parquet)
 


### PR DESCRIPTION
I wanted to take Cody for a spin, and adding Parquet support seemed like a fun detour. The unit test was entirely generated by Cody, but everything else took some finessing. 

I added a sample parquet file to [test_nypl_libraries](https://cloud.digitalocean.com/spaces/edm-recipes?path=datasets/test_nypl_libraries/20210122) if you want to test.