### PR TITLE
Build dev docker images/tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ on:
         type: boolean
         required: true
         default: false
+      dev_image: 
+        description: "Use dev image specific to this branch? (If exists)"
+        type: boolean
+        required: true
+        default: false
   workflow_call:
     inputs:
       dataset_name:
@@ -60,17 +65,24 @@ on:
       recipe_file:
         type: string
         required: true
+      dev_image:
+        type: boolean
+        default: false
 
 jobs:
   health_check:
     name: Health Check
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
     steps:
       - name: Check inputs
         run: |
+          echo "running with image tag ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}"
           echo "Workflow inputs are:"
           echo "${{ toJSON(github.event.inputs) }}"
   template:
+    needs: health_check
     if: inputs.dataset_name == 'template'
     uses: ./.github/workflows/template_build.yml
     secrets: inherit
@@ -79,7 +91,9 @@ jobs:
       logging_level: ${{ inputs.logging_level }}
       build_note: ${{ inputs.build_note }}
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   cbbr:
+    needs: health_check
     if: inputs.dataset_name == 'cbbr'
     uses: ./.github/workflows/cbbr_build.yml
     secrets: inherit
@@ -87,52 +101,69 @@ jobs:
       logging_level: ${{ inputs.logging_level }}
       build_note: ${{ inputs.build_note }}
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   checkbook:
+    needs: health_check
     if: inputs.dataset_name == 'checkbook'
     uses: ./.github/workflows/checkbook_build.yml
     secrets: inherit
     with:
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   colp:
+    needs: health_check
     if: inputs.dataset_name == 'colp'
     uses: ./.github/workflows/colp_build.yml
     secrets: inherit
     with:
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   cpdb:
+    needs: health_check
     if: inputs.dataset_name == 'cpdb'
     uses: ./.github/workflows/cpdb_build.yml
     secrets: inherit
     with:
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   devdb:
+    needs: health_check
     if: inputs.dataset_name == 'devdb'
     uses: ./.github/workflows/developments_build.yml
     secrets: inherit
     with:
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   facilities:
+    needs: health_check
     if: inputs.dataset_name == 'facilities'
     uses: ./.github/workflows/facilities_build.yml
     secrets: inherit
     with:
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   knownprojects:
+    needs: health_check
     if: inputs.dataset_name == 'knownprojects'
     uses: ./.github/workflows/knownprojects_build.yml
     secrets: inherit
     with:
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   pluto:
+    needs: health_check
     if: inputs.dataset_name == 'pluto'
     uses: ./.github/workflows/pluto_build.yml
     secrets: inherit
     with:
       recipe_file: ${{ inputs.recipe_file }}
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}
   ztl:
+    needs: health_check
     if: inputs.dataset_name == 'ztl'
     uses: ./.github/workflows/zoningtaxlots_build.yml
     secrets: inherit
     with:
       run_export: ${{ inputs.run_export }}
+      image_tag: ${{ needs.health_check.outputs.tag }}

--- a/.github/workflows/cbbr_build.yml
+++ b/.github/workflows/cbbr_build.yml
@@ -12,6 +12,9 @@ on:
       run_export:
         type: boolean
         required: true
+      image_tag:
+        type: string
+        required: false
 
 jobs:
   build:
@@ -21,7 +24,7 @@ jobs:
         shell: bash
         working-directory: products/cbbr/cbbr_build
     container:
-      image: nycplanning/build-geosupport:latest
+      image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE: postgresql://postgres:postgres@postgis:5432/postgres
       EDM_DATA: ${{ secrets.EDM_DATA }}

--- a/.github/workflows/checkbook_build.yml
+++ b/.github/workflows/checkbook_build.yml
@@ -6,13 +6,16 @@ on:
       run_export:
         type: boolean
         required: true
