### PR TITLE
add build_name input to zoningtaxlots_build call

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -59,6 +59,7 @@ jobs:
     uses: ./.github/workflows/zoningtaxlots_build.yml
     secrets: inherit
     with:
+      build_name: ${{ github.head_ref || github.ref_name }}
       recipe_file: recipe
 
   pluto_minor:


### PR DESCRIPTION
GIS tried running ZTL dataloading but it fails due to invalid workflow ([example](https://github.com/NYCPlanning/data-engineering/actions/runs/7399164235))

that action calls `zoningtaxlots_build.yml` but doesn't provide [the required input](https://github.com/NYCPlanning/data-engineering/blob/dm-fix-ztl-dataloading/.github/workflows/zoningtaxlots_build.yml#L9-L11) `build_name`