### PR TITLE
Colp packaging

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -251,14 +251,22 @@ def publish(
 
 
 def download_published_version(
-    publish_key: PublishKey, output_dir: Path | None = None
+    publish_key: PublishKey,
+    output_dir: Path | None = None,
+    *,
+    include_prefix_in_export: bool = True,
 ) -> None:
     output_dir = output_dir or Path(".")
     published_versions = get_published_versions(product=publish_key.product)
     assert (
         publish_key.version in published_versions
     ), f"{publish_key} not found in S3 bucket '{BUCKET}'. Published versions are {published_versions}"
-    s3.download_folder(BUCKET, f"{publish_key.path}/", output_dir)
+    s3.download_folder(
+        BUCKET,
+        f"{publish_key.path}/",
+        output_dir,
+        include_prefix_in_export=include_prefix_in_export,
+    )
 
 
 def file_exists(product_key: ProductKey, filepath: str) -> bool:

--- a/dcpy/metadata/validate.py
+++ b/dcpy/metadata/validate.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from pathlib import Path
+import shapely
 import yaml
 
 
@@ -100,8 +101,25 @@ def validate_csv(csv_path: Path, metadata_path: Path):
                         ]
                     )
 
-            case "geometry":
-                pass
+            case "wkb":
+
+                def is_wkb_valid(g):
+                    try:
+                        shapely.wkb.loads(g)
+                        return True
+                    except Exception:
+                        return False
+
+                invalids = csv_df[~csv_df[col_name].apply(is_wkb_valid)]
+                if not invalids.empty:
+                    sample = invalids.iloc[0][col_name]
+                    errors.append(
+                        [
+                            "INVALID_DATA",
+                            f"The {col_name} column contains {len(invalids)} invalid wkb value(s), for example: {sample}",
+                        ]
+                    )
+
             case "text":
                 pass
             case _:

