### PR TITLE
set `BUILD_ENGINE_SERVER` envar in qa app

### DIFF
--- a/.github/workflows/qa_deploy.yml
+++ b/.github/workflows/qa_deploy.yml
@@ -44,6 +44,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Setup SSH
         run: |
@@ -70,6 +71,7 @@ jobs:
                 -e AWS_S3_ENDPOINT=$AWS_S3_ENDPOINT\
                 -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY\
                 -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID\
+                -e BUILD_ENGINE_SERVER=$BUILD_ENGINE_SERVER\
                 -e GHP_TOKEN=$GHP_TOKEN\
                 $DOCKER_IMAGE_NAME"
     


### PR DESCRIPTION
this fixes our only QA page which connects to our persistent postgres DB: an experimental page for source data QA. from the roadmap chat today, we're likely to expand the QA app's use of our DB

runs of the QA App deploy action form this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/qa_deploy.yml?query=branch%3Adm-fix-qa-app-db-use)

## before

<img width="1370" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/c1279421-5915-4d52-b167-594b4d2e3493">

## after

<img width="1341" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/fadc4821-2019-4fc9-82e8-5e7b9992ffcc">