### PR TITLE
Data Library: Fix export for single datasets

### DIFF
--- a/.github/workflows/data_library_single.yml
+++ b/.github/workflows/data_library_single.yml
@@ -60,4 +60,4 @@ jobs:
         env:
           latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
           version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-        run: library archive --name ${{ github.event.inputs.dataset }} --output ${{ github.event.inputs.format }} --s3 $latest $version
+        run: library archive --name ${{ github.event.inputs.dataset }} --output-format ${{ github.event.inputs.format }} --s3 $latest $version


### PR DESCRIPTION
When running a [job](https://github.com/NYCPlanning/data-engineering/actions/runs/7427573511/job/20213501998#step:6:16) to update a single dataset, export failed because of an incorrect flag:

<img width="685" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/f90003e9-dbae-4201-a2f9-c6bb607e836e">

@fvankrieken, I saw you had a similar issue and fixed it on your branch. I couldn't find the branch, so opening a PR. 