### PR TITLE
fix builds failing on main nightly runs

### DIFF
--- a/.github/workflows/knownprojects_build.yml
+++ b/.github/workflows/knownprojects_build.yml
@@ -15,7 +15,7 @@ jobs:
     name: build
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/build-base:${{ inputs.image_tag }}
+      image: nycplanning/build-base:${{ inputs.image_tag || 'latest' }}
     defaults:
       run:
         shell: bash

--- a/products/checkbook/build_scripts/build.py
+++ b/products/checkbook/build_scripts/build.py
@@ -10,7 +10,6 @@ from . import (
     OUTPUT_DIR,
     SQL_QUERY_DIR,
     BUILD_OUTPUT_FILENAME,
-    BUILD_NAME,
     PG_CLIENT,
 )
 
@@ -148,7 +147,7 @@ def _assign_checkbook_category(df: pd.DataFrame, sql_dir=SQL_QUERY_DIR) -> pd.Da
         if_exists="replace",
         index=False,
     )
-    with ENGINE.connect() as conn:
+    with ENGINE.begin() as conn:
         for k, v in target_cols.items():
             with open(sql_dir / "categorization.sql", "r") as query_file:
                 query = query_file.read()

--- a/products/zoningtaxlots/bash/02_build.sh
+++ b/products/zoningtaxlots/bash/02_build.sh
@@ -3,22 +3,24 @@ source bash/config.sh
 
 echo "Run build"
 
+echo "Build section 1 ..."
 run_sql_file sql/create_priority.sql
 run_sql_file sql/create.sql
 run_sql_file sql/preprocessing.sql
 run_sql_file sql/bbl.sql
-
 wait
+
+echo "Build section 2 ..."
 run_sql_file sql/area_commercialoverlay.sql
 run_sql_file sql/area_specialdistrict.sql
 run_sql_file sql/area_limitedheight.sql
 run_sql_file sql/area_zoningmap.sql
-
 wait
+
+echo "Build section 3 ..."
 run_sql_file sql/area_zoningdistrict.sql
 run_sql_file sql/parks.sql
 run_sql_file sql/inzonechange.sql
 run_sql_file sql/correct_duplicatevalues.sql
 run_sql_file sql/correct_zoninggaps.sql
 run_sql_file sql/correct_invalidrecords.sql
-

--- a/products/zoningtaxlots/bash/03_qaqc_upload.sh
+++ b/products/zoningtaxlots/bash/03_qaqc_upload.sh
@@ -18,11 +18,11 @@ psql ${EDM_DATA} -c "
 
 echo "Run export and qaqc scripts ..."
 run_sql_file sql/export.sql
-psql ${EDM_DATA} -v VERSION=${VERSION_SQL_TABLE} -f sql/qaqc/frequency.sql
-psql ${EDM_DATA} -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_SQL_TABLE} -f sql/qaqc/bbl.sql
-psql ${EDM_DATA} -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_SQL_TABLE} -f sql/qaqc/mismatch.sql
-psql ${EDM_DATA} -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_SQL_TABLE} -f sql/qaqc/out_bbldiffs.sql | 
-    psql ${EDM_DATA} -f sql/qaqc/in_bbldiffs.sql
+psql ${EDM_DATA} --set ON_ERROR_STOP=1 -v VERSION=${VERSION_SQL_TABLE} -f sql/qaqc/frequency.sql
+psql ${EDM_DATA} --set ON_ERROR_STOP=1 -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_SQL_TABLE} -f sql/qaqc/bbl.sql
+psql ${EDM_DATA} --set ON_ERROR_STOP=1 -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_SQL_TABLE} -f sql/qaqc/mismatch.sql
+psql ${EDM_DATA} --set ON_ERROR_STOP=1 -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PREV_SQL_TABLE} -f sql/qaqc/out_bbldiffs.sql | 
+    psql ${BUILD_ENGINE} --set ON_ERROR_STOP=1 -f sql/qaqc/in_bbldiffs.sql
 
 ## remove dtm_id column from archive because it isn't a true id but rather one we generate during build
 psql $EDM_DATA -c "ALTER TABLE dcp_zoningtaxlots.\"${VERSION_SQL_TABLE}\" DROP COLUMN dtm_id;"


### PR DESCRIPTION
resolves #409 

## changes and build runs
- [nightly builds](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml?query=branch%3Adm-fix-nightly-builds) run using this branch
- ZTL [build](https://github.com/NYCPlanning/data-engineering/actions/runs/7092663238/job/19304433771)
  - ensure sql dump files generated during a build have the `public.table_name` in the file (rather than build schema) so they can be piped to and run on the DB `defaultdb` set by the envar `EDM_DATA`
- KPDB [build](https://github.com/NYCPlanning/data-engineering/actions/runs/7092946037)
  - fix approach to determining container image tag
- Checkbook [build](https://github.com/NYCPlanning/data-engineering/actions/runs/7092983373)
  - ensure DataFrame sql methods specify the build schema