### PR TITLE
FacDB Enhancement

### DIFF
--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -6,7 +6,7 @@ on:
       image_tag:
         type: string
         required: false
-      build_name: 
+      build_name:
         type: string
         required: true
       recipe_file:
@@ -74,6 +74,9 @@ jobs:
 
       - name: QAQC facdb
         run: python -m facdb.cli qaqc
+
+      - name: Modify facdb table
+        run: python -m facdb.cli reformat-facdb
 
       - name: Export facdb
         run: ./facdb.sh export

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -265,6 +265,7 @@ function fgdb_export_partial {
             -nlt ${geomtype}\
             -t_srs ${target_projection}\
             "$@"
+        ogrinfo -al -so ${filename}.gdb
         rm -f ${filename}.gdb.zip
     )
 }

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -4,6 +4,7 @@ DATE=$(date "+%Y-%m-%d")
 recipes_bucket=edm-recipes
 publishing_bucket=edm-publishing
 recipes_url=${AWS_S3_ENDPOINT}/${recipes_bucket}
+default_srs=EPSG:2263
 UTILS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 ROOT_DIR=$(dirname ${UTILS_DIR})
 export PYTHONPATH=$ROOT_DIR
@@ -246,7 +247,8 @@ function fgdb_export_partial {
     local geomtype=${2}
     local nln=${3}
     local table=${4}
-    shift 4
+    local target_projection=${5}
+    shift 5
     if [ -n "${BUILD_ENGINE_SCHEMA}" ]; then
         local schema=${BUILD_ENGINE_SCHEMA}
     else
@@ -261,6 +263,7 @@ function fgdb_export_partial {
             -lco GEOMETRY_NAME=Shape\
             -nln ${nln}\
             -nlt ${geomtype}\
+            -t_srs ${target_projection}\
             "$@"
         rm -f ${filename}.gdb.zip
     )
@@ -282,7 +285,8 @@ function fgdb_export {
     local table=${1}
     local geomtype=${2}
     local filename=${3:-$table}
-    fgdb_export_partial ${filename} ${geomtype} ${table} ${table}
+    local target_projection=${4:-$default_srs}
+    fgdb_export_partial ${filename} ${geomtype} ${table} ${table} ${target_projection}
     fgdb_export_cleanup ${filename}
 }
 

--- a/products/facilities/facdb/bash/export.sh
+++ b/products/facilities/facdb/bash/export.sh
@@ -11,7 +11,7 @@ mkdir -p output && (
     cp ../facdb/metadata.yml ./
     cp ../build_metadata.json ./
     cp ../source_data_versions.csv ./
-    csv_export facdb facilities &
+    csv_export facdb_without_geom_col facilities &
     csv_export qc_operator &
     csv_export qc_oversight &
     csv_export qc_classification &

--- a/products/facilities/facdb/bash/export.sh
+++ b/products/facilities/facdb/bash/export.sh
@@ -22,7 +22,7 @@ mkdir -p output && (
     csv_export qc_subgrpbins &
     # csv_export geo_rejects &
     # csv_export geo_result &
-    shp_export facdb POINT -f facilities
+    shp_export facdb POINT -f facilities -t_srs "EPSG:2263"
     fgdb_export facdb POINT facilities
     wait
     echo "export complete"

--- a/products/facilities/facdb/cli.py
+++ b/products/facilities/facdb/cli.py
@@ -109,6 +109,16 @@ def run(
 
 
 @app.command()
+def reformat_facdb():
+    """Update columns and data types in facdb table."""
+    postgres.execute_file_via_shell(
+        BUILD_ENGINE,
+        SQL_PATH / "_reformat_facdb.sql",
+        build_schema=BUILD_NAME,
+    )
+
+
+@app.command()
 def sql(
     scripts: Optional[List[Path]] = typer.Option(
         None, "-f", help="SQL Scripts to execute"

--- a/products/facilities/facdb/sql/_reformat_facdb.sql
+++ b/products/facilities/facdb/sql/_reformat_facdb.sql
@@ -40,6 +40,50 @@ SELECT
     schooldist::VARCHAR(3) AS "SCHOOLDIST",
     policeprct::SMALLINT AS "POLICEPRCT",
     datasource::VARCHAR(150) AS "DATASOURCE",
+    uid::VARCHAR AS "UID",
+    geom
+FROM facdb;
+
+
+-- create facdb table without geometry column
+CREATE TABLE facdb_without_geom_col AS
+SELECT
+    facname::VARCHAR(250) AS "FACNAME",
+    addressnum::VARCHAR(12) AS "ADDRESSNUM",
+    streetname::VARCHAR(50) AS "STREETNAME",
+    address::VARCHAR(150) AS "ADDRESS",
+    city::VARCHAR(50) AS "CITY",
+    zipcode::VARCHAR(5) AS "ZIPCODE",
+    factype::VARCHAR(250) AS "FACTYPE",
+    facsubgrp::VARCHAR(100) AS "FACSUBGRP",
+    facgroup::VARCHAR(100) AS "FACGROUP",
+    facdomain::VARCHAR(100) AS "FACDOMAIN",
+    servarea::VARCHAR(10) AS "SERVAREA",
+    opname::VARCHAR(150) AS "OPNAME",
+    opabbrev::VARCHAR(12) AS "OPABBREV",
+    optype::VARCHAR(12) AS "OPTYPE",
+    overagency::VARCHAR(150) AS "OVERAGENCY",
+    overabbrev::VARCHAR(12) AS "OVERABBREV",
+    overlevel::VARCHAR(12) AS "OVERLEVEL",
+    capacity::INT AS "CAPACITY",
+    captype::VARCHAR(12) AS "CAPTYPE",
+    boro::VARCHAR(15) AS "BORO",
+    bin::INT AS "BIN",
+    bbl::NUMERIC(10) AS "BBL",
+    latitude::FLOAT AS "LATITUDE",
+    longitude::FLOAT AS "LONGITUDE",
+    xcoord::FLOAT AS "XCOORD",
+    ycoord::FLOAT AS "YCOORD",
+    cd::SMALLINT AS "CD",
+    nta2010::VARCHAR(6) AS "NTA2010",
+    nta2020::VARCHAR(6) AS "NTA2020",
+    council::SMALLINT AS "COUNCIL",
+    ct2010::VARCHAR(6) AS "CT2010",
+    ct2020::VARCHAR(6) AS "CT2020",
+    borocode::SMALLINT AS "BOROCODE",
+    schooldist::VARCHAR(3) AS "SCHOOLDIST",
+    policeprct::SMALLINT AS "POLICEPRCT",
+    datasource::VARCHAR(150) AS "DATASOURCE",
     uid::VARCHAR AS "UID"
 FROM facdb;
 
@@ -49,3 +93,4 @@ ALTER TABLE temp_facdb RENAME TO facdb;
 
 -- replace empty strings ('' or ' ') with NULL value in facdb
 CALL replace_empty_strings(:'build_schema', 'facdb');
+CALL replace_empty_strings(:'build_schema', 'facdb_without_geom_col')

--- a/products/facilities/facdb/sql/_reformat_facdb.sql
+++ b/products/facilities/facdb/sql/_reformat_facdb.sql
@@ -1,0 +1,51 @@
+-- modify facdb column names and their data types based on GIS template schema: https://github.com/NYCPlanning/gis-facilities-and-pops/blob/main/templates/_template_facilities_schema.json#L12
+-- mapping of data types between postgres and geodabase reference: https://pro.arcgis.com/en/pro-app/3.1/help/data/geodatabases/manage-postgresql/data-types-postgresql.htm
+
+-- create facdb table with expected column names and data types
+CREATE TABLE temp_facdb AS
+SELECT
+    facname::VARCHAR(250) AS "FACNAME",
+    addressnum::VARCHAR(12) AS "ADDRESSNUM",
+    streetname::VARCHAR(50) AS "STREETNAME",
+    address::VARCHAR(150) AS "ADDRESS",
+    city::VARCHAR(50) AS "CITY",
+    zipcode::VARCHAR(5) AS "ZIPCODE",
+    factype::VARCHAR(250) AS "FACTYPE",
+    facsubgrp::VARCHAR(100) AS "FACSUBGRP",
+    facgroup::VARCHAR(100) AS "FACGROUP",
+    facdomain::VARCHAR(100) AS "FACDOMAIN",
+    servarea::VARCHAR(10) AS "SERVAREA",
+    opname::VARCHAR(150) AS "OPNAME",
+    opabbrev::VARCHAR(12) AS "OPABBREV",
+    optype::VARCHAR(12) AS "OPTYPE",
+    overagency::VARCHAR(150) AS "OVERAGENCY",
+    overabbrev::VARCHAR(12) AS "OVERABBREV",
+    overlevel::VARCHAR(12) AS "OVERLEVEL",
+    capacity::INT AS "CAPACITY",
+    captype::VARCHAR(12) AS "CAPTYPE",
+    boro::VARCHAR(15) AS "BORO",
+    bin::INT AS "BIN",
+    bbl::NUMERIC(10) AS "BBL",
+    latitude::FLOAT AS "LATITUDE",
+    longitude::FLOAT AS "LONGITUDE",
+    xcoord::FLOAT AS "XCOORD",
+    ycoord::FLOAT AS "YCOORD",
+    cd::SMALLINT AS "CD",
+    nta2010::VARCHAR(6) AS "NTA2010",
+    nta2020::VARCHAR(6) AS "NTA2020",
+    council::SMALLINT AS "COUNCIL",
+    ct2010::VARCHAR(6) AS "CT2010",
+    ct2020::VARCHAR(6) AS "CT2020",
+    borocode::SMALLINT AS "BOROCODE",
+    schooldist::VARCHAR(3) AS "SCHOOLDIST",
+    policeprct::SMALLINT AS "POLICEPRCT",
+    datasource::VARCHAR(150) AS "DATASOURCE",
+    uid::VARCHAR AS "UID"
+FROM facdb;
+
+-- delete old facdb table and rename the new one
+DROP TABLE facdb;
+ALTER TABLE temp_facdb RENAME TO facdb;
+
+-- replace empty strings ('' or ' ') with NULL value in facdb
+CALL replace_empty_strings(:'build_schema', 'facdb');

--- a/products/facilities/recipe.yml
+++ b/products/facilities/recipe.yml
@@ -9,95 +9,96 @@ inputs:
       function: dispatch
   missing_versions_strategy: find_latest
   datasets:
-  - name: dcp_facilities_with_unmapped
-    version_env_var: VERSION_PREV
-    file_type: pg_dump
-  - name: dcp_mappluto_wi
-    file_type: pg_dump
-  - name: dcp_boroboundaries_wi
-    file_type: pg_dump
-  - name: dcp_ct2010
-    file_type: pg_dump
-  - name: dcp_ct2020
-    file_type: pg_dump
-  - name: dcp_councildistricts
-    file_type: pg_dump
-    version: 22c
-  - name: dcp_cdboundaries
-    file_type: pg_dump
-  - name: dcp_nta2010
-    file_type: pg_dump
-  - name: dcp_nta2020
-    file_type: pg_dump
-  - name: dcp_policeprecincts
-    file_type: pg_dump
-  - name: doitt_zipcodeboundaries
-    file_type: pg_dump
-  - name: doitt_buildingfootprints
-    file_type: pg_dump
-  - name: dcp_school_districts
-    file_type: pg_dump
+    - name: dcp_facilities_with_unmapped
+      version_env_var: VERSION_PREV
+      file_type: pg_dump
+    - name: dcp_mappluto_wi
+      file_type: pg_dump
+    - name: dcp_boroboundaries_wi
+      file_type: pg_dump
+    - name: dcp_ct2010
+      file_type: pg_dump
+    - name: dcp_ct2020
+      file_type: pg_dump
+    - name: dcp_councildistricts
+      file_type: pg_dump
+      version: 22c
+    - name: dcp_cdboundaries
+      file_type: pg_dump
+    - name: dcp_nta2010
+      file_type: pg_dump
+    - name: dcp_nta2020
+      file_type: pg_dump
+    - name: dcp_policeprecincts
+      file_type: pg_dump
+    - name: doitt_zipcodeboundaries
+      file_type: pg_dump
+    - name: doitt_buildingfootprints
+      file_type: pg_dump
+    - name: dcp_school_districts
+      file_type: pg_dump
 
-  # CSVs
-  - name: nypl_libraries
-  - name: bpl_libraries
-  - name: dcp_colp
-  - name: dca_operatingbusinesses
-  - name: dcla_culturalinstitutions
-  - name: dcp_sfpsd
-    version: "20210409"
-  # TODO: revisit this pin
-  - name: dcp_pops
-    version: "20230320"
-  - name: dsny_garages
-  - name: dsny_specialwastedrop
-  - name: dsny_donatenycdirectory
-  - name: dsny_leafdrop
-  - name: dsny_fooddrop
-  - name: dsny_electronicsdrop
-  - name: hra_snapcenters
-  - name: hra_jobcenters
-  - name: hra_medicaid
-  - name: nycha_communitycenters
-  - name: nycha_policeservice
-  - name: nycourts_courts
-  - name: nysdec_lands
-  - name: dot_bridgehouses
-  - name: dot_ferryterminals
-  - name: dot_mannedfacilities
-  - name: dot_pedplazas
-  - name: dot_publicparking
-  - name: qpl_libraries
-  - name: sbs_workforce1
-  - name: uscourts_courts
-  - name: usdot_airports
-  - name: usdot_ports
-  - name: usnps_parks
-  - name: nysdec_solidwaste
-  - name: nysdoh_healthfacilities
-  - name: nysdoh_nursinghomes
-  - name: nysdoccs_corrections
-  - name: nysed_nonpublicenrollment
-  - name: nysed_activeinstitutions
-  - name: nysomh_mentalhealth
-  - name: dpr_parksproperties
-  - name: dycd_afterschoolprograms
-  - name: fbop_corrections
-  - name: fdny_firehouses
-  - name: nysomh_mentalhealth
-  - name: dep_wwtc
-    version: "20210413"
-  - name: dfta_contracts
-  - name: doe_busroutesgarages
-  - name: sca_enrollment_capacity
-  - name: doe_lcgms
-  - name: doe_universalprek
-  - name: dohmh_daycare
-  - name: foodbankny_foodbanks
-  - name: hhc_hospitals
-  - name: moeo_socialservicesitelocations
-  - name: nycdoc_corrections
-  - name: nysopwdd_providers
-  - name: nysparks_historicplaces
-  - name: nysparks_parks
-  - name: nysoasas_programs
+    # CSVs
+    - name: nypl_libraries
+    - name: bpl_libraries
+    - name: dcp_colp
+    - name: dca_operatingbusinesses
+    - name: dcla_culturalinstitutions
+    - name: dcp_sfpsd
+      version: "20210409"
+    # TODO: revisit this pin
+    - name: dcp_pops
+      version: "20230320"
+    - name: dsny_garages
+    - name: dsny_specialwastedrop
+    - name: dsny_donatenycdirectory
+    - name: dsny_leafdrop
+    - name: dsny_fooddrop
+    - name: dsny_electronicsdrop
+    - name: hra_snapcenters
+    - name: hra_jobcenters
+    - name: hra_medicaid
+    - name: nycha_communitycenters
+    - name: nycha_policeservice
+    - name: nycourts_courts
+    - name: nysdec_lands
+    - name: dot_bridgehouses
+    - name: dot_ferryterminals
+    - name: dot_mannedfacilities
+    - name: dot_pedplazas
+    - name: dot_publicparking
+    - name: qpl_libraries
+    - name: sbs_workforce1
+    - name: uscourts_courts
+    - name: usdot_airports
+    - name: usdot_ports
+    - name: usnps_parks
+    - name: nysdec_solidwaste
+    - name: nysdoh_healthfacilities
+    - name: nysdoh_nursinghomes
+    - name: nysdoccs_corrections
+    - name: nysed_nonpublicenrollment
+    - name: nysed_activeinstitutions
+    - name: nysomh_mentalhealth
+    - name: dpr_parksproperties
+    - name: dycd_afterschoolprograms
+    - name: fbop_corrections
+    - name: fdny_firehouses
+    - name: nysomh_mentalhealth
+    - name: dep_wwtc
+      version: "20210413"
+    - name: dfta_contracts
+      version: "20210423"
+    - name: doe_busroutesgarages
+    - name: sca_enrollment_capacity
+    - name: doe_lcgms
+    - name: doe_universalprek
+    - name: dohmh_daycare
+    - name: foodbankny_foodbanks
+    - name: hhc_hospitals
+    - name: moeo_socialservicesitelocations
+    - name: nycdoc_corrections
+    - name: nysopwdd_providers
+    - name: nysparks_historicplaces
+    - name: nysparks_parks
+    - name: nysoasas_programs

--- a/products/pluto/pluto_build/bash/config.sh
+++ b/products/pluto/pluto_build/bash/config.sh
@@ -41,7 +41,7 @@ function fgdb_export_pluto {
     mkdir ${foldername}
     (
         cd ${foldername}
-        fgdb_export_partial ${filename} MULTIPOLYGON ${filename} ${filename}
+        fgdb_export_partial ${filename} MULTIPOLYGON ${filename} ${filename} ${default_srs}
         fgdb_export_partial ${filename} NONE NOT_MAPPED_LOTS unmapped -update
         fgdb_export_cleanup ${filename}
     )


### PR DESCRIPTION
Resolves #449.

# Changes:

This PR consists of 2 commits: 

1) Specify spatial projection of `EPSG:2263` as a default value when exporting build to geodabase `.gdb` format.
    * This update will impact all data products that use `fgdb_export` and/or `fgdb_partial_export` fn from `bash/utils.sh` script. 
    * Current products that use the function: **FacDB**, **COLP**, and **PLUTO**. Note, PLUTO has its own fn `fgdb_export_pluto` that is built on top of the utils`fgdb_partial_export` fn.
    * If a certain data product needs a different projection, it can be specified when calling the `fgdb_export` fn. 
   
2) Modify `facdb` table before exporting to various data formats using [this](https://github.com/NYCPlanning/gis-facilities-and-pops/blob/main/templates/_template_facilities_schema.json) metadata:
    * Updated column names, data formats, data max length (example, `VARCHAR(250)` for `FACNAME` column).
    * Replace empty strings (`''` and `' '`) with `NULL` value across the table.
    * These modifications are done via an additional step in the end of the build. The rational to do this in the end rather than in the beginning when setting up expected table schema is because it would impact many downstream sql commands. For example, renamed columns would have to be updated in `SELECT` statements in the QA-related queries.

# Tests:
* ### Projection is set correctly:

Run command to get a summary of a geodabase file including its spatial projection: 

```bash
ogrinfo -al -so facilities.gdb
```

Output when NOT specifying projection (example below is for the latest published FacDB version `2023-08-09`): 

 
   <img width="489" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/2ee1bbb1-bb17-401c-ba89-84f926ea9e23">

Output when specifying projection (example below is a draft [build](https://github.com/NYCPlanning/data-engineering/actions/runs/7415362668) ran from `sf-facdb-gis-enhancement` branch):

   
<img width="666" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/85e54292-6e56-4e08-947d-6ff74f22374a">

* ### Correct column names and data types:
Using the same CLI gdal command, investigated my geodabase (left) versus the FacDB Bytes geodabase (right):
<img width="735" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/2b1f58dd-905c-41aa-a22b-8ec0cf9bfe4e">
They should be the same. 

Also, checked my geodabase against expected table [schema](https://github.com/NYCPlanning/gis-facilities-and-pops/blob/main/templates/_template_facilities_schema.json) defined by GIS.

# Notes:
* Successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7415362668)
* Outputs from the run in `edm-publishing/db-facilities/draft/sf-facdb-gis-enhancement/`. [DO link](https://cloud.digitalocean.com/spaces/edm-publishing?i=266877&path=db-facilities%2Fdraft%2Fsf-facdb-gis-enhancement%2F).