### PR TITLE
improve use of envars in python files

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -400,11 +400,11 @@ def _cli_wrapper_upload(
 ):
     acl_literal = s3.string_as_acl(acl)
     if not output_path.exists():
-        raise Exception(f"Path {output_path} does not exist")
+        raise FileNotFoundError(f"Path {output_path} does not exist")
     build_name = build or os.environ["BUILD_NAME"]
-    if build_name is None:
-        raise Exception(
-            "Build name must either be supplied via CLI or found in env var 'BUILD_NAME'."
+    if not build_name:
+        raise ValueError(
+            f"Build name supplied via CLI or the env var 'BUILD_NAME' cannot be '{build_name}'."
         )
     logger.info(
         f'Uploading {output_path} to {product}/draft/{build_name} with ACL "{acl}"'

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -401,7 +401,7 @@ def _cli_wrapper_upload(
     acl_literal = s3.string_as_acl(acl)
     if not output_path.exists():
         raise Exception(f"Path {output_path} does not exist")
-    build_name = build or os.environ.get("BUILD_NAME")
+    build_name = build or os.environ["BUILD_NAME"]
     if build_name is None:
         raise Exception(
             "Build name must either be supplied via CLI or found in env var 'BUILD_NAME'."

--- a/dcpy/test/conftest.py
+++ b/dcpy/test/conftest.py
@@ -17,16 +17,16 @@ TEST_BUCKETS = [
 ]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     if "AWS_S3_ENDPOINT" in os.environ:
         os.environ.pop("AWS_S3_ENDPOINT")
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def create_buckets(aws_credentials):
     """Creates a test S3 bucket."""
     with mock_s3():

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -33,6 +33,8 @@ def test_upload(create_buckets, create_temp_filesystem, mock_data_constants):
 
 
 def test_publish(create_buckets, create_temp_filesystem, mock_data_constants):
+    data_path = mock_data_constants["TEST_DATA_DIR"]
+    publishing.upload(output_path=data_path, draft_key=draft_key, acl=TEST_ACL)
     publishing.publish(
         draft_key=draft_key, acl=TEST_ACL, version=None, keep_draft=False
     )

--- a/dcpy/test/utils/test_s3.py
+++ b/dcpy/test/utils/test_s3.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+from botocore.exceptions import EndpointConnectionError
 from dcpy.utils import s3
 from dcpy.test.conftest import TEST_BUCKET, TEST_BUCKETS
 
@@ -8,9 +9,28 @@ TEST_DIR_NAME_2 = "test-dir-2"
 TEST_FILE_NAME = "test-file"
 
 
+# assert that the default mock credentials work
+def test_client_create(aws_credentials):
+    s3.client()
+
+
+# assert client creation results for invalid client endpoint_url options
+# shows approaches that don't work for a mock endpoint in aws_credentials
+def test_client_create_errors(aws_credentials):
+    with pytest.raises(TypeError, match="str expected, not NoneType"):
+        os.environ["AWS_S3_ENDPOINT"] = None
+
+    with pytest.raises(ValueError, match="Invalid endpoint: testing"):
+        os.environ["AWS_S3_ENDPOINT"] = "testing"
+        s3.client()
+
+    with pytest.raises(ValueError, match="Invalid endpoint: "):
+        os.environ["AWS_S3_ENDPOINT"] = ""
+        s3.client()
+
+
 def test_list_buckets(create_buckets):
     """Tests listing s3 buckets."""
-    # buckets = s3.client().list_buckets()["Buckets"][0]["Name"]
     buckets = [bucket["Name"] for bucket in s3.client().list_buckets()["Buckets"]]
     assert buckets == TEST_BUCKETS
 

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 else:
     S3Client = object
 
-
 ACL = Literal[
     "authenticated-read",
     "aws-exec-read",
@@ -92,15 +91,15 @@ def _progress():
 
 def client() -> S3Client:
     """Returns a client for S3."""
+    aws_s3_endpoint = os.environ.get("AWS_S3_ENDPOINT")
     aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
     aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
-    endpoint_url = os.environ["AWS_S3_ENDPOINT"]
     config = Config(read_timeout=120)
     return boto3.client(
         "s3",
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
-        endpoint_url=endpoint_url,
+        endpoint_url=aws_s3_endpoint,
         config=config,
     )
 

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -94,7 +94,7 @@ def client() -> S3Client:
     """Returns a client for S3."""
     aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
     aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
-    endpoint_url = os.environ.get("AWS_S3_ENDPOINT")
+    endpoint_url = os.environ["AWS_S3_ENDPOINT"]
     config = Config(read_timeout=120)
     return boto3.client(
         "s3",

--- a/products/colp/python/utils.py
+++ b/products/colp/python/utils.py
@@ -4,7 +4,7 @@ import os
 from sqlalchemy import create_engine
 import pandas as pd
 
-engine = create_engine(os.environ.get("BUILD_ENGINE"))
+engine = create_engine(os.environ["BUILD_ENGINE"])
 
 
 def psql_insert_copy(table, conn, keys, data_iter):

--- a/products/cpdb/python/attributes_geom_agencyverified_geocode.py
+++ b/products/cpdb/python/attributes_geom_agencyverified_geocode.py
@@ -10,7 +10,7 @@ from utils import psql_insert_copy
 g = Geosupport()
 
 # connect to postgres db
-engine = create_engine(os.environ.get("BUILD_ENGINE", ""))
+engine = create_engine(os.environ["BUILD_ENGINE"])
 
 
 def quick_clean(address):

--- a/products/cpdb/python/checkbook_spending_by_year.py
+++ b/products/cpdb/python/checkbook_spending_by_year.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine, text
 import os
 
 # connect to postgres db
-engine = create_engine(os.environ.get("BUILD_ENGINE", ""))
+engine = create_engine(os.environ["BUILD_ENGINE"])
 
 # Get current year
 current_year = datetime.today().year

--- a/products/cpdb/python/doitt_buildingfootprints.py
+++ b/products/cpdb/python/doitt_buildingfootprints.py
@@ -4,7 +4,7 @@ import os
 from utils import psql_insert_copy
 
 # connect to postgres db
-engine = create_engine(os.environ.get("BUILD_ENGINE", ""))
+engine = create_engine(os.environ["BUILD_ENGINE"])
 
 with engine.begin() as conn:
     # makes selection

--- a/products/cpdb/python/dot_bridges.py
+++ b/products/cpdb/python/dot_bridges.py
@@ -4,7 +4,7 @@ import os
 from utils import psql_insert_copy
 
 # connect to postgres db
-engine = create_engine(os.environ.get("BUILD_ENGINE", ""))
+engine = create_engine(os.environ["BUILD_ENGINE"])
 
 
 # helper function

--- a/products/developments/python/unit_change_summary.py
+++ b/products/developments/python/unit_change_summary.py
@@ -48,10 +48,10 @@ geoms = {
 if __name__ == "__main__":
     filename = sys.argv[1]
     decade = sys.argv[2]  # e.g. "10" or "20"
-    CAPTURE_DATE = os.environ.get("CAPTURE_DATE")
+    CAPTURE_DATE = os.environ["CAPTURE_DATE"]
 
     # Get current year
-    version = os.environ.get("VERSION")
+    version = os.environ["VERSION"]
     current_year = int(f"20{version[:2]}")
 
     # SQL Template

--- a/products/developments/python/utils.py
+++ b/products/developments/python/utils.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 
 import pandas as pd
 
-engine = create_engine(os.environ.get("BUILD_ENGINE"))
+engine = create_engine(os.environ["BUILD_ENGINE"])
 
 
 def psql_insert_copy(table, conn, keys, data_iter):

--- a/products/factfinder/factfinder/__init__.py
+++ b/products/factfinder/factfinder/__init__.py
@@ -11,5 +11,5 @@ base_path = ".cache"
 if not os.path.isdir(base_path):
     os.makedirs(base_path, exist_ok=True)
 
-api_key = os.environ.get("API_KEY")
+api_key = os.environ["API_KEY"]
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "WARNING").upper())

--- a/products/factfinder/tests/__init__.py
+++ b/products/factfinder/tests/__init__.py
@@ -4,4 +4,4 @@ from dotenv import load_dotenv
 
 # Load environmental variables
 load_dotenv()
-api_key = os.environ.get("API_KEY")
+api_key = os.environ["API_KEY"]


### PR DESCRIPTION
resolves #288 

These changes are to to standardize how we retrieve envars since we're happy with how they're being set (only set in github action and test setups rather than when we run application code).

Seems more ideal to use `os.environ["ENVAR_NAME"]` rather than `os.environ.get("ENVAR_NAME")` when there's no default value so that our code raises an error when a required envar isn't set.