### PR TITLE
Data library - expand pydantic use beyond validation

### DIFF
--- a/dcpy/library/__init__.py
+++ b/dcpy/library/__init__.py
@@ -1,8 +1,8 @@
-import os
-import pprint
-
 from dotenv import load_dotenv
+import os
 from osgeo import gdal
+from pathlib import Path
+import pprint
 from rich.traceback import install
 
 # Use rich to handle exceptions
@@ -31,6 +31,7 @@ gdal.SetConfigOption("AWS_ACCESS_KEY_ID", aws_access_key_id)
 
 # Create a local .library directory to store temporary files
 base_path = ".library"
+TEMPLATE_DIR = Path(__file__).parent / "templates"
 
 if not os.path.isdir(base_path):
     os.makedirs(base_path, exist_ok=True)

--- a/dcpy/library/config.py
+++ b/dcpy/library/config.py
@@ -75,7 +75,7 @@ class Config:
             version = self.version_socrata(_config.source.socrata.uid)
         else:
             # backwards compatibility before templates were simplified
-            if _config.version == r"{{version}}":
+            if _config.version and _config.version.replace(" ", "") == r"{{version}}":
                 _config.version = None
             version = self.version or _config.version or self.version_today
         config = self.parsed_rendered_template(version=version)

--- a/dcpy/library/script/scriptor.py
+++ b/dcpy/library/script/scriptor.py
@@ -6,12 +6,12 @@ class ScriptorInterface:
 
     @property
     def name(self) -> str:
-        return self.config["dataset"]["name"]
+        return self.config["name"]
 
     @property
     def version(self) -> str:
-        return self.config["dataset"]["version"]
+        return self.config["version"]
 
     @property
     def path(self) -> str:
-        return self.config["dataset"]["source"]["path"]
+        return self.config["source"]["script"]["path"]

--- a/dcpy/library/sources.py
+++ b/dcpy/library/sources.py
@@ -54,7 +54,9 @@ def postgres_source(url: str) -> gdal.Dataset:
     return gdal.OpenEx(parsed, gdal.OF_VECTOR)
 
 
