### PR TITLE
Use council district from dcp_councildistricts_wi

### DIFF
--- a/dcpy/library/templates/dcp_colp.yml
+++ b/dcpy/library/templates/dcp_colp.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_colp_csv_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/colp_{{ version }}_csv.zip
       subpath: colp_{{ version }}.csv
     options:
       - "AUTODETECT_TYPE=NO"

--- a/products/pluto/pluto_build/sql/dedupecondotable.sql
+++ b/products/pluto/pluto_build/sql/dedupecondotable.sql
@@ -47,22 +47,7 @@ WHERE id IN (
             id,
             ROW_NUMBER() OVER (
                 PARTITION BY condo_base_bbl
-                -- TODO This hard-coding is a temporary fix to preserve ordering from 23v3
-                -- 24v1 should have the `condo_billing_bbl IN ...` removed, and order just by condo_billing_bbl
-                ORDER BY condo_billing_bbl IN (
-                    '3002787502',
-                    '3003047501',
-                    '4050667502',
-                    '4050667507',
-                    '4076217502',
-                    '5014957501',
-                    '5024017501',
-                    '5030247501',
-                    '5031737504',
-                    '5070487502',
-                    '5070557501'
-                ) DESC,
-                condo_billing_bbl
+                ORDER BY condo_billing_bbl
             ) AS row_num
         FROM pluto_condo
         WHERE condo_billing_bbl IS NOT NULL

--- a/products/pluto/pluto_build/sql/geocodes.sql
+++ b/products/pluto/pluto_build/sql/geocodes.sql
@@ -9,7 +9,7 @@ SET
     tract2010 = b.ct2010,
     cb2010 = b.cb2010,
     schooldist = b.schooldist,
-    -- council = ltrim(b.council, '0'),
+    council = ltrim(b.council, '0'),
     zipcode = b.zipcode,
     firecomp = b.firecomp,
     policeprct = ltrim(b.policeprct, '0'),

--- a/products/pluto/recipe.yml
+++ b/products/pluto/recipe.yml
@@ -6,7 +6,6 @@ inputs:
   missing_versions_strategy: find_latest
   datasets:
     - name: dcp_councildistricts_wi
-      version: 22c
     - name: dcp_cb2010_wi
     - name: dcp_cb2020_wi
     - name: dcp_cdboundaries_wi


### PR DESCRIPTION
Also bumps council districts to match current geosupport version. 

Context: We want to take council district values geosupport, instead of computing them ourselves via a spatial join. We used to do it this way, and uncommenting the one line in `geocodes.sql` reverts to that behavior.  

Issue [here](https://github.com/NYCPlanning/data-engineering/issues/463)