### PR TITLE
create template for quarterly milestone

### DIFF
--- a/docs/templates/milestone_quarterly_template.md
+++ b/docs/templates/milestone_quarterly_template.md
@@ -1,0 +1,26 @@
+# Priorities and Goals
+
+## Product
+
+### Update and release scheduled data products
+
+- Monthly: ZTL, ZAP, PLUTO
+- Month1: XXX, XXX, XXX
+- Month2: XXX, XXX
+- Month3: [FILL IN BASED ON [PLANNING DOCS](https://github.com/NYCPlanning/data-engineering/wiki/Operations)]
+
+### Enhance and create products
+
+- [FILL IN BASED ON [PLANNING DOCS](https://github.com/NYCPlanning/data-engineering/wiki/Operations)]
+
+## Operation
+
+- [FILL IN BASED ON [PLANNING DOCS](https://github.com/NYCPlanning/data-engineering/wiki/Operations)]
+
+## Ecosystem
+
+- [FILL IN BASED ON [PLANNING DOCS](https://github.com/NYCPlanning/data-engineering/wiki/Operations)]
+
+## Community
+
+- [FILL IN BASED ON [PLANNING DOCS](https://github.com/NYCPlanning/data-engineering/wiki/Operations)]


### PR DESCRIPTION
We now use milestones to scope and track projects. To do that for our data updates, I've tried using a "quarterly milestone" (see the 2024 Q1 milestone [here](https://github.com/NYCPlanning/data-engineering/milestone/10) and our Project Plan view [here](https://github.com/orgs/NYCPlanning/projects/27/views/17)).

This adds a template to reference when creating future quarterly milestones.