-def generic_source(path: str, options: list = [], fields: list = []) -> gdal.Dataset:
+def generic_source(
+    path: str, options: list | None = None, fields: list | None = None
+) -> gdal.Dataset:
     """
     path: filepath, http url or s3 file url
     e.g.
@@ -67,5 +69,6 @@ def generic_source(path: str, options: list = [], fields: list = []) -> gdal.Dat
         path, gdal.OF_VECTOR, open_options=options, allowed_drivers=allowed_drivers
     )
     assert dataset, f"{path} is invalid"
-    dataset = format_field_names(dataset, fields)
+    if fields:
+        dataset = format_field_names(dataset, fields)
     return dataset

--- a/dcpy/library/templates/bpl_libraries.yml
+++ b/dcpy/library/templates/bpl_libraries.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name bpl_libraries
-  version: "{{ version }}"
+  name: bpl_libraries
   acl: public-read
   source:
-    script: *name
-    path: "https://www.bklynlibrary.org/locations/json"
+    script: 
+      path: "https://www.bklynlibrary.org/locations/json"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/cbbr_submissions.yml
+++ b/dcpy/library/templates/cbbr_submissions.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name cbbr_submissions
-  version: "{{ version }}"
+  name: cbbr_submissions
   acl: public-read
   source:
     url:
       path: library/tmp/cbbr_submissions.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/council_members.yml
+++ b/dcpy/library/templates/council_members.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name council_members
-  version: "{{ version }}"
+  name: council_members
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dca_operatingbusinesses.yml
+++ b/dcpy/library/templates/dca_operatingbusinesses.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dca_operatingbusinesses
-  version: "{{ version }}"
+  name: dca_operatingbusinesses
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcas_ipis.yml
+++ b/dcpy/library/templates/dcas_ipis.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dcas_ipis
-  version: "{{ version }}"
+  name: dcas_ipis
   acl: public-read
   source:
-    script: *name
-    path: library/tmp/dcas_ipis.csv
+    script:
+      path: library/tmp/dcas_ipis.csv
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcla_culturalinstitutions.yml
+++ b/dcpy/library/templates/dcla_culturalinstitutions.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcla_culturalinstitutions
-  version: "{{ version }}"
+  name: dcla_culturalinstitutions
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_access_ADA_subway.yml
+++ b/dcpy/library/templates/dcp_access_ADA_subway.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_access_ada_subway
-  version: "{{ version }}"
+  name: dcp_access_ada_subway
   acl: public-read
   source:
     url:
       path: library/tmp/dcp_access_ADA_subway.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_access_subway_SBS.yml
+++ b/dcpy/library/templates/dcp_access_subway_SBS.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_access_subway_sbs
-  version: "{{ version }}"
+  name: dcp_access_subway_sbs
   acl: public-read
   source:
     url:
       path: library/tmp/dcp_access_subway_SBS.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_addresspoints.yml
+++ b/dcpy/library/templates/dcp_addresspoints.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_addresspoints
-  version: "{{ version }}"
+  name: dcp_addresspoints
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_address_points/staging/dcp_address_points.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_atomicpolygons.yml
+++ b/dcpy/library/templates/dcp_atomicpolygons.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_atomicpolygons
-  version: "{{ version }}"
+  name: dcp_atomicpolygons
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: POLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POLYGON

--- a/dcpy/library/templates/dcp_boroboundaries.yml
+++ b/dcpy/library/templates/dcp_boroboundaries.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_boroboundaries
-  version: "{{ version }}"
+  name: dcp_boroboundaries
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_boroboundaries_wi.yml
+++ b/dcpy/library/templates/dcp_boroboundaries_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_boroboundaries_wi
-  version: "{{ version }}"
+  name: dcp_boroboundaries_wi
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_cb2010.yml
+++ b/dcpy/library/templates/dcp_cb2010.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_cb2010
-  version: "{{ version }}"
+  name: dcp_cb2010
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_cb2010_wi.yml
+++ b/dcpy/library/templates/dcp_cb2010_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_cb2010_wi
-  version: "{{ version }}"
+  name: dcp_cb2010_wi
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_cb2020.yml
+++ b/dcpy/library/templates/dcp_cb2020.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_cb2020
-  version: "{{ version }}"
+  name: dcp_cb2020
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_cb2020_wi.yml
+++ b/dcpy/library/templates/dcp_cb2020_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_cb2020_wi
-  version: "{{ version }}"
+  name: dcp_cb2020_wi
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_cdboundaries.yml
+++ b/dcpy/library/templates/dcp_cdboundaries.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name dcp_cdboundaries
+  name: dcp_cdboundaries
   version: "{{ version}}"
   acl: public-read
 
@@ -15,7 +15,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_cdboundaries_wi.yml
+++ b/dcpy/library/templates/dcp_cdboundaries_wi.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name dcp_cdboundaries_wi
+  name: dcp_cdboundaries_wi
   version: "{{ version}}"
   acl: public-read
 
@@ -15,7 +15,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_cdta2020.yml
+++ b/dcpy/library/templates/dcp_cdta2020.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_cdta2020
-  version: "{{ version }}"
+  name: dcp_cdta2020
   acl: public-read
   source:
     url:
@@ -13,7 +12,6 @@ dataset:
       - AUTODETECT_TYPE=NO
       - EMPTY_STRING_AS_NULL=YES
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_censusdata.yml
+++ b/dcpy/library/templates/dcp_censusdata.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dcp_censusdata
-  version: "{{ version }}"
+  name: dcp_censusdata
   acl: public-read
   source:
-    script: *name
-    path: https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/census/census2020/nyc_decennialcensusdata_2010_2020_change-core-geographies.xlsx
+    script:
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/census/census2020/nyc_decennialcensusdata_2010_2020_change-core-geographies.xlsx
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_censusdata_blocks.yml
+++ b/dcpy/library/templates/dcp_censusdata_blocks.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dcp_censusdata_blocks
-  version: "{{ version }}"
+  name: dcp_censusdata_blocks
   acl: public-read
   source:
-    script: *name
-    path: https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/census/census2020/nyc-decennialcensusdata_2010_2020_census-blocks.xlsx
+    script:
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/census/census2020/nyc-decennialcensusdata_2010_2020_census-blocks.xlsx
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_colp.yml
+++ b/dcpy/library/templates/dcp_colp.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_colp
-  version: "{{ version }}"
+  name: dcp_colp
   acl: public-read
   source:
     url:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_commercialoverlay.yml
+++ b/dcpy/library/templates/dcp_commercialoverlay.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_commercialoverlay
-  version: "{{ version }}"
+  name: dcp_commercialoverlay
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_commercial_overlays/staging/dcp_commercial_overlays.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_congressionaldistricts.yml
+++ b/dcpy/library/templates/dcp_congressionaldistricts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_congressionaldistricts
-  version: "{{ version }}"
+  name: dcp_congressionaldistricts
   acl: public-read
 
   source:
@@ -14,7 +13,6 @@ dataset:
       - AUTODETECT_TYPE=NO
       - EMPTY_STRING_AS_NULL=YES
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_congressionaldistricts_wi.yml
+++ b/dcpy/library/templates/dcp_congressionaldistricts_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_congressionaldistricts_wi
-  version: "{{ version }}"
+  name: dcp_congressionaldistricts_wi
   acl: public-read
 
   source:
@@ -14,7 +13,6 @@ dataset:
       - AUTODETECT_TYPE=NO
       - EMPTY_STRING_AS_NULL=YES
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_councildistricts.yml
+++ b/dcpy/library/templates/dcp_councildistricts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_councildistricts
-  version: "{{ version }}"
+  name: dcp_councildistricts
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_councildistricts_wi.yml
+++ b/dcpy/library/templates/dcp_councildistricts_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_councildistricts_wi
-  version: "{{ version }}"
+  name: dcp_councildistricts_wi
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_ct2010.yml
+++ b/dcpy/library/templates/dcp_ct2010.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_ct2010
-  version: "{{ version }}"
+  name: dcp_ct2010
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
   
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_ct2010_wi.yml
+++ b/dcpy/library/templates/dcp_ct2010_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_ct2010_wi
-  version: "{{ version }}"
+  name: dcp_ct2010_wi
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
   
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_ct2020.yml
+++ b/dcpy/library/templates/dcp_ct2020.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_ct2020
-  version: "{{ version }}"
+  name: dcp_ct2020
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
   
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_ct2020_wi.yml
+++ b/dcpy/library/templates/dcp_ct2020_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_ct2020_wi
-  version: "{{ version }}"
+  name: dcp_ct2020_wi
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
   
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_dcmstreetcenterline.yml
+++ b/dcpy/library/templates/dcp_dcmstreetcenterline.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_dcmstreetcenterline
-  version: "{{ version }}"
+  name: dcp_dcmstreetcenterline
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_dcm_street_centerline/staging/dcp_dcm_street_centerline.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTILINESTRING
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTILINESTRING

--- a/dcpy/library/templates/dcp_developments.yml
+++ b/dcpy/library/templates/dcp_developments.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_developments
-  version: "{{ version }}"
+  name: dcp_developments
   acl: public-read
   source:
     url:
       path: https://nyc3.digitaloceanspaces.com/edm-publishing/db-developments/main/{{ version }}/output/devdb.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_dot_trafficinjuries.yml
+++ b/dcpy/library/templates/dcp_dot_trafficinjuries.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_dot_trafficinjuries
-  version: "{{ version }}"
+  name: dcp_dot_trafficinjuries
   acl: public-read
   source:
     url:
       path: library/tmp/crash{{ version }}.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_edesignation.yml
+++ b/dcpy/library/templates/dcp_edesignation.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_edesignation
-  version: "{{ version }}"
+  name: dcp_edesignation
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_e_designations/staging/dcp_e_designations.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_electiondistricts.yml
+++ b/dcpy/library/templates/dcp_electiondistricts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_electiondistricts
-  version: "{{ version }}"
+  name: dcp_electiondistricts
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_electiondistricts_wi.yml
+++ b/dcpy/library/templates/dcp_electiondistricts_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_electiondistricts_wi
-  version: "{{ version }}"
+  name: dcp_electiondistricts_wi
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_facilities.yml
+++ b/dcpy/library/templates/dcp_facilities.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_facilities
-  version: "{{ version }}"
+  name: dcp_facilities
   acl: public-read
   source:
     url:
       path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/facilities_{{ version }}_shp.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_facilities_with_unmapped.yml
+++ b/dcpy/library/templates/dcp_facilities_with_unmapped.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dcp_facilities_with_unmapped
-  version: "{{ version }}"
+  name: dcp_facilities_with_unmapped
   acl: public-read
   source:
-    script: *name
-    path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/facilities_{{ version }}_csv.zip
+    script:
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/facilities_{{ version }}_csv.zip
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_firecompanies.yml
+++ b/dcpy/library/templates/dcp_firecompanies.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_firecompanies
-  version: "{{ version }}"
+  name: dcp_firecompanies
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_healthareas.yml
+++ b/dcpy/library/templates/dcp_healthareas.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_healthareas
-  version: "{{ version }}"
+  name: dcp_healthareas
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_healthcenters.yml
+++ b/dcpy/library/templates/dcp_healthcenters.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_healthcenters
-  version: "{{ version }}"
+  name: dcp_healthcenters
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_limitedheight.yml
+++ b/dcpy/library/templates/dcp_limitedheight.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_limitedheight
-  version: "{{ version }}"
+  name: dcp_limitedheight
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_limited_height_districts/staging/dcp_limited_height_districts.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_mappluto.yml
+++ b/dcpy/library/templates/dcp_mappluto.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_mappluto
-  version: "{{ version }}"
+  name: dcp_mappluto
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_mappluto_clipped.yml
+++ b/dcpy/library/templates/dcp_mappluto_clipped.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_mappluto_clipped
-  version: "{{ version }}"
+  name: dcp_mappluto_clipped
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_mappluto_historical.yml
+++ b/dcpy/library/templates/dcp_mappluto_historical.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_mappluto
-  version: "{{ version }}"
+  name: dcp_mappluto
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/mappluto/mappluto_{{ version | replace(".","_") }}.zip
-      subpath: ''
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_mappluto_wi.yml
+++ b/dcpy/library/templates/dcp_mappluto_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_mappluto_wi
-  version: "{{ version }}"
+  name: dcp_mappluto_wi
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_mih.yml
+++ b/dcpy/library/templates/dcp_mih.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_mih
-  version: "{{ version }}"
+  name: dcp_mih
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_inclusionary_housing/staging/dcp_inclusionary_housing.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_municipalcourtdistricts.yml
+++ b/dcpy/library/templates/dcp_municipalcourtdistricts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_municipalcourtdistricts
-  version: "{{ version }}"
+  name: dcp_municipalcourtdistricts
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
   
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_municipalcourtdistricts_wi.yml
+++ b/dcpy/library/templates/dcp_municipalcourtdistricts_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_municipalcourtdistricts_wi
-  version: "{{ version }}"
+  name: dcp_municipalcourtdistricts_wi
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
   
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_nta2010.yml
+++ b/dcpy/library/templates/dcp_nta2010.yml
@@ -1,6 +1,5 @@
 dataset:
-  name:  &name dcp_nta2010
-  version: "{{ version }}"
+  name:  dcp_nta2010
   acl: public-read
   source:
     url:
@@ -13,7 +12,6 @@ dataset:
       - AUTODETECT_TYPE=NO
       - EMPTY_STRING_AS_NULL=YES
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_nta2020.yml
+++ b/dcpy/library/templates/dcp_nta2020.yml
@@ -1,6 +1,5 @@
 dataset:
-  name:  &name dcp_nta2020
-  version: "{{ version }}"
+  name:  dcp_nta2020
   acl: public-read
   source:
     url:
@@ -13,7 +12,6 @@ dataset:
       - AUTODETECT_TYPE=NO
       - EMPTY_STRING_AS_NULL=YES
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_ntaboundaries.yml
+++ b/dcpy/library/templates/dcp_ntaboundaries.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_ntaboundaries
-  version: "{{ version }}"
+  name: dcp_ntaboundaries
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_pad.yml
+++ b/dcpy/library/templates/dcp_pad.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dcp_pad
-  version: "{{ version }}"
+  name: dcp_pad
   acl: public-read
   source:
-    script: *name
-    path: "https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pad{{ version }}.zip"
+    script:
+      path: "https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pad{{ version }}.zip"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_pluto.yml
+++ b/dcpy/library/templates/dcp_pluto.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_pluto
-  version: "{{ version }}"
+  name: dcp_pluto
   acl: public-read
   source:
     url:
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_policeprecincts.yml
+++ b/dcpy/library/templates/dcp_policeprecincts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_policeprecincts
-  version: "{{ version }}"
+  name: dcp_policeprecincts
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_pop_acs.yml
+++ b/dcpy/library/templates/dcp_pop_acs.yml
@@ -1,17 +1,14 @@
 dataset:
-  name: &name dcp_pop_acs
-  version: "{{ version }}"
+  name: dcp_pop_acs
   acl: public-read
   source:
     url:
       path: library/tmp/acs_{{ version }}.xlsx
-      subpath: ""
     geometry:
       SRS: null
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_pop_decennial_dhc.yml
+++ b/dcpy/library/templates/dcp_pop_decennial_dhc.yml
@@ -1,17 +1,14 @@
 dataset:
-  name: &name dcp_pop_decennial_dhc
-  version: "{{ version }}"
+  name: dcp_pop_decennial_dhc
   acl: public-read
   source:
     url:
       path: library/tmp/dhc_{{ version }}.xlsx
-      subpath: ""
     geometry:
       SRS: null
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dcp_pops.yml
+++ b/dcpy/library/templates/dcp_pops.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_pops
-  version: "{{ version }}"
+  name: dcp_pops
   acl: public-read
   source:
     url:
       path: library/tmp/POPS_Open_Data(2023-5-2_14.45).CSV
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_proximity_establishments.yml
+++ b/dcpy/library/templates/dcp_proximity_establishments.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_proximity_establishments
-  version: "{{ version }}"
+  name: dcp_proximity_establishments
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:2263
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_school_districts.yml
+++ b/dcpy/library/templates/dcp_school_districts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_school_districts
-  version: "{{ version }}"
+  name: dcp_school_districts
   acl: public-read
 
   source:
@@ -15,7 +14,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_sfpsd.yml
+++ b/dcpy/library/templates/dcp_sfpsd.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dcp_sfpsd
-  version: "{{ version }}"
+  name: dcp_sfpsd
   acl: public-read
   source:
-    script: *name
-    path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/facilities_csv_201901.zip
+    script:
+      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/facilities_csv_201901.zip
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +13,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dcp_specialpurpose.yml
+++ b/dcpy/library/templates/dcp_specialpurpose.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_specialpurpose
-  version: "{{ version }}"
+  name: dcp_specialpurpose
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_special_purpose_districts/staging/dcp_special_purpose_districts.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_specialpurposesubdistricts.yml
+++ b/dcpy/library/templates/dcp_specialpurposesubdistricts.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_specialpurposesubdistricts
-  version: "{{ version }}"
+  name: dcp_specialpurposesubdistricts
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_special_purpose_subdistricts/staging/dcp_special_purpose_subdistricts.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_stateassemblydistricts.yml
+++ b/dcpy/library/templates/dcp_stateassemblydistricts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_stateassemblydistricts
-  version: "{{ version }}"
+  name: dcp_stateassemblydistricts
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry: 
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_stateassemblydistricts_wi.yml
+++ b/dcpy/library/templates/dcp_stateassemblydistricts_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_stateassemblydistricts_wi
-  version: "{{ version }}"
+  name: dcp_stateassemblydistricts_wi
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry: 
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_statesenatedistricts.yml
+++ b/dcpy/library/templates/dcp_statesenatedistricts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_statesenatedistricts
-  version: "{{ version }}"
+  name: dcp_statesenatedistricts
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry: 
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_statesenatedistricts_wi.yml
+++ b/dcpy/library/templates/dcp_statesenatedistricts_wi.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_statesenatedistricts_wi
-  version: "{{ version }}"
+  name: dcp_statesenatedistricts_wi
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
-    name: *name
     geometry: 
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_trafficanalysiszones.yml
+++ b/dcpy/library/templates/dcp_trafficanalysiszones.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_trafficanalysiszones
-  version: "{{ version }}"
+  name: dcp_trafficanalysiszones
   acl: public-read
   source:
     url:
       path: dcp_trafficanalysiszones.csv
-      subpath: ""
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON
@@ -14,7 +12,6 @@ dataset:
       - "EMPTY_STRING_AS_NULL=YES"
       - "GEOM_POSSIBLE_NAMES=geom"
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_zoningdistricts.yml
+++ b/dcpy/library/templates/dcp_zoningdistricts.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_zoningdistricts
-  version: "{{ version }}"
+  name: dcp_zoningdistricts
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_zoning_districts/staging/dcp_zoning_districts.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_zoningmapamendments.yml
+++ b/dcpy/library/templates/dcp_zoningmapamendments.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_zoningmapamendments
-  version: "{{ version }}"
+  name: dcp_zoningmapamendments
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dcp_zoning_map_amendments/staging/dcp_zoning_map_amendments.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_zoningmapindex.yml
+++ b/dcpy/library/templates/dcp_zoningmapindex.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name dcp_zoningmapindex
+  name: dcp_zoningmapindex
   version: "20190701"
   acl: public-read
   source:
@@ -14,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dcp_zoningtaxlots.yml
+++ b/dcpy/library/templates/dcp_zoningtaxlots.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_zoningtaxlots
-  version: "{{ version }}"
+  name: dcp_zoningtaxlots
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/ddc_capitalprojects_infrastructure.yml
+++ b/dcpy/library/templates/ddc_capitalprojects_infrastructure.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name ddc_capitalprojects_infrastructure
-  version: "{{ version }}"
+  name: ddc_capitalprojects_infrastructure
   acl: private
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTILINESTRING
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTILINESTRING

--- a/dcpy/library/templates/ddc_capitalprojects_publicbuildings.yml
+++ b/dcpy/library/templates/ddc_capitalprojects_publicbuildings.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name ddc_capitalprojects_publicbuildings
-  version: "{{ version }}"
+  name: ddc_capitalprojects_publicbuildings
   acl: private
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dep_wwtc.yml
+++ b/dcpy/library/templates/dep_wwtc.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dep_wwtc
-  version: "{{ version }}"
+  name: dep_wwtc
   acl: public-read
   source:
     url:
       path: library/tmp/dep_wwtc.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dfta_contracts.yml
+++ b/dcpy/library/templates/dfta_contracts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dfta_contracts
-  version: "{{ version }}"
+  name: dfta_contracts
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dob_cofos.yml
+++ b/dcpy/library/templates/dob_cofos.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dob_cofos
-  version: "{{ version }}"
+  name: dob_cofos
   acl: public-read
   source:
-    script: *name
-    path: library/tmp/dob_cofos.csv
+    script:
+      path: library/tmp/dob_cofos.csv
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dob_jobapplications.yml
+++ b/dcpy/library/templates/dob_jobapplications.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dob_jobapplications
-  version: "{{ version }}"
+  name: dob_jobapplications
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dob_now_applications.yml
+++ b/dcpy/library/templates/dob_now_applications.yml
@@ -1,9 +1,8 @@
 dataset:
-  name: &name dob_now_applications
-  version: "{{ version }}"
+  name: dob_now_applications
   acl: public-read
   source:
-    script: *name
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -12,7 +11,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dob_now_permits.yml
+++ b/dcpy/library/templates/dob_now_permits.yml
@@ -1,9 +1,8 @@
 dataset:
-  name: &name dob_now_permits
-  version: "{{ version }}"
+  name: dob_now_permits
   acl: public-read
   source:
-    script: *name
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -12,7 +11,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dob_permitissuance.yml
+++ b/dcpy/library/templates/dob_permitissuance.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dob_permitissuance
-  version: "{{ version }}"
+  name: dob_permitissuance
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/doe_busroutesgarages.yml
+++ b/dcpy/library/templates/doe_busroutesgarages.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name doe_busroutesgarages
-  version: "{{ version }}"
+  name: doe_busroutesgarages
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/doe_eszones.yml
+++ b/dcpy/library/templates/doe_eszones.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name doe_eszones
+  name: doe_eszones
   version: "2019-2020"
   acl: public-read
   source:
@@ -14,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/doe_hszones.yml
+++ b/dcpy/library/templates/doe_hszones.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name doe_hszones
+  name: doe_hszones
   version: "2019-2020"
   acl: public-read
   source:
@@ -14,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/doe_lcgms.yml
+++ b/dcpy/library/templates/doe_lcgms.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name doe_lcgms
-  version: "{{ version }}"
+  name: doe_lcgms
   acl: public-read
   source:
-    script: *name
-    path: "library/tmp/LCGMS_SchoolData_{{ version }}.csv"
+    script:
+      path: "library/tmp/LCGMS_SchoolData_{{ version }}.csv"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/doe_mszones.yml
+++ b/dcpy/library/templates/doe_mszones.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name doe_mszones
+  name: doe_mszones
   version: "2019-2020"
   acl: public-read
   source:
@@ -14,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/doe_pepmeetingurls.yml
+++ b/dcpy/library/templates/doe_pepmeetingurls.yml
@@ -1,9 +1,8 @@
 dataset:
-  name: &name doe_pepmeetingurls
-  version: "{{ version }}"
+  name: doe_pepmeetingurls
   acl: public-read
   source:
-    script: *name
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -12,7 +11,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/doe_school_subdistricts.yml
+++ b/dcpy/library/templates/doe_school_subdistricts.yml
@@ -1,11 +1,10 @@
 dataset:
-  name: &name doe_school_subdistricts
+  name: doe_school_subdistricts
   version: "2017"
   acl: public-read
   source:
     url:
       path: doe_school_subdistricts.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -15,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/doe_universalprek.yml
+++ b/dcpy/library/templates/doe_universalprek.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name doe_universalprek
-  version: "{{ version }}"
+  name: doe_universalprek
   acl: public-read
   source:
     url:
       path: library/tmp/DOE_Buildings_Locations_DECE.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dof_air_rights_lots.yml
+++ b/dcpy/library/templates/dof_air_rights_lots.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dof_air_rights_lots
-  version: "{{ version }}"
+  name: dof_air_rights_lots
   acl: public-read
   source:
     url:
       path: https://edm-publishing.nyc3.digitaloceanspaces.com/datasets/dof_dtm_air_rights_lots/staging/dof_dtm_air_rights_lots.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dof_condo.yml
+++ b/dcpy/library/templates/dof_condo.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dof_condo
-  version: "{{ version }}"
+  name: dof_condo
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dof_dtm_condo/staging/dof_dtm_condo.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/dof_dtm.yml
+++ b/dcpy/library/templates/dof_dtm.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dof_dtm
-  version: "{{ version }}"
+  name: dof_dtm
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dof_dtm_tax_lot_polygon/staging/dof_dtm_tax_lot_polygon.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dof_shoreline.yml
+++ b/dcpy/library/templates/dof_shoreline.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dof_shoreline
-  version: "{{ version }}"
+  name: dof_shoreline
   acl: public-read
   source:
     url:
       path: s3://edm-publishing/datasets/dof_dtm_shoreline_polygon/staging/dof_dtm_shoreline_polygon.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dohmh_daycare.yml
+++ b/dcpy/library/templates/dohmh_daycare.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dohmh_daycare
-  version: "{{ version }}"
+  name: dohmh_daycare
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/doi_evictions.yml
+++ b/dcpy/library/templates/doi_evictions.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name doi_evictions
-  version: "{{ version }}"
+  name: doi_evictions
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/doitt_buildingcentroids.yml
+++ b/dcpy/library/templates/doitt_buildingcentroids.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name doitt_buildingcentroids
-  version: "{{ version }}"
+  name: doitt_buildingcentroids
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/doitt_buildingfootprints.yml
+++ b/dcpy/library/templates/doitt_buildingfootprints.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name doitt_buildingfootprints
-  version: "{{ version }}"
+  name: doitt_buildingfootprints
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/doitt_buildingfootprints_historical.yml
+++ b/dcpy/library/templates/doitt_buildingfootprints_historical.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name doitt_buildingfootprints_historical
-  version: "{{ version }}"
+  name: doitt_buildingfootprints_historical
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/doitt_zipcodeboundaries.yml
+++ b/dcpy/library/templates/doitt_zipcodeboundaries.yml
@@ -1,11 +1,10 @@
 dataset:
-  name: &name doitt_zipcodeboundaries
+  name: doitt_zipcodeboundaries
   version: "20180910"
   acl: public-read
   source:
     url:
       path: s3://edm-recipes/tmp/doitt_zipcodeboundaries.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"  
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dot_bridgehouses.yml
+++ b/dcpy/library/templates/dot_bridgehouses.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_bridgehouses
-  version: "{{ version }}"
+  name: dot_bridgehouses
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dot_ferryterminals.yml
+++ b/dcpy/library/templates/dot_ferryterminals.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_ferryterminals
-  version: "{{ version }}"
+  name: dot_ferryterminals
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dot_mannedfacilities.yml
+++ b/dcpy/library/templates/dot_mannedfacilities.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_mannedfacilities
-  version: "{{ version }}"
+  name: dot_mannedfacilities
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dot_pedplazas.yml
+++ b/dcpy/library/templates/dot_pedplazas.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_pedplazas
-  version: "{{ version }}"
+  name: dot_pedplazas
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: POLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POLYGON

--- a/dcpy/library/templates/dot_projects_bridges.yml
+++ b/dcpy/library/templates/dot_projects_bridges.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_projects_bridges
-  version: "{{ version }}"
+  name: dot_projects_bridges
   acl: private
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOINT

--- a/dcpy/library/templates/dot_projects_intersections.yml
+++ b/dcpy/library/templates/dot_projects_intersections.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_projects_intersections
-  version: "{{ version }}"
+  name: dot_projects_intersections
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: MULTIPOINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOINT

--- a/dcpy/library/templates/dot_projects_streets.yml
+++ b/dcpy/library/templates/dot_projects_streets.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_projects_streets
-  version: "{{ version }}"
+  name: dot_projects_streets
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: MULTILINESTRING
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTILINESTRING

--- a/dcpy/library/templates/dot_publicparking.yml
+++ b/dcpy/library/templates/dot_publicparking.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dot_publicparking
-  version: "{{ version }}"
+  name: dot_publicparking
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dpr_capitalprojects.yml
+++ b/dcpy/library/templates/dpr_capitalprojects.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name dpr_capitalprojects
-  version: "{{ version }}"
+  name: dpr_capitalprojects
   acl: public-read
   source:
-    script: *name
-    path: https://www.nycgovparks.org/bigapps/DPR_CapitalProjectTracker_001.json
+    script:
+      path: https://www.nycgovparks.org/bigapps/DPR_CapitalProjectTracker_001.json
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dpr_greenthumb.yml
+++ b/dcpy/library/templates/dpr_greenthumb.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dpr_greenthumb
-  version: "{{ version }}"
+  name: dpr_greenthumb
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dpr_park_access_zone.yml
+++ b/dcpy/library/templates/dpr_park_access_zone.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dpr_park_access_zone
-  version: "{{ version }}"
+  name: dpr_park_access_zone
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dpr_parksproperties.yml
+++ b/dcpy/library/templates/dpr_parksproperties.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dpr_parksproperties
-  version: "{{ version }}"
+  name: dpr_parksproperties
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dsny_donatenycdirectory.yml
+++ b/dcpy/library/templates/dsny_donatenycdirectory.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_donatenycdirectory
-  version: "{{ version }}"
+  name: dsny_donatenycdirectory
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dsny_electronicsdrop.yml
+++ b/dcpy/library/templates/dsny_electronicsdrop.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_electronicsdrop
-  version: "{{ version }}"
+  name: dsny_electronicsdrop
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dsny_fooddrop.yml
+++ b/dcpy/library/templates/dsny_fooddrop.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_fooddrop
-  version: "{{ version }}"
+  name: dsny_fooddrop
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dsny_frequencies.yml
+++ b/dcpy/library/templates/dsny_frequencies.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_frequencies
-  version: "{{ version }}"
+  name: dsny_frequencies
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/dsny_garages.yml
+++ b/dcpy/library/templates/dsny_garages.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_garages
-  version: "{{ version }}"
+  name: dsny_garages
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dsny_leafdrop.yml
+++ b/dcpy/library/templates/dsny_leafdrop.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_leafdrop
-  version: "{{ version }}"
+  name: dsny_leafdrop
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dsny_specialwastedrop.yml
+++ b/dcpy/library/templates/dsny_specialwastedrop.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_specialwastedrop
-  version: "{{ version }}"
+  name: dsny_specialwastedrop
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dsny_textiledrop.yml
+++ b/dcpy/library/templates/dsny_textiledrop.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dsny_textiledrop
-  version: "{{ version }}"
+  name: dsny_textiledrop
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/dycd_afterschoolprograms.yml
+++ b/dcpy/library/templates/dycd_afterschoolprograms.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dycd_afterschoolprograms
-  version: "{{ version }}"
+  name: dycd_afterschoolprograms
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/edc_capitalprojects.yml
+++ b/dcpy/library/templates/edc_capitalprojects.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name edc_capitalprojects
-  version: "{{ version }}"
+  name: edc_capitalprojects
   acl: private
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/edc_capitalprojects_ferry.yml
+++ b/dcpy/library/templates/edc_capitalprojects_ferry.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name edc_capitalprojects_ferry
-  version: "{{ version }}"
+  name: edc_capitalprojects_ferry
   acl: private
   source:
     url:
       path: edc_capitalprojects_ferry.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -15,7 +13,6 @@ dataset:
       type: MULTILINESTRING
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTILINESTRING

--- a/dcpy/library/templates/fbop_corrections.yml
+++ b/dcpy/library/templates/fbop_corrections.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name fbop_corrections
-  version: "{{ version }}"
+  name: fbop_corrections
   acl: public-read
   source:
     url:
       path: library/tmp/fbop_corrections.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/fdny_firecompanies.yml
+++ b/dcpy/library/templates/fdny_firecompanies.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name fdny_firecompanies
-  version: "{{ version }}"
+  name: fdny_firecompanies
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/fdny_firehouses.yml
+++ b/dcpy/library/templates/fdny_firehouses.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name fdny_firehouses
-  version: "{{ version }}"
+  name: fdny_firehouses
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/fema_firms2007_100yr.yml
+++ b/dcpy/library/templates/fema_firms2007_100yr.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name fema_firms2007_100yr
+  name: fema_firms2007_100yr
   version: "20181219"
   acl: public-read
   source:
@@ -14,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/fema_firms_500yr.yml
+++ b/dcpy/library/templates/fema_firms_500yr.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name fema_firms_500yr
+  name: fema_firms_500yr
   version: "20181219"
   acl: public-read
   source:
@@ -14,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/fema_pfirms2015_100yr.yml
+++ b/dcpy/library/templates/fema_pfirms2015_100yr.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: &name fema_pfirms2015_100yr
+  name: fema_pfirms2015_100yr
   version: "20181219"
   acl: public-read
   source:
@@ -14,7 +14,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/fisa_capitalcommitments.yml
+++ b/dcpy/library/templates/fisa_capitalcommitments.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name fisa_capitalcommitments
-  version: "{{ version }}"
+  name: fisa_capitalcommitments
   acl: private
   source:
-    script: *name
-    path: library/tmp/AICP_OREQ_CAPPLN_PJCP.asc
+    script:
+      path: library/tmp/AICP_OREQ_CAPPLN_PJCP.asc
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/fisa_dailybudget.yml
+++ b/dcpy/library/templates/fisa_dailybudget.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name fisa_dailybudget
-  version: "{{ version }}"
+  name: fisa_dailybudget
   acl: private
   source:
-    script: *name
-    path: library/tmp/fisa_dailybudget/
+    script:
+      path: library/tmp/fisa_dailybudget/
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/foodbankny_foodbanks.yml
+++ b/dcpy/library/templates/foodbankny_foodbanks.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name foodbankny_foodbanks
-  version: "{{ version }}"
+  name: foodbankny_foodbanks
   acl: public-read
   source:
     url:
       path: "library/tmp/Food_Bank_For_NYC_Open_Members_as_of_{{ version }}.csv"
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/hhc_hospitals.yml
+++ b/dcpy/library/templates/hhc_hospitals.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name hhc_hospitals
-  version: "{{ version }}"
+  name: hhc_hospitals
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/hpd_historical_units_by_building.yml
+++ b/dcpy/library/templates/hpd_historical_units_by_building.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name hpd_historical_units_by_building
-  version: "{{ version }}"
+  name: hpd_historical_units_by_building
   acl: public-read
   source:
-    script: *name
-    path: library/tmp/HPD_FROM_DCP_HOUSING/06_20_2023_Lookback Legislation.xlsx
+    script:
+      path: library/tmp/HPD_FROM_DCP_HOUSING/06_20_2023_Lookback Legislation.xlsx
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/hpd_hny_units_by_building.yml
+++ b/dcpy/library/templates/hpd_hny_units_by_building.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name hpd_hny_units_by_building
-  version: "{{ version }}"
+  name: hpd_hny_units_by_building
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/hra_centers.yml
+++ b/dcpy/library/templates/hra_centers.yml
@@ -1,9 +1,8 @@
 dataset:
-  name: &name hra_centers
-  version: "{{ version }}"
+  name: hra_centers
   acl: public-read
   source:
-    script: *name
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -12,7 +11,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/hra_jobcenters.yml
+++ b/dcpy/library/templates/hra_jobcenters.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name hra_jobcenters
-  version: "{{ version }}"
+  name: hra_jobcenters
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/hra_medicaid.yml
+++ b/dcpy/library/templates/hra_medicaid.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name hra_medicaid
-  version: "{{ version }}"
+  name: hra_medicaid
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/hra_snapcenters.yml
+++ b/dcpy/library/templates/hra_snapcenters.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name hra_snapcenters
-  version: "{{ version }}"
+  name: hra_snapcenters
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/lpc_historic_district_areas.yml
+++ b/dcpy/library/templates/lpc_historic_district_areas.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name lpc_historic_district_areas
-  version: "{{ version }}"
+  name: lpc_historic_district_areas
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/lpc_historic_districts.yml
+++ b/dcpy/library/templates/lpc_historic_districts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name lpc_historic_districts
-  version: "{{ version }}"
+  name: lpc_historic_districts
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/lpc_landmarks.yml
+++ b/dcpy/library/templates/lpc_landmarks.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name lpc_landmarks
-  version: "{{ version }}"
+  name: lpc_landmarks
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/moeo_socialservicesitelocations.yml
+++ b/dcpy/library/templates/moeo_socialservicesitelocations.yml
@@ -1,9 +1,8 @@
 dataset:
-  name: &name moeo_socialservicesitelocations
-  version: "{{ version }}"
+  name: moeo_socialservicesitelocations
   acl: public-read
   source:
-    script: *name
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -12,7 +11,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nycdoc_corrections.yml
+++ b/dcpy/library/templates/nycdoc_corrections.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name nycdoc_corrections
-  version: "{{ version }}"
+  name: nycdoc_corrections
   acl: public-read
   source:
-    script: *name
-    path: https://www1.nyc.gov/site/doc/about/facilities-locations.page
+    script:
+      path: https://www1.nyc.gov/site/doc/about/facilities-locations.page
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nycha_communitycenters.yml
+++ b/dcpy/library/templates/nycha_communitycenters.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name nycha_communitycenters
-  version: "{{ version }}"
+  name: nycha_communitycenters
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/nycha_policeservice.yml
+++ b/dcpy/library/templates/nycha_policeservice.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name nycha_policeservice
-  version: "{{ version }}"
+  name: nycha_policeservice
   acl: public-read
   source:
     socrata:
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/nycoc_checkbook.yml
+++ b/dcpy/library/templates/nycoc_checkbook.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name nycoc_checkbook
-  version: "{{ version }}"
+  name: nycoc_checkbook
   acl: public-read
 
   source:
-    script: *name
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nycourts_courts.yml
+++ b/dcpy/library/templates/nycourts_courts.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nycourts_courts
-  version: "{{ version }}"
+  name: nycourts_courts
   acl: public-read
   source:
     url:
       path: library/tmp/nycourts_courts.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nypd_policeprecincts.yml
+++ b/dcpy/library/templates/nypd_policeprecincts.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name nypd_policeprecincts
-  version: "{{ version }}"
+  name: nypd_policeprecincts
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/nypl_libraries.yml
+++ b/dcpy/library/templates/nypl_libraries.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name nypl_libraries
-  version: "{{ version }}"
+  name: nypl_libraries
   acl: public-read
   source:
-    script: *name
-    path: https://refinery.nypl.org/api/nypl/locations/v1.0/locations
+    script:
+      path: https://refinery.nypl.org/api/nypl/locations/v1.0/locations
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -15,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/nysdec_lands.yml
+++ b/dcpy/library/templates/nysdec_lands.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysdec_lands
-  version: "{{ version }}"
+  name: nysdec_lands
   acl: public-read
   source:
     url:
       path: library/tmp/NYS_DEC_Lands.zip
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/library/templates/nysdec_solidwaste.yml
+++ b/dcpy/library/templates/nysdec_solidwaste.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysdec_solidwaste
-  version: "{{ version }}"
+  name: nysdec_solidwaste
   acl: public-read
   source:
     url:
       path: https://data.ny.gov/api/views/2fni-raj8/rows.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nysdoccs_corrections.yml
+++ b/dcpy/library/templates/nysdoccs_corrections.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysdoccs_corrections
-  version: "{{ version }}"
+  name: nysdoccs_corrections
   acl: public-read
   source:
     url:
       path: library/tmp/nysdoccs_corrections_20200323.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nysdoh_healthfacilities.yml
+++ b/dcpy/library/templates/nysdoh_healthfacilities.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysdoh_healthfacilities
-  version: "{{ version }}"
+  name: nysdoh_healthfacilities
   acl: public-read
   source:
     url:
       path: https://health.data.ny.gov/api/views/vn5v-hh5r/rows.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/nysdoh_nursinghomes.yml
+++ b/dcpy/library/templates/nysdoh_nursinghomes.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysdoh_nursinghomes
-  version: "{{ version }}"
+  name: nysdoh_nursinghomes
   acl: public-read
   source:
     url:
       path: https://health.data.ny.gov/api/views/izta-vnpq/rows.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -15,7 +13,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/nysed_activeinstitutions.yml
+++ b/dcpy/library/templates/nysed_activeinstitutions.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysed_activeinstitutions
-  version: "{{ version }}"
+  name: nysed_activeinstitutions
   acl: public-read
   source:
     url:
       path: library/tmp/All_Institutions_by_County.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nysed_nonpublicenrollment.yml
+++ b/dcpy/library/templates/nysed_nonpublicenrollment.yml
@@ -1,10 +1,9 @@
 dataset:
-  name: &name nysed_nonpublicenrollment
-  version: "{{ version }}"
+  name: nysed_nonpublicenrollment
   acl: public-read
   source:
-    script: *name
-    path: https://www.p12.nysed.gov/irs/statistics/nonpublic/enrollment-by-grade-nonpublic-{{ version }}.xlsx
+    script:
+      path: https://www.p12.nysed.gov/irs/statistics/nonpublic/enrollment-by-grade-nonpublic-{{ version }}.xlsx
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nysoasas_programs.yml
+++ b/dcpy/library/templates/nysoasas_programs.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysoasas_programs
-  version: "{{ version }}"
+  name: nysoasas_programs
   acl: public-read
   source:
     url:
       path: https://webapps.oasas.ny.gov/providerDirectory/download/Treatment_Programs_OASAS_Directory_Search_{{ version }}.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nysomh_mentalhealth.yml
+++ b/dcpy/library/templates/nysomh_mentalhealth.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysomh_mentalhealth
-  version: "{{ version }}"
+  name: nysomh_mentalhealth
   acl: public-read
   source:
     url:
       path: https://data.ny.gov/api/views/6nvr-tbv8/rows.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nysopwdd_providers.yml
+++ b/dcpy/library/templates/nysopwdd_providers.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysopwdd_providers
-  version: "{{ version }}"
+  name: nysopwdd_providers
   acl: public-read
   source:
     url:
       path: https://data.ny.gov/api/views/ieqx-cqyk/rows.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/nysparks_historicplaces.yml
+++ b/dcpy/library/templates/nysparks_historicplaces.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysparks_historicplaces
-  version: "{{ version }}"
+  name: nysparks_historicplaces
   acl: public-read
   source:
     url:
       path: https://data.ny.gov/api/views/iisn-hnyv/rows.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/nysparks_parks.yml
+++ b/dcpy/library/templates/nysparks_parks.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name nysparks_parks
-  version: "{{ version }}"
+  name: nysparks_parks
   acl: public-read
   source:
     url:
       path: https://data.ny.gov/api/views/9uuk-x7vh/rows.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/pluto_corrections.yml
+++ b/dcpy/library/templates/pluto_corrections.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name pluto_corrections
-  version: "{{ version }}"
+  name: pluto_corrections
   acl: public-read
   source:
     url:
@@ -16,7 +15,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/qpl_libraries.yml
+++ b/dcpy/library/templates/qpl_libraries.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name qpl_libraries
-  version: "{{ version }}"
+  name: qpl_libraries
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/sbs_workforce1.yml
+++ b/dcpy/library/templates/sbs_workforce1.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name sbs_workforce1
-  version: "{{ version }}"
+  name: sbs_workforce1
   acl: public-read
   source:
     socrata:
@@ -16,7 +15,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/sca_bluebook.yml
+++ b/dcpy/library/templates/sca_bluebook.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name sca_bluebook
-  version: "{{ version }}"
+  name: sca_bluebook
   acl: public-read
   source:
     url:
       path: library/tmp/2021-22 Blue Book SV.csv
-      subpath: ""
     options:
       - AUTODETECT_TYPE=NO
       - EMPTY_STRING_AS_NULL=YES
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/sca_capacity_projects_current.yml
+++ b/dcpy/library/templates/sca_capacity_projects_current.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name sca_capacity_projects_current
-  version: "{{ version }}"
+  name: sca_capacity_projects_current
   acl: public-read
   source:
     url:
       path: library/tmp/sca_capacity_projects_current.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/sca_e_pct.yml
+++ b/dcpy/library/templates/sca_e_pct.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name sca_e_pct
-  version: "{{ version }}"
+  name: sca_e_pct
   acl: public-read
   source:
     url:
       path: library/tmp/sca_e_pct.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/sca_e_projections.yml
+++ b/dcpy/library/templates/sca_e_projections.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name sca_e_projections
-  version: "{{ version }}"
+  name: sca_e_projections
   acl: public-read
   source:
     url:
       path: library/tmp/sca_e_projections.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/sca_enrollment_capacity.yml
+++ b/dcpy/library/templates/sca_enrollment_capacity.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name sca_enrollment_capacity
-  version: "{{ version }}"
+  name: sca_enrollment_capacity
   acl: public-read
   source:
     socrata:
@@ -14,7 +13,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/test_nypl_libraries.yml
+++ b/dcpy/library/templates/test_nypl_libraries.yml
@@ -1,11 +1,10 @@
 dataset:
-  name: &name test_nypl_libraries
+  name: test_nypl_libraries
   version: "20210122"
   acl: public-read
   source:
     url:
       path: dcpy/test/library/data/test_nypl_libraries.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/uscourts_courts.yml
+++ b/dcpy/library/templates/uscourts_courts.yml
@@ -1,9 +1,8 @@
 dataset:
-  name: &name uscourts_courts
-  version: "{{ version }}"
+  name: uscourts_courts
   acl: public-read
   source:
-    script: *name
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +13,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/usdot_airports.yml
+++ b/dcpy/library/templates/usdot_airports.yml
@@ -1,10 +1,8 @@
 dataset:
-  name: &name usdot_airports
-  version: "{{ version }}"
+  name: usdot_airports
   acl: public-read
   source:
-    script: *name
-    path: https://adip.faa.gov/publishedAirports/all-airport-data.xlsx
+    script: {}
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -13,7 +11,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/dcpy/library/templates/usdot_ports.yml
+++ b/dcpy/library/templates/usdot_ports.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name usdot_ports
-  version: "{{ version }}"
+  name: usdot_ports
   acl: public-read
   source:
     url:
       path: https://services7.arcgis.com/n1YM8pTrFmm7L4hs/ArcGIS/rest/services/ndc/FeatureServer/2/query?outFields=*&where=1%3D1&f=geojson
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/library/templates/usnps_parks.yml
+++ b/dcpy/library/templates/usnps_parks.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name usnps_parks
-  version: "{{ version }}"
+  name: usnps_parks
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: POLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POLYGON

--- a/dcpy/library/utils.py
+++ b/dcpy/library/utils.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlparse
 
+from . import TEMPLATE_DIR
+
 
 def parse_engine(url: str) -> str:
     """
