### PR TITLE
use our `nycplanning/base` image in qa app image

### DIFF
--- a/apps/qa/Dockerfile
+++ b/apps/qa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM nycplanning/base:latest
 
 WORKDIR /app
 


### PR DESCRIPTION
see failed qa app deploy run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7493166441/job/20398276167#step:4:196) due to lack of gdal

glad is now needed in qa app because we move data-library code into dcpy

successful deploy run with this branch [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7493320215)