--- a/dcpy/metadata/validate.py
+++ b/dcpy/metadata/validate.py
@@ -1,0 +1,140 @@
+import pandas as pd
+from pathlib import Path
+import yaml
+
+
+def validate_csv(csv_path: Path, metadata_path: Path):
+    """Validate a csv against a metadata file."""
+    csv_df = pd.read_csv(csv_path, dtype=str)
+    csv_df_non_null = csv_df.fillna("")
+
+    metadata = yaml.safe_load(open(metadata_path, "r"))
+
+    errors = []
+
+    # Find mismatched columns
+    # Assumes that if `appears_in` isn't set, every filetype will contain the column
+    metadata_column_names = {
+        x["name"]
+        for x in metadata["columns"]
+        if not x.get("appears_in") or "csv" in x.get("appears_in")
+    }
+    csv_headers = set(csv_df.columns)
+
+    extras_in_csv = csv_headers.difference(metadata_column_names)
+    if extras_in_csv:
+        errors.append(
+            [
+                "COLUMN_MISMATCH",
+                f"Invalid column(s) found in source data: {extras_in_csv}.",
+            ]
+        )
+
+    not_found_in_csv = metadata_column_names.difference(csv_headers)
+    if not_found_in_csv:
+        errors.append(
+            [
+                "COLUMN_MISMATCH",
+                f"Column(s) missing from source data: {not_found_in_csv}.",
+            ]
+        )
+
+    # Validate Data in Columns
+    for col in metadata["columns"]:
+        col_name = col["name"]
+        if col_name in not_found_in_csv:
+            continue
+
+        match col["data_type"]:
+            case "bbl":
+                with_invalid_bbl = csv_df[~csv_df["BBL"].str.match("^\d{10}$")]
+                if not with_invalid_bbl.empty:
+                    errors.append(
+                        [
+                            "INVALID_DATA",
+                            f"Column {col_name} contains {len(with_invalid_bbl)} invalid records, for example: {with_invalid_bbl.iloc[0][col_name]}",
+                        ]
+                    )
+
+            case "integer":
+
+                def is_maybe_int(s):
+                    if len(s) == 0 or not s:
+                        return True
+                    if s[0] in ("-", "+"):
+                        return s[1:].isdigit()
+                    return s.isdigit()
+
+                invalids = csv_df_non_null[
+                    ~csv_df_non_null[col_name].apply(is_maybe_int)
+                ]
+                if not invalids.empty:
+                    sample = invalids.iloc[0][col_name]
+                    errors.append(
+                        [
+                            "INVALID_DATA",
+                            f"The {col_name} column contains {len(invalids)} invalid integer types, for example: {sample}",
+                        ]
+                    )
+
+            # TODO: discuss whether it makes sense to call these doubles. It's
+            # just what they're designated as in COLP metadata.
+            case "double":
+
+                def is_maybe_float_or_double(s):
+                    try:
+                        float(s)
+                        return True
+                    except ValueError:
+                        return False
+
+                invalids = csv_df_non_null[
+                    ~csv_df_non_null[col_name].apply(is_maybe_float_or_double)
+                ]
+                if not invalids.empty:
+                    sample = invalids.iloc[0][col_name]
+                    errors.append(
+                        [
+                            "INVALID_DATA",
+                            f"The {col_name} column contains {len(invalids)} invalid double types, for example: {sample}",
+                        ]
+                    )
+
+            case "geometry":
+                pass
+            case "text":
+                pass
+            case _:
+                errors.append(
+                    [
+                        "INVALID_METADATA",
+                        f"Column {col_name} has unknown type {col['data_type']}.",
+                    ]
+                )
+
+        # Validate standardized / enum values
+        if "values" in col:
+            accepted_values = {str(x[0]) for x in col["values"]} | {
+                ""
+            }  # Adding empty str so we can do null-checking elsewhere (in just one place)
+            invalids = csv_df_non_null[~csv_df_non_null[col_name].isin(accepted_values)]
+            if not invalids.empty:
+                invalid_counts = dict(invalids.groupby(by=col_name).size())
+                errors.append(
+                    [
+                        "INVALID_DATA",
+                        f"Found counts of non-standardized values for column {col_name}: {invalid_counts}",
+                    ]
+                )
+
+        if "is_nullable" in col and not col["is_nullable"]:
+            nulls = csv_df[csv_df[col_name].isnull()]
+            if not nulls.empty:
+                errors.append(
+                    [
+                        "INVALID_DATA",
+                        f"Column {col_name} has {len(nulls)} empty values",
+                    ]
+                )
+
+    return errors

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -231,13 +231,13 @@ def download_folder(
     prefix: str,
     export_path: Path,
     *,
-    include_prefix_in_export: bool = False,
+    include_prefix_in_export: bool = True,
 ) -> None:
     """Given bucket, prefix filter, and export path, download contents of folder from s3 recursively"""
     if prefix[-1] != "/":
         raise NotADirectoryError("prefix must be a folder path, ending with '/'")
     for obj in list_objects(bucket, prefix):
-        key = obj["Key"].replace(prefix, "") if include_prefix_in_export else obj["Key"]
+        key = obj["Key"] if include_prefix_in_export else obj["Key"].replace(prefix, "")
         if key and (key != prefix) and (key[-1] != "/"):
             key_directory = Path(key).parent
             (export_path / key_directory).mkdir(parents=True, exist_ok=True)

--- a/products/colp/metadata.yml
+++ b/products/colp/metadata.yml
@@ -1,6 +1,6 @@
 columns:
-  - field_name: UID
-    longform_name: Unique ID
+  - name: uid
+    display_name: Unique ID
     data_source: Department of City Planning
     description: >-
       Unique identifier created from a hash of all fields for the record on the
@@ -9,12 +9,13 @@ columns:
     data_type: text
     example: cbe20732be28f6ab445289d7a67bb241
 
-  - field_name: BOROUGH
-    longform_name: Borough
+  - name: BOROUGH
+    display_name: Borough
     description: >-
       NYC borough – 1 (Manhattan), 2 (Bronx), 3 (Brooklyn), 4 (Queens), 5
       (Staten Island)
     data_type: text
+    is_nullable: False
     values:
       - ["1", Manhattan]
       - ["2", Bronx]
@@ -22,22 +23,22 @@ columns:
       - ["4", Queens]
       - ["5", Staten Island]
 
