### PR TITLE
fix qa app python packages

### DIFF
--- a/apps/qa/requirements.txt
+++ b/apps/qa/requirements.txt
@@ -1,5 +1,6 @@
 folium
 geoalchemy2
+leafmap
 mapclassify
 matplotlib
 numerize


### PR DESCRIPTION
although tests on main which use `leafmap` are passing, the QA app can't find the package (see screenshot)

this change fixes that by adding `leafmap` to the list of packages we want the QA to use. that list is a subset of our primary list in [`python/requirements.in`](https://github.com/NYCPlanning/data-engineering/blob/main/python/requirements.in)

tested by delplying QA app from this branch and it [seems to have fixed it](https://de-qaqc.nycplanningdigital.com/?page=Template+DB)

<img width="959" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/d7c180b7-339c-4166-99c1-ebbd07d3efa6">
