### PR TITLE
Move to forked gdal 3.8.3

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -11,12 +11,17 @@ on:
         description: "Build Pluto (minor) after dataloading is complete"
         type: boolean
         default: false
+      dev_image: 
+        description: "Use dev image specific to this branch? (If exists)"
+        type: boolean
+        required: true
+        default: false
 
 jobs:
   dataloading:
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/build-base:latest
+      image: nycplanning/build-base:${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
     env:
       AWS_S3_BUCKET: edm-recipes
     strategy:

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -62,6 +62,7 @@ jobs:
     uses: ./.github/workflows/zoningtaxlots_build.yml
     secrets: inherit
     with:
+      image_tag: ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
       build_name: ${{ github.head_ref || github.ref_name }}
       recipe_file: recipe
 
@@ -73,5 +74,6 @@ jobs:
     secrets: inherit
     with:
       create_issue: true
+      image_tag: ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
       build_name: ${{ github.head_ref || github.ref_name }}
       recipe_file: recipe-minor

--- a/docker/config.sh
+++ b/docker/config.sh
@@ -26,9 +26,9 @@ function install_gdal {
 
     echo "installing gdal from source" && (
         cd ~
-        wget download.osgeo.org/gdal/3.8.3/gdal383.zip
-        unzip gdal383.zip
-        cd gdal-3.8.3
+        wget https://github.com/fvankrieken/gdal/archive/refs/heads/3.8-revert-null-date-behavior.zip
+        unzip "3.8-revert-null-date-behavior.zip"
+        cd gdal-3.8-revert-null-date-behavior
         mkdir build
         cd build
         sudo cmake -DPROJ_INCLUDE_DIR=/usr/include ..

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -34,20 +34,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.34.17
+boto3==1.34.18
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs==1.34.17
+boto3-stubs==1.34.18
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.34.17
+botocore==1.34.18
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.34.17
+botocore-stubs==1.34.18
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -536,7 +536,7 @@ rich==13.7.0
     # via
     #   -r python/requirements.in
     #   streamlit
-rpds-py==0.16.2
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -34,20 +34,20 @@ black==23.1.0
     # via -r python/requirements.in
 blinker==1.7.0
     # via streamlit
-boto3==1.34.17
+boto3==1.34.18
     # via
     #   -r python/requirements.in
     #   moto
-boto3-stubs[s3]==1.34.17
+boto3-stubs[s3]==1.34.18
     # via
     #   -r python/requirements.in
     #   boto3-stubs
-botocore==1.34.17
+botocore==1.34.18
     # via
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.34.17
+botocore-stubs==1.34.18
     # via
     #   -r python/requirements.in
     #   boto3-stubs
@@ -536,7 +536,7 @@ rich==13.7.0
     # via
     #   -r python/requirements.in
     #   streamlit
-rpds-py==0.16.2
+rpds-py==0.17.1
     # via
     #   jsonschema
     #   referencing


### PR DESCRIPTION
resolves #508 

I forked gdal, branched off of release/3.8 (which seemed to be most up-to-date branch for 3.8.3, a few commits ahead of 3.8.3 tag with some bash cleanup). Added [this commit](https://github.com/fvankrieken/gdal/commit/fe3bd65448a8e15bcdb870d2a15e374c9a6e1bf4), undoing a [change from 3.8.0 to 3.8.1](https://github.com/OSGeo/gdal/compare/v3.8.0...v3.8.1#diff-a13ee344527a8c597d816c3e7527be0a03a58c0a941a0ff397f3065cc5d36caeL1449). It seems like maybe [this](https://github.com/OSGeo/gdal/compare/v3.8.0...v3.8.1#diff-3c2d0a796b98eed8a1f7c6f1fc29d010012c40bd5b4149945ed35751b93e4582R1168) was supposed to catch this case, given the similar comment?

[Here's the troublesome commit](https://github.com/OSGeo/gdal/commit/813cca6d783cda46538778c8d038c59d3e5122c1)

Anyways, this branch now downloads gdal from my forked repo with the fix. I built `base` image off of it, let PR tests here build dev images, then ran dof_shoreline archival from this branch, and we're back in business

https://nyc3.digitaloceanspaces.com/edm-recipes/datasets/dof_shoreline/gdalcustom/dof_shoreline.sql