-  - field_name: BLOCK
-    longform_name: Tax block
+  - name: BLOCK
+    display_name: Tax block
     description: >-
       The tax block in which the tax lot is located. Each tax block is unique
       within a borough.
     data_type: integer
     example: 1637
 
-  - field_name: LOT
-    longform_name: Tax lot
+  - name: LOT
+    display_name: Tax lot
     description: The number of the tax lot. Each tax lot is unique within a tax block.
     data_type: integer
     example: 141
 
-  - field_name: BBL
-    longform_name: BBL
+  - name: BBL
+    display_name: BBL
     description: >-
       10-digit identifier for a tax lot, consisting of the borough code followed
       by the tax block followed by the tax lot. The borough code is one numeric
@@ -45,11 +46,12 @@ columns:
       zeros when the block is less than five digits. The tax lot is one to four
       digits and is preceded with leading zeros when the lot is less than four
       digits. For condominiums, this is usually the unit BBL.
-    data_type: double
+    data_type: bbl
+    data_readme_type: double
     example: 1016370141
 
-  - field_name: MAPBBL
-    longform_name: Mapped BBL
+  - name: MAPBBL
+    display_name: Mapped BBL
     data_source: Department of City Planning - Geosupport
     description: >-
       The mapped BBL is the BBL used to map the record. For condominium lots,
@@ -60,11 +62,12 @@ columns:
       Finance’s Digital Tax Map. If there is more than one donating BBL, the one
       whose lot number most closely matches that of the air rights lot is used.
       For all other lots, MAPBBL is the same as BBL.
-    data_type: double
+    data_type: bbl
+    data_readme_type: double
     example: 1016370141
 
-  - field_name: CD
-    longform_name: Community district
+  - name: CD
+    display_name: Community district
     data_source: Department of City Planning
     description: >-
       The community district or joint interest area for the tax lot. The city is
@@ -76,26 +79,26 @@ columns:
     data_type: integer
     example: 111
 
-  - field_name: HNUM
-    longform_name: House number
+  - name: HNUM
+    display_name: House number
     description: House number
     data_type: text
     example: "1955"
 
-  - field_name: SNAME
-    longform_name: Street name
+  - name: SNAME
+    display_name: Street name
     description: Name of the street
     data_type: text
     example: Third Avenue
 
-  - field_name: ADDRESS
-    longform_name: Address
+  - name: ADDRESS
+    display_name: Address
     description: House number and street name
     data_type: text
     example: 1955 Third Avenue
 
-  - field_name: PARCELNAME
-    longform_name: Parcel name
+  - name: PARCELNAME
+    display_name: Parcel name
     description: >-
       Name of the parcel or facility on the lot. DCP applies some modifications
       to parcel names to improve readability. Some abbreviations are expanded
@@ -104,60 +107,63 @@ columns:
     data_type: text
     example: AGUILAR BRANCH LIBRARY
 
-  - field_name: AGENCY
-    longform_name: Agency
+  - name: AGENCY
+    display_name: Agency
     description: >-
       Abbreviation for agency or entity using the lot. See appendix A for a list
       of abbreviations with their full name.
     data_type: text
     example: NYPL
 
-  - field_name: USECODE
-    longform_name: Use code
+  - name: USECODE
+    display_name: Use code
     description: >-
       The use code indicates how the lot is being used by the agency. See
       Appendix B for a complete list of use codes and descriptions.
     data_type: text
     example: "218"
 
-  - field_name: USETYPE
-    longform_name: Use description
+  - name: USETYPE
+    display_name: Use description
     description: >-
       Description of how the lot is being used by the agency. See Appendix B for
       a complete list of use codes and descriptions.
     data_type: text
     example: BRANCH LIBRARY
 
-  - field_name: OWNERSHIP
-    longform_name: Owner type
+  - name: OWNERSHIP
+    display_name: Owner type
     description: Type of owner
     data_type: text
+    is_nullable: False
     values:
       - [C, City owned]
       - [M, Mixed ownership]
       - [P, Private]
       - [O, Other/public authority (includes properties owned by federal and state entities)]
 
