### PR TITLE
fix QA app deploy and page for Template DB

### DIFF
--- a/.github/workflows/qa_deploy.yml
+++ b/.github/workflows/qa_deploy.yml
@@ -20,7 +20,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           DOCKER_USERNAME: "op://Data Engineering/Dockerhub/username"
           DOCKER_PASSWORD: "op://Data Engineering/Dockerhub/password"
-      - name: Build and Push
+      - name: Build and Push docker image
         run: apps/qa/bash/docker_build_and_publish.sh
 
   deploy:
@@ -35,6 +35,8 @@ jobs:
       GHP_TOKEN: ${{ secrets.GHP_TOKEN }}
       DOCKER_IMAGE_NAME: nycplanning/qa-streamlit:latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -46,32 +48,5 @@ jobs:
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
           BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
-      - name: Setup SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "$QA_DROPLET_SSH_PRIVATE_KEY" > ~/.ssh/qa.key
-          chmod 400 ~/.ssh/qa.key
-          cat >> ~/.ssh/config <<EOF
-          Host qa
-            HostName $QA_DROPLET_SSH_HOST
-            User root
-            IdentityFile ~/.ssh/qa.key
-            StrictHostKeyChecking no
-          EOF
-      - name: Deploy
-        run: |
-          ssh qa "\
-            docker pull $DOCKER_IMAGE_NAME
-            pid=\"\$(docker ps -a -q)\"
-            if [[ \$pid ]]; then
-              docker stop \"\$pid\"
-              docker rm \"\$pid\"
-            fi
-            docker run -p 8501:8501 -d --restart always\
-                -e AWS_S3_ENDPOINT=$AWS_S3_ENDPOINT\
-                -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY\
-                -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID\
-                -e BUILD_ENGINE_SERVER=$BUILD_ENGINE_SERVER\
-                -e GHP_TOKEN=$GHP_TOKEN\
-                $DOCKER_IMAGE_NAME"
-    
+      - name: Deploy docker image
+        run: apps/qa/bash/docker_deploy.sh

--- a/apps/qa/bash/docker_deploy.sh
+++ b/apps/qa/bash/docker_deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+FILE_DIR=$(dirname "$(readlink -f "$0")")
+PROJECT_DIR=$(dirname $FILE_DIR)
+ROOT_DIR=$PROJECT_DIR/../..
+
+source $ROOT_DIR/bash/utils.sh
+set_error_traps
+
+mkdir -p ~/.ssh
+echo "$QA_DROPLET_SSH_PRIVATE_KEY" > ~/.ssh/qa.key
+chmod 400 ~/.ssh/qa.key
+cat >> ~/.ssh/config <<EOF
+    Host qa
+    HostName $QA_DROPLET_SSH_HOST
+    User root
+    IdentityFile ~/.ssh/qa.key
+    StrictHostKeyChecking no
+EOF
+
+ssh qa "\
+    set -e
+    docker info
+    docker images
+    docker pull $DOCKER_IMAGE_NAME
+    pid=\"\$(docker ps -a -q)\"
+    if [[ \$pid ]]; then
+        docker stop \"\$pid\"
+        docker rm \"\$pid\"
+    fi
+    docker run -p 8501:8501 -d --restart always\
+        -e AWS_S3_ENDPOINT=$AWS_S3_ENDPOINT\
+        -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY\
+        -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID\
+        -e BUILD_ENGINE_SERVER=$BUILD_ENGINE_SERVER\
+        -e GHP_TOKEN=$GHP_TOKEN\
+        $DOCKER_IMAGE_NAME"

--- a/apps/qa/bash/docker_deploy.sh
+++ b/apps/qa/bash/docker_deploy.sh
@@ -16,18 +16,21 @@ cat >> ~/.ssh/config <<EOF
     User root
     IdentityFile ~/.ssh/qa.key
     StrictHostKeyChecking no
+    ConnectTimeout 600
 EOF
 
 ssh qa "\
     set -e
     docker info
     docker images
+    docker system prune --force
     docker pull $DOCKER_IMAGE_NAME
     pid=\"\$(docker ps -a -q)\"
     if [[ \$pid ]]; then
         docker stop \"\$pid\"
         docker rm \"\$pid\"
     fi
+    docker images
     docker run -p 8501:8501 -d --restart always\
         -e AWS_S3_ENDPOINT=$AWS_S3_ENDPOINT\
         -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY\

--- a/apps/qa/src/index.py
+++ b/apps/qa/src/index.py
@@ -17,10 +17,10 @@ def run():
     )
 
     datasets_list = list(DATASET_PAGES.keys())
-    query_params = st.experimental_get_query_params()
+    query_params = st.query_params.to_dict()
 
     if query_params:
-        name = query_params["page"][0]
+        name = query_params["page"]
     else:
         name = "Home"
 
@@ -29,7 +29,7 @@ def run():
     )
     st.sidebar.divider()
 
