### PR TITLE
Expand parquet support, make default datasettype

### DIFF
--- a/.github/workflows/data_library_single.yml
+++ b/.github/workflows/data_library_single.yml
@@ -16,14 +16,6 @@ on:
       version:
         description: "The version of the dataset (i.e. 22v2, 21C) if needed (optional)"
         required: false
-      format:
-        type: choice
-        options:
-          - pgdump
-          - parquet
-          - csv
-          - shapefile
-        default: pgdump
       dev_image: 
         description: "Use dev image specific to this branch? (If exists)"
         type: boolean
@@ -61,4 +53,4 @@ jobs:
         env:
           latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
           version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-        run: library archive --name ${{ github.event.inputs.dataset }} --output-format ${{ github.event.inputs.format }} --s3 $latest $version
+        run: library archive --name ${{ github.event.inputs.dataset }} --s3 $latest $version

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -41,7 +41,7 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Library Archive
-        run: library archive --name ${{ matrix.dataset }} --latest --s3 --output-format pgdump --output-format csv
+        run: library archive --name ${{ matrix.dataset }} --latest --s3
 
   geocode:
     name: Geocode HPD Data

--- a/.github/workflows/pluto_input_cama.yml
+++ b/.github/workflows/pluto_input_cama.yml
@@ -85,8 +85,7 @@ jobs:
           library archive --name pluto_input_cama_dof \
             --path templates/pluto_input_cama_dof.yml \
             --version ${{ steps.processing.outputs.version }} \
-            --output-format pgdump --output-format csv \
-            --latest --s3 --compress
+            --latest --s3
 
       - name: Clean CAMA
         run: ./pluto clean cama

--- a/.github/workflows/pluto_input_numbldgs.yml
+++ b/.github/workflows/pluto_input_numbldgs.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           library archive --name pluto_input_numbldgs \
             --path templates/pluto_input_numbldgs.yml \
-            --output-format pgdump --output-format csv \
             --latest --s3
 
       - name: clean numbldgs

--- a/.github/workflows/pluto_input_pts.yml
+++ b/.github/workflows/pluto_input_pts.yml
@@ -83,8 +83,7 @@ jobs:
         run: |
           library archive --name pluto_pts \
             --path templates/pluto_pts.yml \
-            --output-format pgdump --output-format csv \
-            --latest --s3 --compress
+            --latest --s3
 
       - name: geocode pts
         run: ./pluto geocode pts
@@ -93,8 +92,7 @@ jobs:
         run: |
           library archive --name pluto_input_geocodes \
             --path templates/pluto_input_geocodes.yml \
-            --output-format pgdump --output-format csv \
-            --latest --s3 --compress
+            --latest --s3
 
       - name: clean up pts
         run: ./pluto clean pts

--- a/.github/workflows/zap_export.yml
+++ b/.github/workflows/zap_export.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Library Archive
         run: |
           library archive --name ${{ matrix.entity }} --path templates/${{ matrix.entity }}.yml \
-            --latest --s3 --compress --output-format pgdump --output-format csv
+            --latest --s3
 
       - name: Export to edm-private and edm-publishing
         env:

--- a/.github/workflows/zap_single_visible.yml
+++ b/.github/workflows/zap_single_visible.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Library Archive
         run: |
           library archive --name ${{ github.event.inputs.dataset }} --path templates/${{ github.event.inputs.dataset }}.yml \
-            --latest --s3 --compress --output-format pgdump --output-format csv
+            --latest --s3
 
       - name: Export to edm-private and edm-publishing
         env:

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -56,9 +56,7 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Library Archive
-        run: |
-          library archive --name ${{ matrix.dataset }} --latest --s3 --compress \
-            --output-format pgdump --output-format shapefile
+        run: library archive --name ${{ matrix.dataset }} --latest --s3
 
   build_ztl:
     needs: [dataloading]

--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -23,10 +23,6 @@ def import_dataset(
     pg_client: postgres.PostgresClient,
 ):
     """Import a recipe to local data library folder and build engine."""
-    ds_table_name = ds.import_as or ds.name
-    logger.info(
-        f"Importing {ds.name} into {pg_client.database}.{pg_client.schema}.{ds_table_name}"
-    )
 
     if ds.version == "latest" or ds.version is None:
         raise Exception(f"Cannot import a dataset without a resolved version: {ds}")