+      image_tag:
+        type: string
+        required: false
 
 jobs:
   build:
     name: Build Dataset
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/build-geosupport:latest
+      image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE: postgresql://postgres:postgres@postgis:5432/postgres
     services:

--- a/.github/workflows/colp_build.yml
+++ b/.github/workflows/colp_build.yml
@@ -5,6 +5,9 @@ on:
       run_export:
         type: boolean
         required: true
+      image_tag:
+        type: string
+        required: false
   workflow_dispatch:
     inputs:
       run_export:
@@ -12,6 +15,10 @@ on:
         type: boolean
         required: true
         default: false
+      image_tag:
+        description: "Tag of build docker image to use"
+        type: string
+        required: false
 
 jobs:
   build:
@@ -21,7 +28,7 @@ jobs:
         shell: bash
         working-directory: products/colp
     container: 
-      image: nycplanning/build-geosupport:latest
+      image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE: postgresql://postgres:postgres@postgis:5432/dbcolp
       BUILD_ENGINE_SERVER: postgresql://postgres:postgres@postgis:5432

--- a/.github/workflows/cpdb_build.yml
+++ b/.github/workflows/cpdb_build.yml
@@ -6,7 +6,10 @@ on:
       run_export:
         type: boolean
         required: true
-
+      image_tag:
+        type: string
+        required: false
+        
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -15,7 +18,7 @@ jobs:
         shell: bash
         working-directory: products/cpdb
     container: 
-      image: nycplanning/build-geosupport:latest
+      image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
       BUILD_ENGINE_DB: db-cpdb

--- a/.github/workflows/developments_build.yml
+++ b/.github/workflows/developments_build.yml
@@ -7,6 +7,9 @@ on:
         type: boolean
         required: true
         default: false
+      image_tag:
+        type: string
+        required: false
 
 jobs:
   build:
@@ -16,7 +19,7 @@ jobs:
         shell: bash
         working-directory: products/developments
     container:
-      image: nycplanning/build-geosupport:latest
+      image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
       env:
         BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
         BUILD_ENGINE_DB: db-devdb

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -22,7 +22,11 @@ on:
         type: boolean
         required: true
         default: false
-  
+
+env:
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+
 jobs:
   build-base:
     runs-on: ubuntu-22.04
@@ -31,9 +35,6 @@ jobs:
       run:
         shell: bash
         working-directory: docker
-    env:
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     steps:
       - uses: actions/checkout@v3
         
@@ -47,9 +48,6 @@ jobs:
       run:
         shell: bash
         working-directory: docker
-    env:
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     steps:
       - uses: actions/checkout@v3
         
@@ -63,9 +61,6 @@ jobs:
       run:
         shell: bash
         working-directory: docker
-    env:
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     steps:
       - uses: actions/checkout@v3
         
@@ -79,9 +74,6 @@ jobs:
       run:
         shell: bash
         working-directory: docker
-    env:
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     steps:
       - uses: actions/checkout@v3
         

--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -6,6 +6,9 @@ on:
       run_export:
         type: boolean
         required: true
+      image_tag:
+        type: string
+        required: false
   workflow_dispatch:
     inputs:
       run_export:
@@ -13,6 +16,10 @@ on:
         type: boolean
         required: true
         default: false
+      image_tag:
+        description: "Tag of build docker image to use"
+        type: string
+        required: false
 
 jobs:
   build:
@@ -23,7 +30,7 @@ jobs:
         shell: bash
         working-directory: products/facilities
     container:
-      image: nycplanning/build-geosupport:latest
+      image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
       env:
         BUILD_ENGINE: postgresql://postgres:postgres@postgis:5432/postgres # TODO: address this duplication
         BUILD_ENGINE_SERVER: postgresql://postgres:postgres@postgis:5432

--- a/.github/workflows/knownprojects_build.yml
+++ b/.github/workflows/knownprojects_build.yml
@@ -6,13 +6,16 @@ on:
       run_export:
         type: boolean
         required: true
