### PR TITLE
add manual schema override for nightly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,9 @@ on:
       repeat:
         type: boolean
         default: false
+      build_name:
+        type: string
+        required: false
 
 jobs:
   health_check:
@@ -78,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
+      build_name: ${{ inputs.build_name || github.head_ref || github.ref_name }}
     steps:
       - name: Check inputs
         run: |
@@ -91,6 +95,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
       version: ${{ inputs.version }}
       repeat: ${{ inputs.repeat }}
@@ -105,6 +110,7 @@ jobs:
       logging_level: ${{ inputs.logging_level }}
       build_note: ${{ inputs.build_note }}
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
   checkbook:
     needs: health_check
     if: inputs.dataset_name == 'checkbook' || inputs.dataset_name  == 'all'
@@ -112,6 +118,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
   colp:
     needs: health_check
     if: inputs.dataset_name == 'colp' || inputs.dataset_name  == 'all'
@@ -119,6 +126,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
       version: ${{ inputs.version }}
       repeat: ${{ inputs.repeat }}
@@ -129,6 +137,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
       version: ${{ inputs.version }}
       repeat: ${{ inputs.repeat }}
@@ -139,6 +148,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
   facilities:
     needs: health_check
     if: inputs.dataset_name == 'facilities' || inputs.dataset_name  == 'all'
@@ -146,6 +156,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
       version: ${{ inputs.version }}
       repeat: ${{ inputs.repeat }}
@@ -156,6 +167,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
   pluto:
     needs: health_check
     if: inputs.dataset_name == 'pluto' || inputs.dataset_name  == 'all'
@@ -163,6 +175,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
       version: ${{ inputs.version }}
       repeat: ${{ inputs.repeat }}
@@ -173,6 +186,7 @@ jobs:
     secrets: inherit
     with:
       image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
       version: ${{ inputs.version }}
       repeat: ${{ inputs.repeat }}

--- a/.github/workflows/cbbr_build.yml
+++ b/.github/workflows/cbbr_build.yml
@@ -12,6 +12,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
 
 jobs:
   build:
@@ -25,7 +28,7 @@ jobs:
       image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_DB: db-cbbr
-      BUILD_ENGINE_SCHEMA: cbbr_build
+      BUILD_NAME: ${{ inputs.build_name }}
     services:
       postgis:
         image: postgis/postgis:15-3.3-alpine

--- a/.github/workflows/checkbook_build.yml
+++ b/.github/workflows/checkbook_build.yml
@@ -6,6 +6,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name:
+        type: string
+        required: true
 
 jobs:
   build:
@@ -15,6 +18,7 @@ jobs:
       image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_DB: db-checkbook
+      BUILD_NAME: ${{ inputs.build_name }}
     defaults:
       run:
         shell: bash
@@ -36,6 +40,10 @@ jobs:
       - name: Setup build environment
         working-directory: ./
         run: ./bash/docker_container_setup.sh
+
+      - name: Set build environment variables
+        working-directory: ./
+        run: ./bash/build_env_setup.sh
 
       - name: Run dataloading and build
         run: |

--- a/.github/workflows/colp_build.yml
+++ b/.github/workflows/colp_build.yml
@@ -5,6 +5,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
       recipe_file:
         type: string
         required: true
@@ -27,7 +30,7 @@ jobs:
       image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_DB: db-colp
-      BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
+      BUILD_NAME: ${{ inputs.build_name }}
     services:
       postgis:
         image: postgis/postgis:15-3.3-alpine

--- a/.github/workflows/cpdb_build.yml
+++ b/.github/workflows/cpdb_build.yml
@@ -6,6 +6,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
       recipe_file:
         type: string
         required: true
@@ -28,7 +31,7 @@ jobs:
       image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_DB: db-cpdb