-  - field_name: CATEGORY
-    longform_name: Category
+  - name: CATEGORY
+    display_name: Category
     data_source: Department of City Planning
     description: >-
       Category classifies lots as non-residential properties with a current use,
       residential properties, or properties without a current use.
     data_type: integer
+    is_nullable: False
     values:
       - [1, Non-residential properties with a current use]
       - [2, Residential properties]
       - [3, Properties with no current use]
 
-  - field_name: EXPANDCAT
-    longform_name: Expanded category
+  - name: EXPANDCAT
+    display_name: Expanded category
     data_source: Department of City Planning
     description: >-
       This categorization classifies records into broad groups based on use.
       Valid values are 1 – 9.
     data_type: integer
-    Description of values:
+    is_nullable: False
+    values:
       - [1, Office use]
       - [2, Educational use]
       - [3, Cultural & recreational use]
@@ -168,36 +174,34 @@ columns:
       - [8, Property with no use]
       - [9, Property with a residential used]
 
-  - field_name: EXCATDESC
-    longform_name: Expanded category description
+  - name: EXCATDESC
+    display_name: Expanded category description
     data_source: Department of City Planning
     description: >-
       Descriptions for the expanded category values. See EXPANDCAT for the
       domain values.
     data_type: text
 
-  - field_name: LEASED
-    longform_name: Leased
+  - name: LEASED
+    display_name: Leased
     description: >-
       A value of “L” indicates that the agency’s use of the property is
       authorized through a lease. For questions about the lease or ownership
       status of specific lots, please contact DCAS at (212) 386-0622 or
       RESPlanning311@dcas.nyc.gov.
     data_type: text
-    is_nullable: True
     values:
       - L
 
-  - field_name: FINALCOM
-    longform_name: Final commitment
+  - name: FINALCOM
+    display_name: Final commitment
     description: A value of “D” indicates potential disposition by the City.
     data_type: text
-    is_nullable: True
     values:
       - D
 
-  - field_name: AGREEMENT
-    longform_name: Lease agreement
+  - name: AGREEMENT
+    display_name: Lease agreement
     description: >-
       For City-owned properties that are leased to another entity, this field
       indicates whether the agreement is short-term, long-term, or there are
@@ -208,8 +212,8 @@ columns:
       - [L, Long-term]
       - [M, Mixed (there are both short- and long-term agreements on the property)]
 
-  - field_name: XCOORD
-    longform_name: X coordinate
+  - name: XCOORD
+    display_name: X coordinate
     data_source: Department of City Planning
     description: >-
       X coordinate based on the Geosupport label point for the billing BBL.
@@ -218,8 +222,8 @@ columns:
     data_type: integer
     example: 999900
 
-  - field_name: YCOORD
-    longform_name: Y coordinate
+  - name: YCOORD
+    display_name: Y coordinate
     data_source: Department of City Planning
     description: >-
       Y coordinate based on the Geosupport label point for the billing BBL.
@@ -228,8 +232,8 @@ columns:
     data_type: integer
     example: 228619
 
-  - field_name: LATITUDE
-    longform_name: Latitude
+  - name: LATITUDE
+    display_name: Latitude
     data_source: Department of City Planning
     description: >-
       Latitude based on the Geosupport label point for the billing BBL.
@@ -237,8 +241,8 @@ columns:
     data_type: double
     example: 40.794169
 
-  - field_name: LONGITUDE
-    longform_name: Longitude
+  - name: LONGITUDE
+    display_name: Longitude
     data_source: Department of City Planning
     description: >-
       Longitude based on the Geosupport label point for the billing BBL.
@@ -246,8 +250,8 @@ columns:
     data_type: double
     example: -73.943479
 
-  - field_name: DCPEDITED
-    longform_name: DCP Edited
+  - name: DCPEDITED
+    display_name: DCP Edited
     data_source: Department of City Planning
     description: >-
       City Planning modifies some records to correct street names or normalize
@@ -258,7 +262,9 @@ columns:
     values:
       - [Y, Yes]
 
-  - field_name: GEOM (csv file only)
-    longform_name: Geometry
+  - name: GEOM
+    display_name: Geometry
+    appears_in:
+      - csv
     description: Point geometry type
     data_type: geometry

