### PR TITLE
pin less python package versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ on:
           - knownprojects
           - pluto
           - ztl
+          - all
       recipe_file:
         description: "Filename of recipe to use"
         type: choice

--- a/dcpy/test/utils/test_geospatial.py
+++ b/dcpy/test/utils/test_geospatial.py
@@ -41,10 +41,8 @@ def test_convert_to_geodata_wkb(data_wkb):
     ]
     assert isinstance(geodata["geometry_generated"], gpd.GeoSeries)
     assert geodata.geom_type.to_list() == ["Point", "MultiPolygon", None, None, None]
-    assert geodata.iloc[2:]["geometry_error"].to_list() == [
-        "ParseException: Unexpected EOF parsing WKB",
-        "Expected bytes or string, got float",
-        "Expected bytes or string, got float",
+    assert list(geodata[geodata.geometry.isnull()]["geometry_error"].unique()) == [
+        "Expected bytes or string, got float"
     ]
     assert str(geodata.crs) == geospatial.GeometryCRS.wgs_84_deg.value
 
@@ -71,10 +69,10 @@ def test_convert_to_geodata_wkt(data_wkt):
 
 
 def test_geoseries_constructors_fail(data_wkb, data_wkt):
-    with pytest.raises(shapely.errors.GEOSException):
+    with pytest.raises(TypeError):
         data_wkb["new_geometry_column"] = gpd.GeoSeries.from_wkb(data_wkb["geom"])
 
-    with pytest.raises(shapely.errors.GEOSException):
+    with pytest.raises(TypeError):
         data_wkb["new_geometry_column"] = gpd.GeoSeries.from_wkt(data_wkt["geom"])
 
 

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -28,20 +28,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.34.2
+boto3==1.34.3
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs==1.34.2
+boto3-stubs==1.34.3
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.34.2
+botocore==1.34.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.34.2
+botocore-stubs==1.34.3
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -136,7 +136,7 @@ folium==0.14.0
     #   -r python/requirements.in
     #   leafmap
     #   streamlit-folium
-fonttools==4.46.0
+fonttools==4.47.0
     # via matplotlib
 future==0.18.3
     # via usaddress
@@ -227,7 +227,7 @@ jsonschema-specifications==2023.11.2
     # via jsonschema
 jupyter-client==8.6.0
     # via ipykernel
-jupyter-core==5.5.0
+jupyter-core==5.5.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -237,7 +237,7 @@ kiwisolver==1.4.5
     # via matplotlib
 leafmap==0.29.7
     # via -r python/requirements.in
-lxml==4.9.3
+lxml==4.9.4
     # via -r python/requirements.in
 mapclassify==2.5.0
     # via -r python/requirements.in
@@ -260,7 +260,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mercantile==1.2.1
     # via contextily
-moto==4.2.11
+moto==4.2.12
     # via -r python/requirements.in
 msal==1.23.0
     # via -r python/requirements.in
@@ -290,6 +290,7 @@ numpy==1.26.2
     #   mapclassify
     #   matplotlib
     #   pandas
+    #   pandas-stubs
     #   pyarrow
     #   pydeck
     #   rasterio
@@ -311,7 +312,7 @@ packaging==23.2
     #   plotly
     #   pytest
     #   streamlit
-pandas==1.5.3
+pandas==2.1.4
     # via
     #   -r python/requirements.in
     #   altair
@@ -321,7 +322,7 @@ pandas==1.5.3
     #   mapclassify
     #   streamlit
     #   streamlit-aggrid
-pandas-stubs==1.5.3.230321
+pandas-stubs==2.1.4.231218
     # via -r python/requirements.in
 parso==0.8.3
     # via jedi
@@ -354,7 +355,7 @@ prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.1
     # via streamlit
-psutil==5.9.6
+psutil==5.9.7
     # via ipykernel
 psycopg2-binary==2.9.5
     # via -r python/requirements.in
@@ -362,9 +363,9 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-py-partiql-parser==0.4.2
+py-partiql-parser==0.5.0
     # via moto
-pyarrow==14.0.1
+pyarrow==14.0.2
     # via
     #   -r python/requirements.in
     #   streamlit
@@ -410,7 +411,7 @@ pytest-cov==4.0.0
     # via -r python/requirements.in
 python-box==7.1.1
     # via leafmap
-python-crfsuite==0.9.9
+python-crfsuite==0.9.10
     # via usaddress
 python-dateutil==2.8.2
     # via
@@ -466,7 +467,7 @@ rich==13.7.0
     # via
     #   -r python/requirements.in
     #   streamlit
-rpds-py==0.14.1
+rpds-py==0.15.2
     # via
     #   jsonschema
     #   referencing
@@ -590,6 +591,8 @@ typing-extensions==4.9.0
     #   sqlfluff
     #   streamlit
     #   typer
+tzdata==2023.3
+    # via pandas
 tzlocal==5.2
     # via streamlit
 urllib3==2.0.7

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -22,8 +22,8 @@ msal==1.23.0
 mypy==1.5.1
 numerize==0.*
 openpyxl==3.1.2
-pandas==1.5.3
-pandas-stubs==1.5.3.230321
+pandas
+pandas-stubs
 plotly==5.*
 psycopg2-binary==2.9.5
 types-psycopg2

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -28,20 +28,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.34.2
+boto3==1.34.3
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs[s3]==1.34.2
+boto3-stubs[s3]==1.34.3
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.34.2
+botocore==1.34.3
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.34.2
+botocore-stubs==1.34.3
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -136,7 +136,7 @@ folium==0.14.0
     #   -r python/requirements.in
     #   leafmap
     #   streamlit-folium
-fonttools==4.46.0
+fonttools==4.47.0
     # via matplotlib
 future==0.18.3
     # via usaddress
@@ -227,7 +227,7 @@ jsonschema-specifications==2023.11.2
     # via jsonschema
 jupyter-client==8.6.0
     # via ipykernel
-jupyter-core==5.5.0
+jupyter-core==5.5.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -237,7 +237,7 @@ kiwisolver==1.4.5
     # via matplotlib
 leafmap==0.29.7
     # via -r python/requirements.in
-lxml==4.9.3
+lxml==4.9.4
     # via -r python/requirements.in
 mapclassify==2.5.0
     # via -r python/requirements.in
@@ -260,7 +260,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mercantile==1.2.1
     # via contextily
-moto[s3]==4.2.11
+moto[s3]==4.2.12
     # via -r python/requirements.in
 msal==1.23.0
     # via -r python/requirements.in
@@ -290,6 +290,7 @@ numpy==1.26.2
     #   mapclassify
     #   matplotlib
     #   pandas
+    #   pandas-stubs
     #   pyarrow
     #   pydeck
     #   rasterio
@@ -311,7 +312,7 @@ packaging==23.2
     #   plotly
     #   pytest
     #   streamlit
-pandas==1.5.3
+pandas==2.1.4
     # via
     #   -r python/requirements.in
     #   altair
@@ -321,7 +322,7 @@ pandas==1.5.3
     #   mapclassify
     #   streamlit
     #   streamlit-aggrid
-pandas-stubs==1.5.3.230321
+pandas-stubs==2.1.4.231218
     # via -r python/requirements.in
 parso==0.8.3
     # via jedi
@@ -354,7 +355,7 @@ prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.1
     # via streamlit
-psutil==5.9.6
+psutil==5.9.7
     # via ipykernel
 psycopg2-binary==2.9.5
     # via -r python/requirements.in
@@ -362,9 +363,9 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-py-partiql-parser==0.4.2
+py-partiql-parser==0.5.0
     # via moto
-pyarrow==14.0.1
+pyarrow==14.0.2
     # via
     #   -r python/requirements.in
     #   streamlit
@@ -410,7 +411,7 @@ pytest-cov==4.0.0
     # via -r python/requirements.in
 python-box==7.1.1
     # via leafmap
-python-crfsuite==0.9.9
+python-crfsuite==0.9.10
     # via usaddress
 python-dateutil==2.8.2
     # via
@@ -466,7 +467,7 @@ rich==13.7.0
     # via
     #   -r python/requirements.in
     #   streamlit
-rpds-py==0.14.1
+rpds-py==0.15.2
     # via
     #   jsonschema
     #   referencing
@@ -590,6 +591,8 @@ typing-extensions==4.9.0
     #   sqlfluff
     #   streamlit
     #   typer
+tzdata==2023.3
+    # via pandas
 tzlocal==5.2
     # via streamlit
 urllib3==2.0.7


### PR DESCRIPTION
With our python packages, we don't seem to have strong reasons to pin packages to certain versions. As an experiment, this is an attempt to unpin `pandas` in the `.in` file and use the compile action that runs on `main` every Sunday.

The compile action was run on this branch is [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7267192121). The auto-generated PR was closed [here](https://github.com/NYCPlanning/data-engineering/pull/433) to merge changes into this branch.

All product builds were run on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-compile-requirements) to ensure package changes didn't break any.