### PR TITLE
Pluto inputs - fix ssh key in 1pass

### DIFF
--- a/.github/workflows/pluto_input_cama.yml
+++ b/.github/workflows/pluto_input_cama.yml
@@ -41,7 +41,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
-          SSH_PRIVATE_KEY_GINGER: "op://Data Engineering/DOF_SFTP/ssh_private_key"
+          SSH_PRIVATE_KEY_GINGER: "op://Data Engineering/DOF_SFTP/private key"
           GINGER_HOST: "op://Data Engineering/DOF_SFTP/url"
           GINGER_USER: "op://Data Engineering/DOF_SFTP/username"
 

--- a/.github/workflows/pluto_input_pts.yml
+++ b/.github/workflows/pluto_input_pts.yml
@@ -41,7 +41,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
-          SSH_PRIVATE_KEY_GINGER: "op://Data Engineering/DOF_SFTP/ssh_private_key"
+          SSH_PRIVATE_KEY_GINGER: "op://Data Engineering/DOF_SFTP/private key"
           GINGER_HOST: "op://Data Engineering/DOF_SFTP/url"
           GINGER_USER: "op://Data Engineering/DOF_SFTP/username"
 


### PR DESCRIPTION
SSH key was stored in a password field in 1pass, which does not support newlines. Support for ssh keys in browser is not great, but in 1pass desktop app they have more support around them. I've replaced the dof sftp info in our 1pass vault and updates the path for in these workflows (ssh keys have specific set paths like `private key` and `public key` so they needed to be changed here rather than in 1pass

Failing [CAMA](https://github.com/NYCPlanning/data-engineering/actions/runs/7377532301), [pts](https://github.com/NYCPlanning/data-engineering/actions/runs/7377515747) before

Passing [CAMA](https://github.com/NYCPlanning/data-engineering/actions/runs/7387278575), [pts](https://github.com/NYCPlanning/data-engineering/actions/runs/7387335683) now

Also just a reminder for us to test a little more rigorously when updating infrastructure.