### PR TITLE
QAQC App: Add list of new & vanished BBLs for PLUTO

### DIFF
--- a/apps/qa/src/pages/pluto/components/bbl_diffs_report.py
+++ b/apps/qa/src/pages/pluto/components/bbl_diffs_report.py
@@ -1,0 +1,31 @@
+import streamlit as st
+
+
+class BblDiffsReport:
+    def __init__(self, data):
+        self.df_bbl_diffs = data
+
+    def __call__(self):
+        st.header(f"New and Vanished BBLs")
+        st.markdown(
+            f"""
+            The table of BBLs in the current PLUTO that were added (new) and removed (vanished) since its previous version. 
+            """
+        )
+        st.info(
+            """
+            ⚠️ The filters on the left to filter condo and mapped lots DO NOT apply to this table. 
+            """
+        )
+        st.info(
+            """
+            ⚠️ When choosing a PLUTO minor version, the table below should be empty: BBL records are supposed to be added/removed in major versions only.
+            """
+        )
+
+        if self.df_bbl_diffs is None:
+            st.warning(f"QAQC table for vanished and new BBLs was not found.")
+            return
+
+        df = self.df_bbl_diffs
+        st.write(df)

--- a/apps/qa/src/pages/pluto/helpers.py
+++ b/apps/qa/src/pages/pluto/helpers.py
@@ -28,6 +28,12 @@ def get_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
     )
     data["df_outlier"] = read_pluto_csv("outlier", converters={"outlier": json.loads})
 
+    # only PLUTO 23v3+ versions are expected to have a bbl_diffs table
+    try:
+        data["df_bbl_diffs"] = read_pluto_csv("bbl_diffs")
+    except:
+        pass
+
     data = data | get_changes(product_key)
 
     data["source_data_versions"] = publishing.read_csv(

--- a/apps/qa/src/pages/pluto/pluto.py
+++ b/apps/qa/src/pages/pluto/pluto.py
@@ -14,6 +14,7 @@ def pluto():
     )
     from .components.outlier_report import OutlierReport
     from .components.aggregate_report import AggregateReport
+    from .components.bbl_diffs_report import BblDiffsReport
 
     st.title("PLUTO QAQC")
 
@@ -66,7 +67,7 @@ def pluto():
             st.markdown(
                 f"""
                 This series of reports compares two pairs of PLUTO versions using two colors in graphs:
-                - blue: the Celected and the Previous versions ({v1})
+                - blue: the Selected and the Previous versions ({v1})
                 - gold: the previous two versions ({v2})
 
                 The graphs report the number of records that have a different value in a given field but share the same BBL between versions.
@@ -117,6 +118,8 @@ def pluto():
             OutlierReport(
                 data=data["df_outlier"], v1=v1, v2=v2, condo=condo, mapped=mapped
             )()
+
+            BblDiffsReport(data=data.get("df_bbl_diffs", None))()
 
         if report_type == "Compare with Previous Version":
             version_comparison_report(data)

--- a/products/pluto/pluto_build/05_qaqc.sh
+++ b/products/pluto/pluto_build/05_qaqc.sh
@@ -10,6 +10,10 @@ import_qaqc qaqc_outlier $VERSION_PREV
 
 wait
 
+# QAQC NEW/VANISHED BBL ANALYSIS
+run_sql_file sql/qaqc_bbl_diffs.sql -v VERSION=${VERSION} -v VERSION_PREV=${VERSION_PREV}
+
+
 # QAQC EXPECTED VALUE ANALYSIS
 run_sql_file sql/qaqc_expected.sql -v VERSION=${VERSION}
 

--- a/products/pluto/pluto_build/06_export.sh
+++ b/products/pluto/pluto_build/06_export.sh
@@ -73,7 +73,7 @@ mkdir -p dof && (
 echo "Exporting QAQC"
 mkdir -p qaqc && (
     cd qaqc
-    for table in qaqc_aggregate qaqc_expected qaqc_mismatch qaqc_null qaqc_outlier
+    for table in qaqc_aggregate qaqc_expected qaqc_mismatch qaqc_null qaqc_outlier qaqc_bbl_diffs
     do
         csv_export $table
     done

--- a/products/pluto/pluto_build/sql/qaqc_bbl_diffs.sql
+++ b/products/pluto/pluto_build/sql/qaqc_bbl_diffs.sql
@@ -1,0 +1,30 @@
+DROP TABLE IF EXISTS qaqc_bbl_diffs;
+CREATE TABLE qaqc_bbl_diffs (
+    source_version text,
+    bbl text,
+    type text
+);
+
+-- add new bbl records
+INSERT INTO qaqc_bbl_diffs (
+    SELECT
+        :'VERSION' AS source_version,
+        ap.bbl::float::bigint::text AS bbl,
+        'new' AS type
+    FROM archive_pluto AS ap
+    LEFT JOIN previous_pluto AS pp
+        ON ap.bbl::float::bigint = pp.bbl::float::bigint
+    WHERE pp.bbl IS NULL
+);
+
+-- add vanished bbl records
+INSERT INTO qaqc_bbl_diffs (
+    SELECT
+        :'VERSION_PREV' AS source_version,
+        pp.bbl::float::bigint::text AS bbl,
+        'vanished' AS type
+    FROM previous_pluto AS pp
+    LEFT JOIN archive_pluto AS ap
+        ON ap.bbl::float::bigint = pp.bbl::float::bigint
+    WHERE ap.bbl IS NULL
+);


### PR DESCRIPTION
Fixes #335. The PR consists of 2 commits:
1. Generates a new QAQC table with new and disappeared BBLs during a PLUTO build. 
2. Adds the generated table to the QAQC page. 
    * I re-deployed the qaqc [app](https://de-qaqc.nycplanningdigital.com/?page=PLUTO) on my branch. 
    * Go to PLUTO -> `draft` version -> `sf-qaqc-app-pluto-lots` build and scroll all the way down to see the table.
    
      <img width="1386" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/f7aeea3b-42ae-4e29-ba3e-a93531db7c74">


    * If choosing a build where the table is not available (earlier versions), here is the view: 
    
      <img width="1425" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/ac554fb5-5f93-49ad-b6c1-7631c827beec">
 
## TO DO:
Confirm correctness of the query:
- [x] after Finn merges #413, re-run pluto minor and make sure there are zero records in the table. <-- done
- [x] for pluto major build (23v3), imported `previous_pluto` recipe is 23v3. However, 23v2 or 23v2.1 are expected. <-- #413 addressed this concern by adding an option to **repeat** existing build. 