@@ -41,7 +37,10 @@ def import_dataset(
         preproc_func = None
 
     recipes.import_dataset(
-        ds.dataset, pg_client, preprocessor=preproc_func, import_as=ds.import_as
+        ds.dataset,
+        pg_client,
+        preprocessor=preproc_func,
+        import_as=ds.import_as,
     )
 
 

--- a/dcpy/builds/plan.py
+++ b/dcpy/builds/plan.py
@@ -40,8 +40,8 @@ class InputDataset(BaseModel, use_enum_values=True, extra="forbid"):
 
     @property
     def dataset(self):
-        if self.version is None or self.file_type is None:
-            raise Exception(f"Dataset {self.name} requires both version and file_type")
+        if self.version is None:
+            raise Exception(f"Dataset {self.name} requires version")
 
         return recipes.Dataset(
             name=self.name, version=self.version, file_type=self.file_type
@@ -176,14 +176,12 @@ def get_source_data_versions(recipe: Recipe):
 
 
 def _apply_recipe_defaults(recipe: Recipe):
-    recipe.inputs.dataset_defaults = (
-        recipe.inputs.dataset_defaults
-        or InputDatasetDefaults(file_type=recipes.DatasetType.pg_dump)
-    )
-
-    for ds in recipe.inputs.datasets:
-        ds.preprocessor = ds.preprocessor or recipe.inputs.dataset_defaults.preprocessor
-        ds.file_type = ds.file_type or recipe.inputs.dataset_defaults.file_type
+    if recipe.inputs.dataset_defaults is not None:
+        for ds in recipe.inputs.datasets:
+            ds.preprocessor = (
+                ds.preprocessor or recipe.inputs.dataset_defaults.preprocessor
+            )
+            ds.file_type = ds.file_type or recipe.inputs.dataset_defaults.file_type
 
 
 def recipe_from_yaml(path: Path) -> Recipe:

--- a/dcpy/library/cli.py
+++ b/dcpy/library/cli.py
@@ -17,7 +17,7 @@ s3 = S3(aws_access_key_id, aws_secret_access_key, aws_s3_endpoint, aws_s3_bucket
 @app.command()
 def archive(
     path: str = typer.Option(None, "--path", "-f", help="Path to config yml"),
-    output_formats: list[str] = typer.Option(["pgdump"], "--output-format", "-o", help="csv, geojson, shapefile, pgdump and postgres"),
+    output_formats: list[str] = typer.Option(["pgdump", "parquet"], "--output-format", "-o", help="csv, geojson, shapefile, pgdump and parquet"),
     push: bool = typer.Option(False, "--s3", "-s", help="Push to s3"),
     clean: bool = typer.Option(False, "--clean", "-c", help="Remove temporary files"),
     latest: bool = typer.Option(False, "--latest", "-l", help="Tag with latest"),

--- a/dcpy/library/script/dob_cofos.py
+++ b/dcpy/library/script/dob_cofos.py
@@ -40,9 +40,8 @@ class Scriptor(ScriptorInterface):
         previous_dataset = recipes.Dataset(
             name=self.name,
             version=self.previous_version,
-            file_type=recipes.DatasetType.csv,
         )
-        return recipes.read_csv(previous_dataset, dtype=str)
+        return recipes.read_df(previous_dataset, dtype=str)
 
     def runner(self) -> str:
         previous = self.previous()

--- a/dcpy/utils/postgres.py
+++ b/dcpy/utils/postgres.py
@@ -191,6 +191,15 @@ class PostgresClient:
         )
         return sorted(column_names["column_name"])
 
+    def add_pk(self, table: str, id_column: str = "id"):
+        self.execute_query(
+            'ALTER TABLE ":schema".":table" ADD COLUMN ":id_column" SERIAL CONSTRAINT ":constraint" PRIMARY KEY;',
+            schema=AsIs(self.schema),
+            table=AsIs(table),
+            id_column=AsIs(id_column),
+            constraint=AsIs(f"{table}_pk"),
+        )
+
     def add_table_column(
         self,
         table_name: str,

--- a/products/developments/devdb.sh
+++ b/products/developments/devdb.sh
@@ -42,7 +42,7 @@ function library_archive {
     local version=${3:-$latest_version}
     echo "version of ${1} is ${version}"
     
-    library archive -f templates/$1.yml -s -l -o csv -o pgdump -v $version
+    library archive -f templates/$1.yml -s -l -v $version
 }
 
 function import {


### PR DESCRIPTION
[Build all](https://github.com/NYCPlanning/data-engineering/actions/runs/7613210139)

Note that this isn't testing what works using parquet imports, just makes sure that current functionality is not broken, in terms of importing via preference (parquet -> pgdump -> csv)

Main changes here are 
- data library - default to generating pgdump (for now, in case things go weird as we try to use parquet) and parquet files for every export
- connectors.edm.recipes and build.plan - if no dataset file type supplied, assume that we want to import parquet, and fall back to pg_dump and then csv if parquet is not found