### PR TITLE
add build_name input to pluto_build call

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       AWS_S3_BUCKET: edm-recipes
+      BUILD_NAME: ${{ github.head_ref || github.ref_name }}
     strategy:
       matrix:
         dataset:
@@ -59,7 +60,7 @@ jobs:
     uses: ./.github/workflows/zoningtaxlots_build.yml
     secrets: inherit
     with:
-      build_name: ${{ github.head_ref || github.ref_name }}
+      build_name: ${{ env.BUILD_NAME }}
       recipe_file: recipe
 
   pluto_minor:
@@ -70,4 +71,5 @@ jobs:
     secrets: inherit
     with:
       create_issue: true
+      build_name: ${{ env.BUILD_NAME }}
       recipe_file: recipe-minor


### PR DESCRIPTION
follow up to #477 because the action failed at the next step ([run logs](https://github.com/NYCPlanning/data-engineering/actions/runs/7400747383))