### PR TITLE
run tests on push to main

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,5 +1,8 @@
 name: Docker Images - Build and Publish
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       build-base:
@@ -30,7 +33,7 @@ env:
 jobs:
   build-base:
     runs-on: ubuntu-22.04
-    if: inputs.build-base
+    if: inputs.build-base || github.event_name == 'push'
     defaults:
       run:
         shell: bash
@@ -43,7 +46,7 @@ jobs:
 
   build-geosupport:
     runs-on: ubuntu-22.04
-    if: inputs.build-geosupport
+    if: inputs.build-geosupport || github.event_name == 'push'
     defaults:
       run:
         shell: bash
@@ -56,7 +59,7 @@ jobs:
 
   dev:
     runs-on: ubuntu-22.04
-    if: inputs.dev
+    if: inputs.dev || github.event_name == 'push'
     defaults:
       run:
         shell: bash
@@ -69,7 +72,7 @@ jobs:
 
   docker-geosupport:
     runs-on: ubuntu-22.04
-    if: inputs.docker-geosupport
+    if: inputs.docker-geosupport || github.event_name == 'push'
     defaults:
       run:
         shell: bash

--- a/docker/config.sh
+++ b/docker/config.sh
@@ -2,6 +2,7 @@
 
 BUILD_APT_PACKAGES="postgresql-client-15 libpq-dev curl jq wget gdal-bin jq zip unzip git locales"
 DEV_APT_PACKAGES="postgresql-client-15 libpq-dev curl jq wget gdal-bin jq zip unzip git locales bash-completion graphviz xdg-utils libgdal-dev"
+GEOSUPPORT_APT_PACKAGES="curl git unzip zip build-essential"
 
 function install_yq {
     wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \

--- a/docker/config.sh
+++ b/docker/config.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-BUILD_APT_PACKAGES="postgresql-client-15 libpq-dev curl jq wget gdal-bin jq zip unzip git locales"
-DEV_APT_PACKAGES="postgresql-client-15 libpq-dev curl jq wget gdal-bin jq zip unzip git locales bash-completion graphviz xdg-utils libgdal-dev"
-GEOSUPPORT_APT_PACKAGES="curl git unzip zip build-essential"
+COMMON_APT_PACKAGES="curl zip unzip git"
+GEOSUPPORT_APT_PACKAGES="${COMMON_APT_PACKAGES} build-essential"
+BUILD_APT_PACKAGES="${COMMON_APT_PACKAGES} postgresql-client-15 libpq-dev jq wget gdal-bin jq locales"
+DEV_APT_PACKAGES="${BUILD_APT_PACKAGES} bash-completion graphviz xdg-utils libgdal-dev"
 
 function install_yq {
     wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \

--- a/docker/docker-geosupport/setup.sh
+++ b/docker/docker-geosupport/setup.sh
@@ -3,7 +3,7 @@
 source config.sh
 set -e
 
-apt update && apt install -y curl git unzip zip build-essential
+apt update && apt install -y $GEOSUPPORT_APT_PACKAGES
 
 install_geosupport
 


### PR DESCRIPTION
the dcpy pytest part of our Nightly QA [failed](https://github.com/NYCPlanning/data-engineering/actions/runs/7218198722/job/19667240605#step:6:60) on main last night. seems to be due to the fact that our docker images used in those tests aren't rebuilt & published when we merge chaneges to main

this change should ensure that Nightly QA uses up-to-date docker images

> [!NOTE]
> These changes will not cause product builds to run on merges to main.
> This note format is a new github markdown feature [[docs here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)].