-    st.experimental_set_query_params(page=datasets_list[datasets_list.index(name)])
+    st.query_params["page"] = datasets_list[datasets_list.index(name)]
 
     dataset_module = importlib.import_module(
         f"pages.{DATASET_PAGES[name]}.{DATASET_PAGES[name]}"

--- a/apps/qa/src/pages/home/home.py
+++ b/apps/qa/src/pages/home/home.py
@@ -29,7 +29,6 @@ CSS = """
 
 @st.cache_data(ttl=30000)
 def retrieve_blog_posts():
-    print(requests.get(BLOG_URL, timeout=10).json())
     return requests.get(BLOG_URL, timeout=10).json()["items"]
 
 

--- a/apps/qa/src/shared/components/build_outputs.py
+++ b/apps/qa/src/shared/components/build_outputs.py
@@ -67,9 +67,14 @@ def generate_geo_data(build_outputs: list[BuildOutput]) -> list[BuildOutput]:
                     geometry_format=geometry_format,
                     crs=geospatial.GeometryCRS.wgs_84_deg,
                 )
-                build_output.geodataframe_for_display = (
-                    build_output.geodataframe.astype(str)
+
+                build_output.geodataframe_for_display = build_output.geodataframe.copy()
+                # st.dataframe fails if a column is type gpd.GeoSeries
+                astype_str = pd.Series(
+                    build_output.geodataframe_for_display["geometry_generated"],
+                    dtype="string",
                 )
+                build_output.geodataframe_for_display["geometry_generated"] = astype_str
     return build_outputs
 
 

--- a/apps/qa/src/shared/components/build_outputs.py
+++ b/apps/qa/src/shared/components/build_outputs.py
@@ -34,7 +34,7 @@ def load_build_outputs(product_key, csv_files) -> list[BuildOutput]:
     loaded_data = []
     for file_name in csv_files:
         with st.spinner(f"Loading csv file `{file_name}` to DataFrame ..."):
-            metadata = read_file_metadata(product_key, file_name)
+            metadata = read_file_metadata(product_key, file_name).model_dump()
             df = read_csv_cached(product_key, file_name)
         loaded_data.append(
             BuildOutput(

--- a/apps/qa/src/shared/utils/publishing.py
+++ b/apps/qa/src/shared/utils/publishing.py
@@ -6,15 +6,19 @@ from dcpy.utils import s3
 from dcpy.connectors.edm import publishing
 
 
-def unzip_csv(csv_filename: str, zipfile: ZipFile):
+def unzip_csv(csv_filename: str, zipfile: ZipFile) -> pd.DataFrame:
     with zipfile.open(csv_filename) as csv:
         return pd.read_csv(csv, true_values=["t"], false_values=["f"])
 
 
-def read_file_metadata(product_key: publishing.ProductKey, filepath: str):
+def read_file_metadata(
+    product_key: publishing.ProductKey, filepath: str
+) -> s3.Metadata:
     return s3.get_metadata(publishing.BUCKET, f"{product_key.path}/{filepath}")
 
 
 @st.cache_data(ttl=600)
-def read_csv_cached(product_key: publishing.ProductKey, filepath: str, **kwargs):
+def read_csv_cached(
+    product_key: publishing.ProductKey, filepath: str, **kwargs
+) -> pd.DataFrame:
     return publishing.read_csv(product_key, filepath, **kwargs)

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -16,7 +16,7 @@ from rich.progress import (
 )
 import typer
 from typing import Any, Literal, TYPE_CHECKING, cast, get_args
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 from dcpy.utils import git
 from dcpy.utils.logging import logger
@@ -38,8 +38,7 @@ ACL = Literal[
 MAX_FILE_COUNT = 50
 
 
-@dataclass
-class Metadata:
+class Metadata(BaseModel):
     last_modified: datetime
     content_length: int
     content_type: str

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -45,7 +45,7 @@ class Metadata(BaseModel):
     custom: dict[str, Any]
 
 
-def generate_metadata():
+def generate_metadata() -> dict[str, str]:
     metadata = {
         "date_created": datetime.now(pytz.timezone("America/New_York")).strftime(
             "%Y-%m-%dT%H:%M:%S%z"


### PR DESCRIPTION
## motivations

All QA pages have a warning to use `st.query_params` in place of experimental functions ([docs](https://docs.streamlit.io/library/api-reference/utilities/st.query_params)).

QA deploy action started to fail silently due to `no space left on device` when pulling the docker image ([example](https://github.com/NYCPlanning/data-engineering/actions/runs/7687967415/job/20948646427#step:4:57)). There were ~54 images in the DO droplet's storage (`docker info` [logs](https://github.com/NYCPlanning/data-engineering/actions/runs/7688144034/job/20949055232#step:4:33) and `docker images` [logs](https://github.com/NYCPlanning/data-engineering/actions/runs/7688275454/job/20949323912#step:4:76))

Template DB QA page fails to show show S3 file metadata and fails to show GeoDataFrames due to a MemoryError when converting the geometry column to a string. That conversion is needed to display the values using `st.dataframe`.

## actions runs

- Template DB QA page [here](https://de-qaqc.nycplanningdigital.com/?page=Template+DB)
- all runs of the QA App deploy action [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/qa_deploy.yml?query=branch%3Adm-qa-page-template-db)
- successful fail on error [example](https://github.com/NYCPlanning/data-engineering/actions/runs/7688221358/job/20949216878#step:4:105)
- successful deploy [example](https://github.com/NYCPlanning/data-engineering/actions/runs/7688447071/job/20949708589)
## screenshots

### old deprecation warning

<img width="520" alt="Screenshot 2024-01-28 at 11 16 18 AM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/398472b6-9a7f-4631-b36c-71202634a12d">

## now showing GeoDataFrame properly

<img width="980" alt="Screenshot 2024-01-28 at 11 19 53 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/f1a7985d-8da2-4c90-bf13-1edf6ca33311">