@@ -43,3 +45,8 @@ def format_url(path: str, subpath: str = "") -> str:
         url = "/vsizip/" + url
 
     return url
+
+
+def get_all_templates():
+    """Get names of all dataset templates included in dcpy"""
+    return [file.stem for file in TEMPLATE_DIR.glob("*")]

--- a/dcpy/test/library/data/bpl_libraries_sql.yml
+++ b/dcpy/test/library/data/bpl_libraries_sql.yml
@@ -3,8 +3,8 @@ dataset:
   version: "{{ version }}"
   acl: public-read
   source:
-    script: *name
-    path: "https://www.bklynlibrary.org/locations/json"
+    script:
+      path: "https://www.bklynlibrary.org/locations/json"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -15,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/test/library/data/bpl_libraries_sql_deprecated.yml
+++ b/dcpy/test/library/data/bpl_libraries_sql_deprecated.yml
@@ -1,5 +1,6 @@
 dataset:
-  name: bpl_libraries
+  name: &name bpl_libraries
+  version: "{{ version }}"
   acl: public-read
   source:
     script:
@@ -14,6 +15,7 @@ dataset:
       type: POINT
 
   destination:
+    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/test/library/data/socrata.yml
+++ b/dcpy/test/library/data/socrata.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dpr_parksproperties
-  version: "{{ version }}"
+  name: dpr_parksproperties
   acl: public-read
   source:
     # if source is socrata, the url can be computed