--- a/products/colp/metadata.yml
+++ b/products/colp/metadata.yml
@@ -1,0 +1,254 @@
+columns:
+  - field_name: UID
+    longform_name: Unique ID
+    data_source: Department of City Planning
+    description: >-
+      Unique identifier created from a hash of all fields for the record on the
+      IPIS source file. As long as no fields change on the record, this
+      identifier is static between versions of COLP.
+    data_type: text
+    example: cbe20732be28f6ab445289d7a67bb241
+
+  - field_name: BOROUGH
+    longform_name: Borough
+    description: >-
+      NYC borough – 1 (Manhattan), 2 (Bronx), 3 (Brooklyn), 4 (Queens), 5
+      (Staten Island)
+    data_type: text
+    example: 1
+
+  - field_name: BLOCK
+    longform_name: Tax block
+    description: >-
+      The tax block in which the tax lot is located. Each tax block is unique
+      within a borough.
+    data_type: integer
+    example: 1637
+
+  - field_name: LOT
+    longform_name: Tax lot
+    description: The number of the tax lot. Each tax lot is unique within a tax block.
+    data_type: integer
+    example: 141
+
+  - field_name: BBL
+    longform_name: BBL
+    description: >-
+      10-digit identifier for a tax lot, consisting of the borough code followed
+      by the tax block followed by the tax lot. The borough code is one numeric
+      digit. The tax block is one to five numeric digits, preceded with leading
+      zeros when the block is less than five digits. The tax lot is one to four
+      digits and is preceded with leading zeros when the lot is less than four
+      digits. For condominiums, this is usually the unit BBL.
+    data_type: double
+    example: 1016370141
+
+  - field_name: MAPBBL
+    longform_name: Mapped BBL
+    data_source: Department of City Planning - Geosupport
+    description: >-
+      The mapped BBL is the BBL used to map the record. For condominium lots,
+      the mapped BBL is the billing BBL, which is the 75nn-series record shown
+      on the tax map and in MapPLUTO. It is generally associated with the
+      condominium management organization. For air rights lots, the mapped BBL
+      is the donating BBL from the Air_Rights_Lot table in the Department of
+      Finance’s Digital Tax Map. If there is more than one donating BBL, the one
+      whose lot number most closely matches that of the air rights lot is used.
+      For all other lots, MAPBBL is the same as BBL.
+    data_type: double
+    example: 1016370141
+
+  - field_name: CD
+    longform_name: Community district
+    data_source: Department of City Planning
+    description: >-
+      The community district or joint interest area for the tax lot. The city is
+      divided into 59 community districts and 12 joint interest areas, which are
+      large parks or airports that are not considered part of any community
+      district. This field consists of three digits, the first of which is the
+      borough code. The second and third digits are the community district or
+      joint interest area number, whichever is applicable.
+    data_type: integer
+    example: 111
+
+  - field_name: HNUM
+    longform_name: House number
+    description: House number
+    data_type: text
+    example: 1955
+
+  - field_name: SNAME
+    longform_name: Street name
+    description: Name of the street
+    data_type: text
+    example: Third Avenue
+
+  - field_name: ADDRESS
+    longform_name: Address
+    description: House number and street name
+    data_type: text
+    example: 1955 Third Avenue
+
+  - field_name: PARCELNAME
+    longform_name: Parcel name
+    description: >-
+      Name of the parcel or facility on the lot. DCP applies some modifications
+      to parcel names to improve readability. Some abbreviations are expanded
+      programmatically. Other modifications are made after manual research. For
+      the latter, DCPEDITED = “Y”.
+    data_type: Text
+    example: AGUILAR BRANCH LIBRARY
+
+  - field_name: AGENCY
+    longform_name: Agency
+    description: >-
+      Abbreviation for agency or entity using the lot. See appendix A for a list
+      of abbreviations with their full name.
+    data_type: Text
+    example: NYPL
+
+  - field_name: USECODE
+    longform_name: Use code
+    description: >-
+      The use code indicates how the lot is being used by the agency. See
+      Appendix B for a complete list of use codes and descriptions.
+    data_type: Text
+    example: 218
+
+  - field_name: USETYPE
+    longform_name: Use description
+    description: >-
+      Description of how the lot is being used by the agency. See Appendix B for
+      a complete list of use codes and descriptions.
+    data_type: text
+    example: BRANCH LIBRARY
+
+  - field_name: OWNERSHIP
+    longform_name: Owner type
+    description: Type of owner
+    data_type: text
+    Values: |
+      C – City owned
+      M – Mixed ownership
+      P – Private
+      O – Other/public authority (includes properties owned by federal and state
+      entities)
+
+  - field_name: CATEGORY
+    longform_name: Category
+    data_source: Department of City Planning
+    description: >-
+      Category classifies lots as non-residential properties with a current use,
+      residential properties, or properties without a current use.
+    data_type: integer
+    Values: |
+      1 – Non-residential properties with a current use
+      2 – Residential properties
+      3 – Properties with no current use
+
+  - field_name: EXPANDCAT
+    longform_name: Expanded category
+    data_source: Department of City Planning
+    description: >-
+      This categorization classifies records into broad groups based on use.
+      Valid values are 1 – 9.
+    data_type: integer
+    Description of values: |
+      1 – Office use
+      2 – Educational use
+      3 – Cultural & recreational use
+      4 – Public safety & criminal justice use
+      5 – Health & social service use
+      6 – Leased out to a private tenant
+      7 – Maintenance, storage & infrastructure
+      8 – Property with no use
+      9 – Property with a residential used
+
+  - field_name: EXCATDESC
+    longform_name: Expanded category description
+    data_source: Department of City Planning
+    description: >-
+      Descriptions for the expanded category values. See EXPANDCAT for the
+      domain values.
+    data_type: text
+
+  - field_name: LEASED
+    longform_name: Leased
+    description: >-
+      A value of “L” indicates that the agency’s use of the property is
+      authorized through a lease. For questions about the lease or ownership
+      status of specific lots, please contact DCAS at (212) 386-0622 or
+      RESPlanning311@dcas.nyc.gov.
+    data_type: text
+    Values: L or blank
+
+  - field_name: FINALCOM
+    longform_name: Final commitment
+    description: A value of “D” indicates potential disposition by the City.
+    data_type: text
+    Values: D or blank
+
+  - field_name: AGREEMENT
+    longform_name: Lease agreement
+    description: >-
+      For City-owned properties that are leased to another entity, this field
+      indicates whether the agreement is short-term, long-term, or there are
+      both short- and long-term agreements present.
+    data_type: text
+    Values: >-
+      S – Short-term L – Long-term M – Mixed (there are both short- and
+      long-term agreements on the property)
+
+  - field_name: XCOORD
+    longform_name: X coordinate
+    data_source: Department of City Planning
+    description: >-
+      X coordinate based on the Geosupport label point for the billing BBL.
+      Coordinate system is NAD 1983 State Plane New York Long Island FIPS 3104
+      Feet.
+    data_type: integer
+    example: 999900
+
+  - field_name: YCOORD
+    longform_name: Y coordinate
+    data_source: Department of City Planning
+    description: >-
+      Y coordinate based on the Geosupport label point for the billing BBL.
+      Coordinate system is NAD 1983 State Plane New York Long Island FIPS 3104
+      Feet.
+    data_type: integer
+    example: 228619
+
+  - field_name: LATITUDE
+    longform_name: Latitude
+    data_source: Department of City Planning
+    description: >-
+      Latitude based on the Geosupport label point for the billing BBL.
+      Coordinate system is NAD_1983.
+    data_type: double
+    example: 40.794169
+
+  - field_name: LONGITUDE
+    longform_name: Longitude
+    data_source: Department of City Planning
+    description: >-
+      Longitude based on the Geosupport label point for the billing BBL.
+      Coordinate system is NAD_1983.
+    data_type: double
+    example: -73.943479
+
+  - field_name: DCPEDITED
+    longform_name: DCP Edited
+    data_source: Department of City Planning
+    description: >-
+      City Planning modifies some records to correct street names or normalize
+      parcel names when programmatic cleaning is insufficient. If a field has
+      been manually modified, the original value can be found on GitHub in the
+      modifications_applied.csv available in Outputs file series.
+    data_type: text
+    example: 'Y'
+
+  - field_name: GEOM (csv file only)
+    longform_name: Geometry
+    description: Point geometry type
+    data_type: geometry