-      BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
+      BUILD_NAME: ${{ inputs.build_name }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/developments_build.yml
+++ b/.github/workflows/developments_build.yml
@@ -6,6 +6,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
 
 jobs:
   build:
@@ -19,7 +22,7 @@ jobs:
       image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
       env:
         BUILD_ENGINE_DB: db-devdb
-        BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
+        BUILD_NAME: ${{ inputs.build_name }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -6,6 +6,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
       recipe_file:
         type: string
         required: true
@@ -28,7 +31,7 @@ jobs:
       image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
       env:
         BUILD_ENGINE_DB: db-facilities
-        BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
+        BUILD_NAME: ${{ inputs.build_name }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/knownprojects_build.yml
+++ b/.github/workflows/knownprojects_build.yml
@@ -6,6 +6,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
 
 jobs:
   build:
@@ -19,7 +22,7 @@ jobs:
         working-directory: ./products/knownprojects
     env:
       BUILD_ENGINE_DB: kpdb
-      BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
+      BUILD_NAME: ${{ inputs.build_name }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/nightly_qa.yml
+++ b/.github/workflows/nightly_qa.yml
@@ -2,6 +2,11 @@ name: ⚙️ Nightly QA
 
 on:
   workflow_dispatch:
+    inputs:
+      build_name:
+        description: Name of the build environment
+        type: string
+        default: nightly_qa
   schedule:
     - cron: "0 5 * * *"
 
@@ -18,3 +23,4 @@ jobs:
       build_note: nightly qa
       recipe_file: recipe
       dev_image: false
+      build_name: ${{ inputs.build_name || 'nightly_qa' }}

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -6,6 +6,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
       create_issue:
         type: boolean
         default: false
@@ -31,7 +34,7 @@ jobs:
       image: nycplanning/build-base:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_DB: db-pluto
-      BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
+      BUILD_NAME: ${{ inputs.build_name }}
       BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pluto_publish_mvt.yml
+++ b/.github/workflows/pluto_publish_mvt.yml
@@ -3,8 +3,8 @@ run-name: "PLUTO - 🚀 Generate MVT ${{ inputs.tileset }} from ${{ inputs.min_z
 on:
   workflow_dispatch:
     inputs:
-      schema:
-        description: "Build schema in EDM Data"
+      build_name:
+        description: "Build build_name in EDM Data"
         type: string
         required: true
       tileset:
@@ -40,7 +40,7 @@ jobs:
       image: nycplanning/build-base:latest 
     env:
       BUILD_ENGINE_DB: db-pluto
-      BUILD_ENGINE_SCHEMA: ${{ inputs.schema }}
+      BUILD_ENGINE_SCHEMA: ${{ inputs.build_name }}
       MIN_ZOOM: ${{ inputs.min_zoom }}
       MAX_ZOOM: ${{ inputs.max_zoom }}
       TILE_SET: ${{ inputs.tileset }}

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -12,6 +12,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: false
       recipe_file:
         type: string
         required: true
@@ -25,6 +28,7 @@ on:
 env:
   TOY_SECRET_GITHUB: ${{ secrets.TOY_SECRET }}
   BUILD_ENGINE_DB: db-template
+  BUILD_NAME: ${{ inputs.build_name || github.head_ref || github.ref_name }}
   LOGGING_LEVEL: ${{ inputs.logging_level }}
 
 jobs:
@@ -64,6 +68,10 @@ jobs:
       - name: Finish container setup
         working-directory: ./
         run: ./bash/docker_container_setup.sh
+
+      - name: Set build environment variables
+        working-directory: ./
+        run: ./bash/build_env_setup.sh
 
       - name: Load
         env:

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -48,7 +48,7 @@ jobs:
           mypy products/template
   
   template-db:
-    if: (needs.check_changes.outputs.path_filters == '') || contains(needs.check_changes.outputs.path_filters, 'template')
+    if: (inputs.path_filter == '') || contains(inputs.path_filter, 'template')
     uses: ./.github/workflows/template_test.yml
     with:
       image_tag: ${{ inputs.image_tag }}

--- a/.github/workflows/zoningtaxlots_build.yml
+++ b/.github/workflows/zoningtaxlots_build.yml
@@ -6,6 +6,9 @@ on:
       image_tag:
         type: string
         required: false
+      build_name: 
+        type: string
+        required: true
       recipe_file:
         type: string
         required: true
@@ -28,7 +31,7 @@ jobs:
       image: nycplanning/build-base:${{ inputs.image_tag || 'latest' }}
     env:
       BUILD_ENGINE_DB: db-ztl
-      BUILD_ENGINE_SCHEMA: ${{ github.head_ref || github.ref_name }}
+      BUILD_NAME: ${{ inputs.build_name }}
     steps:
       - uses: actions/checkout@v3
 

--- a/bash/build_env_setup.sh
+++ b/bash/build_env_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # replace dashes with underscores to create a valid postgres schema name
-export BUILD_ENGINE_SCHEMA=$(echo ${BUILD_ENGINE_SCHEMA} | tr - _)
+export BUILD_ENGINE_SCHEMA=$(echo ${BUILD_NAME} | tr - _)
 echo "BUILD_ENGINE_SCHEMA=$BUILD_ENGINE_SCHEMA" >> "$GITHUB_ENV"
 
 # set postgres schema search path to prioritize BUILD_ENGINE_SCHEMA

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -308,14 +308,6 @@ function compress {
 }
 
 
-function upload {
-    local dataset_name=${1}
-    local acl=${2}
-    local build=${3:-$BUILD_NAME}
-    python3 -m dcpy.connectors.edm.publishing upload -p $dataset_name -o output -b $build -a $acl
-}
-
-
 # cpdb immediately calls with 5 as arg. Similar for devdb, facdb
 function max_bg_procs {
     if [[ $# -eq 0 ]] ; then

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -311,8 +311,7 @@ function compress {
 function upload {
     local dataset_name=${1}
     local acl=${2}
-    local branchname=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
-    local build=${3:-${branchname}}
+    local build=${3:-$BUILD_NAME}
     python3 -m dcpy.connectors.edm.publishing upload -p $dataset_name -o output -b $build -a $acl
 }
 

--- a/dcpy/builds/plan.py
+++ b/dcpy/builds/plan.py
@@ -8,13 +8,11 @@ import typer
 from typing import List
 import yaml
 
-from dcpy.utils import postgres
 from dcpy.utils import versions
 from dcpy.utils.logging import logger
 from dcpy.connectors.edm import recipes, publishing
 
 DEFAULT_RECIPE = "recipe.yml"
-BUILD_SCHEMA = os.environ.get("BUILD_ENGINE_SCHEMA", postgres.DEFAULT_POSTGRES_SCHEMA)
 LIBRARY_DEFAULT_PATH = recipes.LIBRARY_DEFAULT_PATH
 
 

--- a/products/cbbr/cbbr_build/04_export.sh
+++ b/products/cbbr/cbbr_build/04_export.sh
@@ -32,6 +32,6 @@ cd ..
 
 echo "Upload Output to DigitalOcean" 
 
-upload db-cbbr public-read
+python3 -m dcpy.connectors.edm.publishing upload -p db-cbbr -a public-read
 
 echo "Done!"

--- a/products/colp/bash/05_upload.sh
+++ b/products/colp/bash/05_upload.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-source bash/config.sh
-
-upload db-colp public-read
-
-wait 
-echo "Upload Complete"

--- a/products/colp/colp.sh
+++ b/products/colp/colp.sh
@@ -5,7 +5,7 @@ case $1 in
     build ) ./bash/02_build.sh ;;
     qaqc ) ./bash/03_qaqc.sh ;;
     export ) ./bash/04_export.sh ;;
-    upload ) ./bash/05_upload.sh ;;
+    upload ) python3 -m dcpy.connectors.edm.publishing upload -p db-colp -a public-read ;;
     sql) sql $@ ;;
     * ) echo "COMMAND \"$1\" is not found. (valid commands: dataloading|build|export|upload)" ;;
 esac

--- a/products/cpdb/cpdb.sh
+++ b/products/cpdb/cpdb.sh
@@ -64,7 +64,7 @@ case $1 in
     analysis ) ./bash/04_analysis.sh ;;
     export ) ./bash/05_export.sh ;;
     archive ) cpdb_archive $@ ;;