@@ -17,7 +16,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/test/library/data/test_none.yml
+++ b/dcpy/test/library/data/test_none.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name test_none
-  version: "{{ version }}"
+  name: test_none
   acl: public-read
   source:
     url:
@@ -14,7 +13,6 @@ dataset:
       type: MULTIPOLYGON
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/test/library/data/test_nypl_libraries.yml
+++ b/dcpy/test/library/data/test_nypl_libraries.yml
@@ -1,11 +1,10 @@
 dataset:
-  name: &name test_nypl_libraries
+  name: test_nypl_libraries
   version: "20210122"
   acl: public-read
   source:
     url:
       path: dcpy/test/library/data/test_nypl_libraries.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +15,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/dcpy/test/library/data/url.yml
+++ b/dcpy/test/library/data/url.yml
@@ -1,6 +1,5 @@
 dataset:
-  name: &name dcp_mappluto
-  version: "{{ version }}"
+  name: dcp_mappluto
   acl: public-read
   # Source definition
   source:
@@ -18,7 +17,6 @@ dataset:
 
   # Destination definition
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON

--- a/dcpy/test/library/test_archive.py
+++ b/dcpy/test/library/test_archive.py
@@ -33,10 +33,8 @@ def test_archive_1():
     s3_exist = [
         f"{TEST_DATASET_OUTPUT_PATH_S3}/{TEST_DATASET_NAME}.csv.zip",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.csv.zip",
-        f"{TEST_DATASET_OUTPUT_PATH_S3}/config.yml",
         f"{TEST_DATASET_OUTPUT_PATH_S3}/config.json",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.csv.zip",
-        f"datasets/{TEST_DATASET_NAME}/latest/config.yml",
         f"datasets/{TEST_DATASET_NAME}/latest/config.json",
     ]
     start_clean(local_not_exist, s3_exist)
