### PR TITLE
Add create issue job for all scheduled workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_library_failure.md
+++ b/.github/ISSUE_TEMPLATE/data_library_failure.md
@@ -1,9 +1,0 @@
----
-name: "Data Library Failure"
-about: Notification For failed attempt of data library automated updates
-title: "Data Library Failure - {{ env.ACTION }}"
-labels: ["bug"]
-assignees: []
-
----
-[Failed action]({{ env.BUILD_URL }})

--- a/.github/ISSUE_TEMPLATE/scheduled_action_failure.md
+++ b/.github/ISSUE_TEMPLATE/scheduled_action_failure.md
@@ -1,0 +1,9 @@
+---
+name: "Scheduled Action Failure"
+about: Notification For failed attempt of scheduled github action
+title: "Scheduled Action Failure - {{ env.ACTION }}"
+labels: ["bug"]
+assignees: []
+
+---
+[Failed action]({{ env.BUILD_URL }})

--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -50,9 +50,9 @@ jobs:
         run: library archive --name ${{ matrix.dataset }} --latest --s3
 
   create_issue_on_failure:
-    runs-on: ubuntu-22.04
     needs: dataloading
-    if: ${{ always() && (github.event_name == 'schedule') && contains(needs.dataloading.result, 'failure') }}
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -61,7 +61,7 @@ jobs:
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTION: "Open Data Weekly Updates"
+          ACTION: ${{ github.workflow }}
           BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
-          filename: .github/ISSUE_TEMPLATE/data_library_failure.md
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -114,3 +114,20 @@ jobs:
           ./devdb.sh library_archive hny_geocode_results hpd_hny_units_by_building
           ./devdb.sh library_archive hpd_historical_geocode_results hpd_historical_units_by_building
           ./devdb.sh library_archive dob_geocode_results dob_jobapplications ${{ github.event.inputs.version }}
+
+  create_issue_on_failure:
+    needs: geocode
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/nightly_qa.yml
+++ b/.github/workflows/nightly_qa.yml
@@ -24,3 +24,20 @@ jobs:
       recipe_file: recipe
       dev_image: false
       build_name: ${{ inputs.build_name || 'nightly_qa' }}
+
+  create_issue_on_failure:
+    needs: [test, build]
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/pluto_input_cama.yml
+++ b/.github/workflows/pluto_input_cama.yml
@@ -90,3 +90,20 @@ jobs:
 
       - name: Clean CAMA
         run: ./pluto clean cama
+
+  create_issue_on_failure:
+    needs: process_cama
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/pluto_input_numbldgs.yml
+++ b/.github/workflows/pluto_input_numbldgs.yml
@@ -46,3 +46,20 @@ jobs:
 
       - name: clean numbldgs
         run: ./pluto clean numbldgs
+
+  create_issue_on_failure:
+    needs: process_numbldgs
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/pluto_input_pts.yml
+++ b/.github/workflows/pluto_input_pts.yml
@@ -98,3 +98,20 @@ jobs:
 
       - name: clean up pts
         run: ./pluto clean pts
+
+  create_issue_on_failure:
+    needs: process_pts
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -32,3 +32,20 @@ jobs:
           assignees: ${{ github.event_name == 'schedule' && 'fvankrieken, damonmcc, alexrichey, sf-dcp' || '' }}
           branch: compile_python_reqs
           token: ${{ secrets.GHP_TOKEN }}
+
+  create_issue_on_failure:
+    needs: compile_requirements
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/stale_builds.yml
+++ b/.github/workflows/stale_builds.yml
@@ -32,3 +32,19 @@ jobs:
       - name: Delete docker images
         run: python3 -m dcpy.builds.clean_artifacts dockerhub_tags
           
+  create_issue_on_failure:
+    needs: clean
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/.github/workflows/zap_export.yml
+++ b/.github/workflows/zap_export.yml
@@ -105,3 +105,20 @@ jobs:
           ./zap.sh upload_internal_do ${{ matrix.entity }} $VERSION
           ./zap.sh upload_visible_do ${{ matrix.entity }} $VERSION
           fi
+
+  create_issue_on_failure:
+    needs: build
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Data Engineering Team
+# Data Engineering Team ![CI](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml/badge.svg)
 
 This is the primary repository for the Data Engineering team at the NYC Department of City Planning (DCP).
 


### PR DESCRIPTION
Seemed low-effort and useful enough to add. Now that nightly_qa should actually be passing nightly, figured for it and all other recurring jobs it'd be useful to create issues so nothing fails too silently.

Happy to remove nightly_qa from the list if we feel like it might get spammy. I hope not though.

Will drop the second commit.

As is, it ran [this job](https://github.com/NYCPlanning/data-engineering/actions/runs/7561798946), creating #531