--- a/products/colp/metadata.yml
+++ b/products/colp/metadata.yml
@@ -278,4 +278,5 @@ columns:
     appears_in:
       - csv
     description: Point geometry type
-    data_type: geometry
+    data_type: wkb
+    data_readme_type: geometry

--- a/products/colp/metadata.yml
+++ b/products/colp/metadata.yml
@@ -15,7 +15,12 @@ columns:
       NYC borough – 1 (Manhattan), 2 (Bronx), 3 (Brooklyn), 4 (Queens), 5
       (Staten Island)
     data_type: text
-    example: 1
+    values:
+      - ["1", Manhattan]
+      - ["2", Bronx]
+      - ["3", Brooklyn]
+      - ["4", Queens]
+      - ["5", Staten Island]
 
   - field_name: BLOCK
     longform_name: Tax block
@@ -75,7 +80,7 @@ columns:
     longform_name: House number
     description: House number
     data_type: text
-    example: 1955
+    example: "1955"
 
   - field_name: SNAME
     longform_name: Street name
@@ -96,7 +101,7 @@ columns:
       to parcel names to improve readability. Some abbreviations are expanded
       programmatically. Other modifications are made after manual research. For
       the latter, DCPEDITED = “Y”.
-    data_type: Text
+    data_type: text
     example: AGUILAR BRANCH LIBRARY
 
   - field_name: AGENCY
