### PR TITLE
add option to publish to latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: publish
         env:
-          latest: ${{ inputs.latest == 'true' && '--latest' || '' }}
+          latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
         run: |
           python3 -m dcpy.connectors.edm.publishing publish \
             -p db-${{ inputs.product }} \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ on:
         description: "Publish to 'latest' folder?"
         type: boolean
         default: true
+        required: true
       product_acl:
         description: "Set access control list for output in DO"
         type: choice

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,10 @@ on:
         description: "Version of official release"
         type: string
         required: true
+      latest:
+        description: "Publish to 'latest' folder?"
+        type: boolean
+        default: true
       product_acl:
         description: "Set access control list for output in DO"
         type: choice
@@ -65,9 +69,12 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: publish
+        env:
+          latest: ${{ inputs.latest == 'true' && '--latest' || '' }}
         run: |
           python3 -m dcpy.connectors.edm.publishing publish \
             -p db-${{ inputs.product }} \
             -b ${{ inputs.draft_build }} \
             -v ${{ inputs.publishing_version }} \
-            -a ${{ inputs.product_acl }}
+            -a ${{ inputs.product_acl }} \
+            $latest


### PR DESCRIPTION
We had never added this, so seemed about time

[action that successfully published to latest](https://github.com/NYCPlanning/data-engineering/actions/runs/7349107438)

This will be squashed