### PR TITLE
fix KPDB builds on `main`

### DIFF
--- a/.github/workflows/knownprojects_build.yml
+++ b/.github/workflows/knownprojects_build.yml
@@ -18,7 +18,8 @@ jobs:
         shell: bash
         working-directory: ./products/knownprojects
     env:
-      BUILD_ENGINE_DATABASE: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}/kpdb
+      BUILD_ENGINE_SERVER: ${{ secrets.SQL_ENGINE_EDM_DATA_SERVER }}
+      BUILD_ENGINE_DB: kpdb
       BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
     steps:

--- a/products/knownprojects/python/__init__.py
+++ b/products/knownprojects/python/__init__.py
@@ -39,7 +39,7 @@ DCP_HOUSING_CORRECTIONS_FILENAMES = {
     "corrections_main": "corrections_main.csv",
     "corrections_project": "corrections_project.csv",
     # "corrections_zap": "corrections_zap_20231002.csv",
-    "zap_record_ids": "zap_record_ids_20231005.csv",
+    "zap_record_ids": "zap_record_ids.csv",
 }
 
 # Load environmental variables


### PR DESCRIPTION
build fails on main due to
- lack of `BUILD_ENGINE_SERVER` envar because it's needed in [`build_env_setup.sh`](https://github.com/NYCPlanning/data-engineering/blob/dm-fix-main-kpdb-builds/bash/build_env_setup.sh#L8) ([build log](https://github.com/NYCPlanning/data-engineering/actions/runs/7039064265/job/19157321209#step:7:12))
- an invalid corrections filename ([build log](https://github.com/NYCPlanning/data-engineering/actions/runs/7039124358/job/19157504324#step:7:60))

[successful build](https://github.com/NYCPlanning/data-engineering/actions/runs/7039195511/job/19157714323) on this branch