### PR TITLE
add default value to repeat for workflow call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,9 @@ on:
       dev_image:
         type: boolean
         default: false
+      repeat:
+        type: boolean
+        default: false
 
 jobs:
   health_check:


### PR DESCRIPTION
I seem to have broken nightly builds. Tested `workflow_dispatch` with build=all before merging, but not `workflow_call`, where I forgot to supply a default value (or include at all)

Really repeat should be an invalid option when trying to build all (because you can only provide one version, there's no way it'd be valid for all products), but adding some sort of validation for that seems like unnecessary complexity in the workflow

[Failed run with many jobs failing at startup](https://github.com/NYCPlanning/data-engineering/actions/runs/7335271398)

[Run with jobs at least starting up](https://github.com/NYCPlanning/data-engineering/actions/runs/7340092958)