-    upload ) upload db-cpdb private ;;
+    upload ) python3 -m dcpy.connectors.edm.publishing upload -p db-cpdb -a private ;;
     share ) share $@ ;;
     sql) sql $@;;
     build)
@@ -77,5 +77,5 @@ case $1 in
         ./bash/03_adminbounds.sh
         ./bash/04_analysis.sh
         ./bash/05_export.sh
-        upload db-cpdb private
+        python3 -m dcpy.connectors.edm.publishing upload -p db-cpdb -a private
 esac

--- a/products/developments/bash/06_upload.sh
+++ b/products/developments/bash/06_upload.sh
@@ -1,3 +1,0 @@
-source bash/config.sh
-
-upload db-developments public-read

--- a/products/developments/devdb.sh
+++ b/products/developments/devdb.sh
@@ -24,7 +24,7 @@ function export {
 }
 
 function upload {
-    ./bash/06_upload.sh
+    python3 -m dcpy.connectors.edm.publishing upload -p db-developments -a public-read
 }
 
 function archive { 

--- a/products/facilities/facdb.sh
+++ b/products/facilities/facdb.sh
@@ -26,7 +26,7 @@ function facdb_archive {
 
 case $1 in
     init) init ;;
-    upload) upload "db-facilities" "public-read" ;;
+    upload) python3 -m dcpy.connectors.edm.publishing upload -p db-facilities -a public-read ;;
     archive) facdb_archive $@ ;;
     export) ./facdb/bash/export.sh ;;
     *) facdb_execute $@ ;;

--- a/products/pluto/pluto_build/06_export.sh
+++ b/products/pluto/pluto_build/06_export.sh
@@ -82,4 +82,4 @@ mkdir -p qaqc && (
 wait 
 cd ..
 
-upload db-pluto public-read
+python3 -m dcpy.connectors.edm.publishing upload -p db-pluto -a public-read

--- a/products/zoningtaxlots/bash/03_qaqc_upload.sh
+++ b/products/zoningtaxlots/bash/03_qaqc_upload.sh
@@ -76,4 +76,4 @@ psql -q ${EDM_DATA} -v VERSION=${VERSION_SQL_TABLE} -v VERSION_PREV=${VERSION_PR
     -f sql/qaqc/null.sql > output/qaqc_null.csv
 
 echo "Upload outpits ..."
-upload db-zoningtaxlots public-read
+python3 -m dcpy.connectors.edm.publishing upload -p db-zoningtaxlots -a public-read


### PR DESCRIPTION
Special schema for nightly builds to differentiate it as a special build environment from main. This way, if we're qa'ing something on main over multiple days, it won't get overwritten

[Nightly qa action](https://github.com/NYCPlanning/data-engineering/actions/runs/7341035203)

Pluto running as I write this, but other products have successfully built and exported using "nightly_qa" as schema and draft folder