### PR TITLE
[experiment] expand repeat build feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,14 @@ on:
           - pluto
           - ztl
           - all
+      repeat:
+        description: "Repeat existing build?"
+        type: boolean
+        default: false
+      version:
+        description: "Version of dataset to build"
+        type: string
+        required: false
       recipe_file:
         description: "Filename of recipe to use"
         type: choice
@@ -28,14 +36,6 @@ on:
           - recipe-minor
         required: true
         default: recipe
-      version:
-        description: "Version of dataset being built"
-        type: string
-        required: false
-      repeat:
-        description: "Repeat existing build?"
-        type: boolean
-        default: false
       dev_image: 
         description: "Use dev image specific to this branch? (If exists)"
         type: boolean

--- a/dcpy/builds/plan.py
+++ b/dcpy/builds/plan.py
@@ -209,8 +209,10 @@ def repeat_recipe_from_source_data_versions(
             ds.version = version_by_source_data_name[ds.name]
         else:
             raise Exception(
-                "Dataset found in template recipe not found in historical source data versions, \
-                cannot repeat build."
+                f"""
+                Dataset {ds} found in template recipe not found in historical source data versions, \
+                cannot repeat build.
+                """
             )
 
     return recipe

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -123,7 +123,7 @@ def try_get_previous_version(
 
 
 def get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
-    """Given product name, gets source data versions of published version"""
+    """Gets source data versions of build via csv metadata"""
     source_data_versions = read_csv(product_key, "source_data_versions.csv", dtype=str)
     print(source_data_versions)
     source_data_versions.rename(


### PR DESCRIPTION
This allows us to repeat builds that have a `metadata.yml` rather than `build_metadata.json` or `source_data_versions.csv`

see builds using this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-facdb-repeat-23v2)

### update

likely will abandon this endeavor. for all source data that was a pg_dump (list [here](https://github.com/NYCPlanning/data-engineering/blob/main/products/facilities/recipe.yml#L12-L39)) the versions used in FacDB 2023-08-09 were not documented in `metadata.yml`. so recreating that build would take more investigating and guesswork than seems worth it right now