+      image_tag:
+        type: string
+        required: false
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/build-base:latest
+      image: nycplanning/build-base:${{ inputs.image_tag }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -12,6 +12,9 @@ on:
       create_issue:
         type: boolean
         default: false
+      image_tag:
+        type: string
+        required: false
   workflow_dispatch:
     inputs:
       run_export:
@@ -31,6 +34,10 @@ on:
         type: boolean
         description: Create GH Issue for build?
         default: false
+      image_tag:
+        description: "Tag of build docker image to use"
+        type: string
+        required: false
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -39,7 +46,7 @@ jobs:
         shell: bash
         working-directory: products/pluto/pluto_build
     container:
-      image: nycplanning/build-base:latest
+      image: nycplanning/build-base:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
       BUILD_ENGINE_DB: db-pluto

--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -1,7 +1,7 @@
 name: Compile python requirements
 on:
   schedule: 
-    - cron: 0 5 * * SAT
+  - cron: 0 5 * * SUN
   workflow_dispatch:
 
 jobs:
@@ -32,3 +32,4 @@ jobs:
           title: Compile python requirements
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           assignees: fvankrieken, damonmcc, alexrichey, sf-dcp
+          branch: compile_python_reqs

--- a/.github/workflows/stale_builds.yml
+++ b/.github/workflows/stale_builds.yml
@@ -17,9 +17,12 @@ jobs:
     env:
       GHP_TOKEN: ${{ github.GITHUB_TOKEN }}
       BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     steps:
       - uses: actions/checkout@v3
       - name: Delete build artifacts
-        run: python3 -m dcpy.builds.clean_artifacts
+        run: python3 -m dcpy.builds.clean_artifacts schemas
       - name: Delete docker images
-        run: echo "TODO"
+        run: python3 -m dcpy.builds.clean_artifacts dockerhub_tags
+          

--- a/.github/workflows/stale_builds.yml
+++ b/.github/workflows/stale_builds.yml
@@ -20,5 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Delete build artifacts
-        run: |
-          python3 -m dcpy.builds.clean_artifacts
+        run: python3 -m dcpy.builds.clean_artifacts
+      - name: Delete docker images
+        run: echo "TODO"

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -15,6 +15,9 @@ on:
       run_export:
         type: boolean
         required: true
+      image_tag:
+        type: string
+        required: false
 
 env:
   TOY_SECRET: ${{ secrets.TOY_SECRET }}
@@ -27,7 +30,7 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/dev:latest
+      image: nycplanning/dev:${{ inputs.image_tag || 'latest' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -1,6 +1,10 @@
 name: Template - Tests
 on:
   workflow_call:
+    inputs:
+      image_tag:
+        type: string
+        required: true
 
 env:
   TOY_SECRET: ${{ secrets.TOY_SECRET }}
@@ -12,7 +16,7 @@ jobs:
     name: Template DB Unit tests
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/dev:latest
+      image: nycplanning/dev:${{ inputs.image_tag || 'latest'}}
     steps:
       - uses: actions/checkout@v3
 
@@ -38,6 +42,7 @@ jobs:
       run_export: false
       logging_level: DEBUG
       build_note: a test build
+      image_tag: ${{ inputs.image_tag || 'latest' }}
     secrets: inherit
 
   e2e_tests:
@@ -45,7 +50,7 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/dev:latest
+      image: nycplanning/dev:${{ inputs.image_tag || 'latest' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,104 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    name: Check changed files
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
+    outputs:
+      path_filters: ${{ steps.filter.outputs.changes }}
+      matrix: ${{ steps.set-pytest-matrix.outputs.matrix }}
+      matrix_raw: ${{ steps.set-pytest-matrix.outputs.matrix_raw }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            dcpy:
+              - dcpy/**
+              - pyproject.toml
+              - python/**
+              - docker/**
+            template:
+              - .github/workflows/test.yml
+              - .github/workflows/build.yml
+              - .github/workflows/template_test.yml
+              - products/template/**
+              - dcpy/**
+              - docker/**
+              - python/**
+            data-library:
+              - data-library/**
+              - python/**
+              - docker/**
+            qa:
+              - apps/qa/**
+              - dcpy/**
+              - python/**
+              - docker/**
+            cbbr:
+              - products/cbbr/**
+              - python/**
+              - docker/**
+            checkbook:
+              - products/checkbook/**
+              - python/**
+              - docker/**
+            zap:
+              - products/zap-opendata/**
+              - python/**
+              - docker/**
+            docker:
+              - python/**
+              - docker/**
+              
+      - name: Confirm changes and set matrix for pytest
+        id: set-pytest-matrix
+        run: |
+          echo "path filters with changed files: ${{ steps.filter.outputs.changes }}"
+          if [[ -z "${{ steps.filter.outputs.changes }}" ]]; then
+            matrix=$(cat .github/workflows/data/pytest.json | jq -cr)
+          elif [[ "[]" = "${{ steps.filter.outputs.changes }}" ]]; then
+            matrix="[]"
+          else
+            filter=$(echo '${{ steps.filter.outputs.changes }}' | sed 's/[][]//g' | sed -r 's/([\w-]+)(,|$)/"\1"\2/g')
+            matrix=$(cat .github/workflows/data/pytest.json | jq -cr "map(. | select(.name|IN(${filter})))")
+          fi
+          echo "matrix_raw=$matrix" >> $GITHUB_OUTPUT
+          echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
+
+  build_docker_images:
+    needs: check_changes
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: dev-${{ github.head_ref || 'latest' }}
+    env:
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+    strategy: 
+      matrix: 
+        image:
+          - build-base
+          - build-geosupport
+          - dev
+    steps:
+      - uses: actions/checkout@v4
+      - name: publish images
+        if: contains(needs.check_changes.outputs.path_filters, 'docker')
+        working-directory: docker
+        run: ./publish.sh "${{ matrix.image }}" "dev-${{ github.head_ref || 'latest' }}"
+
   check_formatting:
+    needs: build_docker_images
     name: Check formatting of files
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/dev:latest
+      image: nycplanning/dev:${{ needs.build_docker_images.outputs.tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check python files
         run: black --diff --color --check .
@@ -34,11 +125,12 @@ jobs:
           sqlfluff lint products/zoningtaxlots/sql/
 
   mypy:
+    needs: build_docker_images
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/dev:latest
+      image: nycplanning/dev:${{ needs.build_docker_images.outputs.tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check python files
         run: |
@@ -47,82 +139,28 @@ jobs:
           mypy data-library/library
           mypy products/facilities
           mypy products/template
-
-  check_changes:
-    name: Check changed files
-    runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: read
-    outputs:
-      path_filters: ${{ steps.filter.outputs.changes }}
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      matrix_raw: ${{ steps.set-matrix.outputs.matrix_raw }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
-        if: github.event_name == 'pull_request'
-        id: filter
-        with:
-          filters: |
-            dcpy:
-              - dcpy/**
-              - pyproject.toml
-              - python/**
-            template:
-              - .github/workflows/test.yml
-              - .github/workflows/build.yml
-              - .github/workflows/template_test.yml
-              - products/template/**
-              - dcpy/**
-              - docker/**
-              - python/**
-            data-library:
-              - data-library/**
-              - python/**
-            qa:
-              - apps/qa/**
-              - dcpy/**
-              - docker/**
-              - python/**
-            cbbr:
-              - products/cbbr/**
-              - python/**
-            checkbook:
-              - products/checkbook/**
-              - python/**
-            zap:
-              - products/zap-opendata/**
-              - python/**
-      - name: Confirm changes and set matrix
-        id: set-matrix
-        run: |
-          echo "path filters with changed files: ${{ steps.filter.outputs.changes }}"
-          if [[ -z "${{ steps.filter.outputs.changes }}" ]]; then
-            matrix=$(cat .github/workflows/data/pytest.json | jq -cr)
-          elif [[ "[]" = "${{ steps.filter.outputs.changes }}" ]]; then
-            matrix="[]"
-          else
-            filter=$(echo '${{ steps.filter.outputs.changes }}' | sed 's/[][]//g' | sed -r 's/([\w-]+)(,|$)/"\1"\2/g')
-            matrix=$(cat .github/workflows/data/pytest.json | jq -cr "map(. | select(.name|IN(${filter})))")
-          fi
-          echo "matrix_raw=$matrix" >> $GITHUB_OUTPUT
-          echo "matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
   
   template-db:
-    needs: check_changes
+    needs: 
+      - build_docker_images
+      - check_changes
     if: github.event_name != 'pull_request' || contains(needs.check_changes.outputs.path_filters, 'template')
     uses: ./.github/workflows/template_test.yml
+    with:
+      image_tag: ${{ needs.build_docker_images.outputs.tag }}
     secrets: inherit
 
   pytest:
     name: Pytest - ${{ matrix.name }}
-    needs: check_changes
+    needs: 
+      - build_docker_images
+      - check_changes
     runs-on: ubuntu-22.04
     if: needs.check_changes.outputs.matrix_raw != '[]' 
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.check_changes.outputs.matrix) }}
-    container: nycplanning/dev:latest
+    container: nycplanning/dev:${{ needs.build_docker_images.outputs.tag }}
     defaults:
       run:
         shell: bash
@@ -141,7 +179,7 @@ jobs:
       ZAP_ENGINE: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}/edm-zap
       TEST_SCHEMA_SUFFIX: pr_${{ github.event.pull_request.number || 'workflow_dispatch' }}
     steps:    
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Load Secrets
       uses: 1password/load-secrets-action@v1
       with:
@@ -165,11 +203,13 @@ jobs:
         done
   
   checkbook:
-    needs: check_changes
+    needs: 
+      - build_docker_images
+      - check_changes
     if: github.event_name != 'pull_request' || contains(needs.check_changes.outputs.path_filters, 'checkbook')
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/dev:latest
+      image: nycplanning/dev:${{ needs.build_docker_images.outputs.tag }}
     env:
       BUILD_ENGINE: postgresql://postgres:postgres@postgis:5432/postgres
     services:
@@ -189,7 +229,7 @@ jobs:
         shell: bash
         working-directory: products/checkbook
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/zoningtaxlots_build.yml
+++ b/.github/workflows/zoningtaxlots_build.yml
@@ -6,6 +6,9 @@ on:
       run_export:
         type: boolean
         required: true
+      image_tag:
+        type: string
+        required: false
 
 jobs:
   build:
@@ -16,7 +19,7 @@ jobs:
         shell: bash
         working-directory: products/zoningtaxlots
     container:
-      image: nycplanning/build-base:latest
+      image: nycplanning/build-base:${{ inputs.image_tag || 'latest' }}
     services:
       postgis:
         image: postgis/postgis:15-3.3-alpine

--- a/dcpy/builds/clean_artifacts.py
+++ b/dcpy/builds/clean_artifacts.py
@@ -1,3 +1,7 @@
+import requests
+import subprocess
+import typer
+
 from dcpy.utils import postgres
 from dcpy.utils.logging import logger
 from dcpy.connectors import github
@@ -6,15 +10,18 @@ from dcpy.builds import metadata
 from . import BUILD_REPO, BUILD_DBS
 
 
-def get_active_build_names() -> list:
+def get_active_build_names(as_schema=False) -> list[str]:
     branches = github.get_branches(repo=BUILD_REPO)  # all remote branches
     branch_build_names = sorted(
-        [metadata.build_name(name=branch) for branch in branches]
+        [
+            metadata.build_name(name=branch) if as_schema else branch
+            for branch in branches
+        ]
     )
     return branch_build_names
 
 
-def delete_stale_builds(active_build_names: list):
+def delete_stale_schemas(active_build_names: list[str]):
     logger.info(f"Potential active branch build names: {active_build_names}")
     for database in BUILD_DBS:
         pg_client_default = postgres.PostgresClient(
@@ -35,6 +42,38 @@ def delete_stale_builds(active_build_names: list):
                 logger.info(f"Keeping schema {database}.{build_schema}")
 
 
-if __name__ == "__main__":
+def delete_stale_image_tags(active_build_names: list[str]):
+    logger.info(f"Potential active branch build names: {active_build_names}")
+    DOCKER_IMAGES = ["dev", "build-base", "build-geosupport"]
+    for image in DOCKER_IMAGES:
+        tags = requests.get(
+            f"https://hub.docker.com/v2/repositories/nycplanning/{image}/tags?page_size=1000"
+        ).json()["results"]
+        dev_tags = [tag for tag in tags if tag["name"].startswith("dev-")]
+        for tag in dev_tags:
+            if tag not in active_build_names:
+                logger.warning(f"Deleting tag {image}:{tag['name']}")
+                # Should we include this file in dcpy? A little odd to rely on this file existing, but it's going to be a bit hacky regardless
+                # The intonation seems a bit finicky so don't really want to implement in python rather than bash
+                subprocess.call(["docker/delete.sh", image, tag["name"]])
+            else:
+                logger.info(f"Keeping tag {image}.{tag['name']}")
+
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command("schemas")
+def _cli_wrapper_schemas():
+    active_build_names = get_active_build_names(as_schema=True)
+    delete_stale_schemas(active_build_names)
+
+
+@app.command("dockerhub_tags")
+def _cli_wrapper_iamge_tags():
     active_build_names = get_active_build_names()
-    delete_stale_builds(active_build_names)
+    delete_stale_image_tags(active_build_names)
+
+
+if __name__ == "__main__":
+    app()

--- a/docker/delete.sh
+++ b/docker/delete.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# big thanks to https://devopscell.com/docker/dockerhub/2018/04/09/delete-docker-image-tag-dockerhub.html
+ORGANIZATION="nycplanning"
+IMAGE="$1"
+TAG="$2"
+
+login_data() {
+cat <<EOF
+{
+  "username": "$DOCKER_USER",
+  "password": "$DOCKER_PASSWORD"
+}
+EOF
+}
+
+TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
+
+curl "https://hub.docker.com/v2/repositories/${ORGANIZATION}/${IMAGE}/tags/${TAG}/" \
+-X DELETE \
+-H "Authorization: JWT ${TOKEN}"


### PR DESCRIPTION
I would go commit-by-commit for review

Main goal here - in case where changes result in different docker environment. Desired state (and commits, coincidentally), are:
1. build image and push to dockerhub for the given branch. This happens with pull_request trigger as part of `test` gha. image uses same image name as usual, but publishes with tag "dev-{branch}". Only builds if things in `python` or `docker` folders are edited.
2. be able to use these dev images in builds. This happens via bool input for both the main build workflow and the specific build workflows
3. clean up "stale" image tags - check for active branches, delete all "dev" tags not corresponding to existing branches on github

Commit 4 right now is simply so I can test functionality in 3 more easily. [Here's a run](https://github.com/NYCPlanning/data-engineering/actions/runs/7051310388), I can verify that dev tags existed and then were deleted

Pr tests for this branch are testing commit 1

[Here's a job using a dev tag to build](https://github.com/NYCPlanning/data-engineering/actions/runs/7051225532/job/19193643375#step:2:18)

## Cons to this approach
- slows down testing. Doesn't check in any way if new commits have changed dev image definition since last push to a branch with an open PR. Don't know if there's a huge way around that though
- more complex gha yml