@@ -104,7 +109,7 @@ columns:
     description: >-
       Abbreviation for agency or entity using the lot. See appendix A for a list
       of abbreviations with their full name.
-    data_type: Text
+    data_type: text
     example: NYPL
 
   - field_name: USECODE
@@ -112,8 +117,8 @@ columns:
     description: >-
       The use code indicates how the lot is being used by the agency. See
       Appendix B for a complete list of use codes and descriptions.
-    data_type: Text
-    example: 218
+    data_type: text
+    example: "218"
 
   - field_name: USETYPE
     longform_name: Use description
@@ -127,12 +132,11 @@ columns:
     longform_name: Owner type
     description: Type of owner
     data_type: text
-    Values: |
-      C – City owned
-      M – Mixed ownership
-      P – Private
-      O – Other/public authority (includes properties owned by federal and state
-      entities)
+    values:
+      - [C, City owned]
+      - [M, Mixed ownership]
+      - [P, Private]
+      - [O, Other/public authority (includes properties owned by federal and state entities)]
 
   - field_name: CATEGORY
     longform_name: Category
@@ -141,10 +145,10 @@ columns:
       Category classifies lots as non-residential properties with a current use,
       residential properties, or properties without a current use.
     data_type: integer
-    Values: |
-      1 – Non-residential properties with a current use
-      2 – Residential properties
-      3 – Properties with no current use
+    values:
+      - [1, Non-residential properties with a current use]
+      - [2, Residential properties]
+      - [3, Properties with no current use]
 
   - field_name: EXPANDCAT
     longform_name: Expanded category
@@ -153,16 +157,16 @@ columns:
       This categorization classifies records into broad groups based on use.
       Valid values are 1 – 9.
     data_type: integer
-    Description of values: |
-      1 – Office use
-      2 – Educational use
-      3 – Cultural & recreational use
-      4 – Public safety & criminal justice use
-      5 – Health & social service use
-      6 – Leased out to a private tenant
-      7 – Maintenance, storage & infrastructure
-      8 – Property with no use
-      9 – Property with a residential used
+    Description of values:
+      - [1, Office use]
+      - [2, Educational use]
+      - [3, Cultural & recreational use]
+      - [4, Public safety & criminal justice use]
+      - [5, Health & social service use]
+      - [6, Leased out to a private tenant]
+      - [7, Maintenance, storage & infrastructure]
+      - [8, Property with no use]
+      - [9, Property with a residential used]
 
   - field_name: EXCATDESC
     longform_name: Expanded category description