@@ -58,16 +56,13 @@ def test_archive_1():
 def test_archive_2():
     s3_not_exist = [
         f"{TEST_DATASET_OUTPUT_PATH_S3}/{TEST_DATASET_NAME}.geojson.zip",
-        f"{TEST_DATASET_OUTPUT_PATH_S3}/config.yml",
         f"{TEST_DATASET_OUTPUT_PATH_S3}/config.json",
         f"{TEST_DATASET_OUTPUT_PATH_S3}/{TEST_DATASET_NAME}.geojson",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.geojson.zip",
-        f"datasets/{TEST_DATASET_NAME}/latest/config.yml",
         f"datasets/{TEST_DATASET_NAME}/latest/config.json",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.geojson",
     ]
     local_exist = [
-        f"{TEST_DATASET_OUTPUT_DIRECTORY}/config.yml",
         f"{TEST_DATASET_OUTPUT_DIRECTORY}/config.json",
         f"{TEST_DATASET_OUTPUT_PATH}.geojson.zip",
         f"{TEST_DATASET_OUTPUT_PATH}.geojson",
@@ -116,17 +111,14 @@ def test_archive_4():
         f"datasets/{TEST_DATASET_NAME}/testor/{TEST_DATASET_NAME}.csv.zip",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.csv.zip",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.csv",
-        f"datasets/{TEST_DATASET_NAME}/latest/config.yml",
         f"datasets/{TEST_DATASET_NAME}/latest/config.json",
     ]
     s3_exist = [
-        f"datasets/{TEST_DATASET_NAME}/testor/config.yml",
         f"datasets/{TEST_DATASET_NAME}/testor/config.json",
         f"datasets/{TEST_DATASET_NAME}/testor/{TEST_DATASET_NAME}.csv",
     ]
     local_exist = [
         f".library/datasets/{TEST_DATASET_NAME}/testor/{TEST_DATASET_NAME}.csv",
-        f".library/datasets/{TEST_DATASET_NAME}/testor/config.yml",
         f".library/datasets/{TEST_DATASET_NAME}/testor/config.json",
     ]
     local_not_exist = [
@@ -158,17 +150,14 @@ def test_archive_5():
         f"datasets/{TEST_DATASET_NAME}/testor/{TEST_DATASET_NAME}.csv.zip",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.csv.zip",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.csv",
-        f"datasets/{TEST_DATASET_NAME}/latest/config.yml",
         f"datasets/{TEST_DATASET_NAME}/latest/config.json",
     ]
     s3_exist = [
-        f"datasets/{TEST_DATASET_NAME}/testor/config.yml",
         f"datasets/{TEST_DATASET_NAME}/testor/config.json",
         f"datasets/{TEST_DATASET_NAME}/testor/{TEST_DATASET_NAME}.csv",
     ]
     local_exist = [
         f".library/datasets/{TEST_DATASET_NAME}/testor/{TEST_DATASET_NAME}.csv",
-        f".library/datasets/{TEST_DATASET_NAME}/testor/config.yml",
         f".library/datasets/{TEST_DATASET_NAME}/testor/config.json",
     ]
     local_not_exist = [
@@ -204,9 +193,7 @@ def test_archive_6():
     s3_exist = [
         f"{TEST_DATASET_OUTPUT_PATH_S3}/{TEST_DATASET_NAME}.shp.zip",
         f"datasets/{TEST_DATASET_NAME}/latest/{TEST_DATASET_NAME}.shp.zip",
-        f"{TEST_DATASET_OUTPUT_PATH_S3}/config.yml",
         f"{TEST_DATASET_OUTPUT_PATH_S3}/config.json",
-        f"datasets/{TEST_DATASET_NAME}/latest/config.yml",
         f"datasets/{TEST_DATASET_NAME}/latest/config.json",
     ]
     local_exist = [f"{TEST_DATASET_OUTPUT_PATH}.shp.zip"]

--- a/dcpy/test/library/test_config.py
+++ b/dcpy/test/library/test_config.py
@@ -6,19 +6,20 @@ from . import template_path, get_config_file
 def test_config_parsed_rendered_template():
     c = Config(get_config_file("url"))
     rendered = c.parsed_rendered_template(version="20v7")
-    assert rendered["dataset"]["version"] == "20v7"
+    assert rendered.version == "20v7"
 
 
 def test_config_source_type():
-    c = Config(get_config_file("socrata"))
-    assert c.source_type == "socrata"
-    c = Config(get_config_file("url"))
-    assert c.source_type == "url"
+    c = Config(get_config_file("socrata")).compute
+    assert c.source.socrata
+    c = Config(get_config_file("url")).compute
+    assert c.source.url
 
 
 def test_config_version_socrata():
     c = Config(get_config_file("socrata"))
-    uid = c.parsed_unrendered_template["dataset"]["source"]["socrata"]["uid"]
+    assert c.parsed_unrendered_template.source.socrata
+    uid = c.parsed_unrendered_template.source.socrata.uid
     version = c.version_socrata(uid)
     assert len(version) == 8  # format: YYYYMMDD
     assert int(version[-2:]) <= 31  # check date
@@ -34,23 +35,13 @@ def test_config_version_today():
 
 
 def test_config_compute():
-    config = Config(get_config_file("socrata")).compute
-    assert type(config["dataset"]["source"]["url"]) == dict
-
-
-def test_config_compute_parsed():
-    dataset, source, destination, info = Config(
-        get_config_file("socrata")
-    ).compute_parsed
-    assert dataset["source"] == source
-    assert dataset["info"] == info
-    assert dataset["destination"] == destination
-    assert "url" in list(source.keys())
-    assert "options" in list(source.keys())
-    assert "geometry" in list(source.keys())
-    assert "fields" in list(destination.keys())
-    assert "options" in list(destination.keys())
-    assert "geometry" in list(destination.keys())
+    dataset = Config(get_config_file("socrata")).compute
+    assert dataset.source.gdalpath
+    assert dataset.source.options
+    assert dataset.source.geometry
+    assert dataset.destination.fields == []
+    assert dataset.destination.options
+    assert dataset.destination.geometry
 
 
 def test_config_script():

--- a/dcpy/test/library/test_config.py
+++ b/dcpy/test/library/test_config.py
@@ -47,3 +47,9 @@ def test_config_compute():
 def test_config_script():
     config = Config(f"{template_path}/bpl_libraries.yml").compute
     assert True
+
+
+def test_backwards_compatility_with_jinja_version():
+    config = Config(get_config_file("bpl_libraries_sql_deprecated"))
+    computed = config.compute
+    assert computed.version == config.version_today

--- a/dcpy/test/library/test_validator.py
+++ b/dcpy/test/library/test_validator.py
@@ -12,9 +12,5 @@ def test_tree_structure():
     assert v.tree_is_valid
 
 
-def test_dataset_name_matches():
-    assert v.dataset_name_matches
-
-
 def test_has_only_one_source():
     assert v.has_only_one_source

--- a/dcpy/test/library/test_validator.py
+++ b/dcpy/test/library/test_validator.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 
 from dcpy.library.validator import Validator
+from dcpy.library import TEMPLATE_DIR
 
 with open(f"{Path(__file__).parent}/data/test_none.yml", "r") as f:
     v = Validator(yaml.safe_load(f.read()))
@@ -14,3 +15,11 @@ def test_tree_structure():
 
 def test_has_only_one_source():
     assert v.has_only_one_source
+
+
+def test_validate_all_datasets():
+    for file in TEMPLATE_DIR.glob("*"):
+        with open(file, "r") as f:
+            val = Validator(yaml.safe_load(f))
+        assert val.tree_is_valid
+        assert v.has_only_one_source

--- a/products/developments/templates/dcp_developments.yml
+++ b/products/developments/templates/dcp_developments.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_developments
-  version: "{{ version }}"
+  name: dcp_developments
   acl: public-read
   source:
     url:
       path: https://nyc3.digitaloceanspaces.com/edm-publishing/db-developments/publish/{{ version }}/devdb.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/products/developments/templates/dcp_housing.yml
+++ b/products/developments/templates/dcp_housing.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_housing
-  version: "{{ version }}"
+  name: dcp_housing
   acl: public-read
   source:
     url:
       path: https://nyc3.digitaloceanspaces.com/edm-publishing/db-developments/publish/{{ version }}/housing.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/products/developments/templates/hny_geocode_results.yml
+++ b/products/developments/templates/hny_geocode_results.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name hny_geocode_results
-  version: "{{ version }}"
+  name: hny_geocode_results
   acl: public-read
   source:
     url:
       path: hny_geocode_results.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/developments/templates/hpd_historical_geocode_results.yml
+++ b/products/developments/templates/hpd_historical_geocode_results.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name hpd_historical_geocode_results
-  version: "{{ version }}"
+  name: hpd_historical_geocode_results
   acl: public-read
   source:
     url:
       path: hpd_historical_geocode_results.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/pluto/pluto_build/templates/pluto_input_geocodes.yml
+++ b/products/pluto/pluto_build/templates/pluto_input_geocodes.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name pluto_input_geocodes
-  version: "{{ version }}"
+  name: pluto_input_geocodes
   acl: public-read
   source:
     url:
       path: s3://edm-recipes/tmp/pluto_input_geocodes.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -16,7 +14,6 @@ dataset:
       type: POINT
 
   destination:
-    name: *name
     geometry:
       SRS: EPSG:4326
       type: POINT

--- a/products/pluto/pluto_build/templates/pluto_input_numbldgs.yml
+++ b/products/pluto/pluto_build/templates/pluto_input_numbldgs.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name pluto_input_numbldgs
-  version: "{{ version }}"
+  name: pluto_input_numbldgs
   acl: public-read
   source:
     url:
       path: s3://edm-recipes/tmp/pluto_input_numbldgs.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/pluto/pluto_build/templates/pluto_pts.yml
+++ b/products/pluto/pluto_build/templates/pluto_pts.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name pluto_pts
-  version: "{{ version }}"
+  name: pluto_pts
   acl: public-read
   source:
     url:
       path: s3://edm-recipes/tmp/pluto_pts.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/zap-opendata/templates/dcp_communityboarddispositions.yml
+++ b/products/zap-opendata/templates/dcp_communityboarddispositions.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_communityboarddispositions
-  version: "{{ version }}"
+  name: dcp_communityboarddispositions
   acl: private
   source:
     url:
       path: .output/dcp_communityboarddispositions/dcp_communityboarddispositions.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/zap-opendata/templates/dcp_dcpprojectteams.yml
+++ b/products/zap-opendata/templates/dcp_dcpprojectteams.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_dcpprojectteams
-  version: "{{ version }}"
+  name: dcp_dcpprojectteams
   acl: private
   source:
     url:
       path: .output/dcp_dcpprojectteams/dcp_dcpprojectteams.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/zap-opendata/templates/dcp_projectactionbbls.yml
+++ b/products/zap-opendata/templates/dcp_projectactionbbls.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_projectactionbbls
-  version: "{{ version }}"
+  name: dcp_projectactionbbls
   acl: private
   source:
     url:
       path: .output/dcp_projectactionbbls/dcp_projectactionbbls.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/zap-opendata/templates/dcp_projectactions.yml
+++ b/products/zap-opendata/templates/dcp_projectactions.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_projectactions
-  version: "{{ version }}"
+  name: dcp_projectactions
   acl: private
   source:
     url:
       path: .output/dcp_projectactions/dcp_projectactions.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/zap-opendata/templates/dcp_projectbbls.yml
+++ b/products/zap-opendata/templates/dcp_projectbbls.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_projectbbls
-  version: "{{ version }}"
+  name: dcp_projectbbls
   acl: private
   source:
     url:
       path: .output/dcp_projectbbls/dcp_projectbbls.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/zap-opendata/templates/dcp_projectmilestones.yml
+++ b/products/zap-opendata/templates/dcp_projectmilestones.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_projectmilestones
-  version: "{{ version }}"
+  name: dcp_projectmilestones
   acl: private
   source:
     url:
       path: .output/dcp_projectmilestones/dcp_projectmilestones.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE

--- a/products/zap-opendata/templates/dcp_projects.yml
+++ b/products/zap-opendata/templates/dcp_projects.yml
@@ -1,11 +1,9 @@
 dataset:
-  name: &name dcp_projects
-  version: "{{ version }}"
+  name: dcp_projects
   acl: private
   source:
     url:
       path: .output/dcp_projects/dcp_projects.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -14,7 +12,6 @@ dataset:
       type: NONE
 
   destination:
-    name: *name
     geometry:
       SRS: null
       type: NONE


### PR DESCRIPTION
Feel like I'm rearranging deck chairs on the titanic here slightly, but wanted a bit more ability to specify in a somewhat type-safe way more information in our library yml templates

Started on commit 3 and then decided that was far too much rearranging. So reverted for now so I could come back if I want, but will probably leave that. Leaving as food for thought but will rebase before merging.

Easiest to view the 2 commits separately just because of all the file changes in commit 1. But you can see there that the main changes to the functionality are
- no duplicated "name" field (name of dataset, name of destination - before, there was validation that these were the same). For script sources, assume script has same name as dataset
- no need for `version: {{version}}`
- for script entries, make subsection freeform dictionary. Most require a path field, but not all, so this seemed simplest. That means if a template requires a script but has no args, it should be denoted as `script: {}`. 

Commit 2, we have a few things going on
- use pydantic object instead of freeform dict throughout logic in ingest, config. Clean up logic to remove redundant calls
- Abolish config.yml in export - we already have config.json, and going in line with our decision for build_metadata exported in json, seemed to make sense to just keep json if we're just keeping one