### PR TITLE
Update lpc_historic_districts, tweak data library workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_library_failure.md
+++ b/.github/ISSUE_TEMPLATE/data_library_failure.md
@@ -1,0 +1,9 @@
+---
+name: "Data Library Failure"
+about: Notification For failed attempt of data library automated updates
+title: "Data Library Failure - {{ env.ACTION }}"
+labels: ["bug"]
+assignees: []
+
+---
+[Failed action]({{ env.BUILD_URL }})

--- a/.github/workflows/data_library_docker.yml
+++ b/.github/workflows/data_library_docker.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          username: $DOCKER_USERNAME
-          password: $DOCKER_PASSWORD
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4

--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -41,3 +41,20 @@ jobs:
           s3: true
           compress: true
           output_format: pgdump shapefile csv
+
+  create_issue_on_failure:
+    runs-on: ubuntu-22.04
+    needs: dataloading
+    if: ${{ always() && (github.event_name == 'schedule') && contains(needs.dataloading.result, 'failure') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: "Open Data Weekly Updates"
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/data_library_failure.md

--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -5,6 +5,11 @@ on:
     # Weekly Cron job
     - cron: "0 0 * * 0"
   workflow_dispatch:
+    inputs:
+      use_staging_image:
+        description: "Use staging docker image instead of latest"
+        type: boolean
+        default: false
 
 jobs:
   dataloading:
@@ -35,6 +40,16 @@ jobs:
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
 
       - uses: NYCPlanning/action-library-archive@v1.1
+        if: ${{ !(inputs.use_staging_image) }}
+        with:
+          name: ${{ matrix.dataset }}
+          latest: true
+          s3: true
+          compress: true
+          output_format: pgdump shapefile csv
+
+      - uses: NYCPlanning/action-library-archive@v1.2
+        if: ${{ inputs.use_staging_image }}
         with:
           name: ${{ matrix.dataset }}
           latest: true

--- a/.github/workflows/data_library_quarterly.yml
+++ b/.github/workflows/data_library_quarterly.yml
@@ -7,6 +7,10 @@ on:
         description: 'The quarterly version name (e.g. 21b, has to be all lower case)'
         required: true
         default: 21c
+      use_staging_image:
+        description: "Use staging docker image instead of latest"
+        type: boolean
+        default: false
 
 jobs:
   dataloading:
@@ -61,6 +65,17 @@ jobs:
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
 
       - uses: NYCPlanning/action-library-archive@v1.1
+        if: ${{ !(inputs.use_staging_image) }}
+        with:
+          name: ${{ matrix.dataset }}
+          version: ${{ github.event.inputs.version }}
+          latest: true
+          s3: true
+          compress: true
+          output_format: pgdump shapefile csv
+
+      - uses: NYCPlanning/action-library-archive@v1.2
+        if: ${{ inputs.use_staging_image }}
         with:
           name: ${{ matrix.dataset }}
           version: ${{ github.event.inputs.version }}

--- a/data-library/library/templates/lpc_historic_districts.yml
+++ b/data-library/library/templates/lpc_historic_districts.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     socrata:
-      uid: x3ar-yjn2
+      uid: gpmc-yuvp
       format: csv
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
lpc_historic_districts uid/four-four changed for some reason, leading to failures of recurring job.

Also added tweaks to create an issue when this job fails. See [failing action here](https://github.com/NYCPlanning/data-engineering/actions/runs/7350292406) and created issue #455

[Succeeding update of lpc_historic_districts](https://github.com/NYCPlanning/data-engineering/actions/runs/7350281797)

Also added ability to use staging image/action for these data library jobs which use the published action. [Passing open data update](https://github.com/NYCPlanning/data-engineering/actions/runs/7350440650/job/20012099702)