### PR TITLE
fix ZTL QA page

### DIFF
--- a/apps/qa/tests/test_io.py
+++ b/apps/qa/tests/test_io.py
@@ -17,8 +17,6 @@ TEST_DATA_SOURCE_COLUMNS = [
     "wkb_geometry",
 ]
 
-pg_client = PostgresClient(database=QAQC_DB, schema=QAQC_DB_SCHEMA_SOURCE_DATA)
-
 
 def test_dataset_config():
     dataset_confg = get_config(TEST_DATA_SOURCE_NAME, TEST_DATA_SOURCE_VERSION)
@@ -28,6 +26,7 @@ def test_dataset_config():
 
 
 def test_source_data_columns():
+    pg_client = PostgresClient(database=QAQC_DB, schema=QAQC_DB_SCHEMA_SOURCE_DATA)
     columns = pg_client.get_table_columns(
         table_name=f"{TEST_DATA_SOURCE_NAME}_{TEST_DATA_SOURCE_VERSION}",
     )

--- a/apps/qa/tests/test_source_report.py
+++ b/apps/qa/tests/test_source_report.py
@@ -1,5 +1,6 @@
 # test generation of source data reports
 import pandas as pd
+from dcpy.utils.postgres import PostgresClient
 from dcpy.connectors.edm import publishing
 from src.shared.constants import DATASET_NAMES
 from src.shared.utils.source_report import (
@@ -7,6 +8,7 @@ from src.shared.utils.source_report import (
     compare_source_data_columns,
     compare_source_data_row_count,
 )
+from src import QAQC_DB, QAQC_DB_SCHEMA_SOURCE_DATA
 
 REFERENCE_VESION = "2023-04-01"
 
@@ -62,7 +64,10 @@ def test_get_source_dataset_names():
 
 
 def test_compare_source_data_columns():
-    source_report_results = compare_source_data_columns(TEST_SOURCE_REPORT_RESULTS)
+    pg_client = PostgresClient(database=QAQC_DB, schema=QAQC_DB_SCHEMA_SOURCE_DATA)
+    source_report_results = compare_source_data_columns(
+        TEST_SOURCE_REPORT_RESULTS, pg_client=pg_client
+    )
     assert isinstance(
         source_report_results[TEST_DATA_SOURCE_NAME]["same_columns"], bool
     )
@@ -70,7 +75,10 @@ def test_compare_source_data_columns():
 
 
 def test_compare_source_data_row_count():
-    source_report_results = compare_source_data_row_count(TEST_SOURCE_REPORT_RESULTS)
+    pg_client = PostgresClient(database=QAQC_DB, schema=QAQC_DB_SCHEMA_SOURCE_DATA)
+    source_report_results = compare_source_data_row_count(
+        TEST_SOURCE_REPORT_RESULTS, pg_client=pg_client
+    )
     assert isinstance(
         source_report_results[TEST_DATA_SOURCE_NAME]["same_row_count"], bool
     )


### PR DESCRIPTION
resolves #270 

The issue is about the old format of version names in tables in edm-data (`defaultdb.dcp_zoningtaxlots`).

But it doesn't seem like we need to remove the backslashes from old sql table names and records. There doesn't seem to be any code that parses the values and we're planning to do more dynamic generation of QA artifacts based on actual published data in S3.

So this PR just fixes the broken QA page. This doesn't fix the (experimental) source data report in the ZTL page because that requires setting the envar `BUILD_ENGINE_SCHEMA` in the QA droplet (I think via ssh?).

See ZTL page in deployed QA app [here](https://de-qaqc.nycplanningdigital.com/?page=Zoning+Tax+Lots)

## before
<img width="1349" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/e7d6828a-e159-4633-b35e-718f10deb78c">

## after
<img width="1192" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/6851f2e3-4ef1-46af-a5d1-3087b2f29156">
