### PR TITLE
no envar for build_name in ztl dataloading action

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       AWS_S3_BUCKET: edm-recipes
-      BUILD_NAME: ${{ github.head_ref || github.ref_name }}
     strategy:
       matrix:
         dataset:
@@ -60,7 +59,7 @@ jobs:
     uses: ./.github/workflows/zoningtaxlots_build.yml
     secrets: inherit
     with:
-      build_name: ${{ env.BUILD_NAME }}
+      build_name: ${{ github.head_ref || github.ref_name }}
       recipe_file: recipe
 
   pluto_minor:
@@ -71,5 +70,5 @@ jobs:
     secrets: inherit
     with:
       create_issue: true
-      build_name: ${{ env.BUILD_NAME }}
+      build_name: ${{ github.head_ref || github.ref_name }}
       recipe_file: recipe-minor


### PR DESCRIPTION
follow-up to #478 and #477 

action run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7401028713) was started and cancelled before any archiving was done (to ensure run on `main` is the only one today)