@@ -180,13 +184,17 @@ columns:
       status of specific lots, please contact DCAS at (212) 386-0622 or
       RESPlanning311@dcas.nyc.gov.
     data_type: text
-    Values: L or blank
+    is_nullable: True
+    values:
+      - L
 
   - field_name: FINALCOM
     longform_name: Final commitment
     description: A value of “D” indicates potential disposition by the City.
     data_type: text
-    Values: D or blank
+    is_nullable: True
+    values:
+      - D
 
   - field_name: AGREEMENT
     longform_name: Lease agreement
@@ -195,9 +203,10 @@ columns:
       indicates whether the agreement is short-term, long-term, or there are
       both short- and long-term agreements present.
     data_type: text
-    Values: >-
-      S – Short-term L – Long-term M – Mixed (there are both short- and
-      long-term agreements on the property)
+    values:
+      - [S, Short-term]
+      - [L, Long-term]
+      - [M, Mixed (there are both short- and long-term agreements on the property)]
 
   - field_name: XCOORD
     longform_name: X coordinate
@@ -246,7 +255,8 @@ columns:
       been manually modified, the original value can be found on GitHub in the
       modifications_applied.csv available in Outputs file series.
     data_type: text
-    example: 'Y'
+    values:
+      - [Y, Yes]
 
   - field_name: GEOM (csv file only)
     longform_name: Geometry

--- a/products/colp/metadata.yml
+++ b/products/colp/metadata.yml
@@ -1,3 +1,14 @@
+name: COLP
+display_name: City Owned and Leased Property (COLP)
+summary: |
+  City Owned and Leased Properties (COLP) is published by the Department of City Planning (DCP) as required by chapter 204 of the City Charter. It includes the location and current use of all City-owned and leased properties.
+description: |
+  City Owned and Leased Properties (COLP) is published by the Department of City Planning (DCP) as required by chapter 204 of the City Charter. It includes the location and current use of all City-owned and leased properties. COLP is produced from an extract of the Integrated Property Information System (IPIS), a real estate database maintained by the Department of Citywide Administrative Services (DCAS). Except where indicated, the data provided is from IPIS.
+
+  Questions or feedback on errors within the City Owned and Leased Properties can be directed to DCAS Land Use Planning at (212) 386-0622 or RESPlanning311@dcas.nyc.gov.
+
+tags: [COLP, IPIS, city owned, leased, property, Department of Citywide Administrative Services, DCAS, Department of City Planning, DCP, New York City, NYC]
+
 columns:
   - name: uid
     display_name: Unique ID


### PR DESCRIPTION
This is just a first, very rough, step to validate csv files against our metadata. Currently validation will just return a list of exceptions, e.g. for COLP:
```
[['COLUMN_MISMATCH', "Invalid column(s) found in source data: {'bOROUGH'}."],
 ['COLUMN_MISMATCH', "Column(s) missing from source data: {'BOROUGH'}."],
 ['INVALID_DATA',
  'Column BBL contains 17428 invalid records, for example: 3035880036.00000000'],
 ['INVALID_DATA',
  'Column MAPBBL contains 17428 invalid records, for example: 3035880036.00000000'],
 ['INVALID_DATA', 'Column CATEGORY has 2 empty values'],
 ['INVALID_DATA', 'Column EXPANDCAT has 54 empty values']]
```

This could certainly benefit from unit tests, and there's some deduplication that can happen in the validation function. But this works against COLP for now, and there are higher priority tasks. 

I'd certainly appreciate feedback on the metadata format itself. Any comments about field names, formats, etc. would be great to incorporate before we add metadata for other products. Also, we'd originally put some product specific metadata in `dcpy` but I'm not convinced it should live there, so for now I just put the metadata with the COLP product itself.

The next step is to add a `distributions` key to the COLP metadata, and use that update COLP on Socrata. I'll be working on that next.

Also, you can read commit-by-commit to get a sense of exactly what I changed in the metadata when I ported it from PDF to yml. First commit is a faithful representation, then following that are my modifications.