### PR TITLE
fix failing Nightly QA tests and builds

### DIFF
--- a/dcpy/builds/plan.py
+++ b/dcpy/builds/plan.py
@@ -15,8 +15,8 @@ from dcpy.connectors.edm import recipes, publishing
 DEFAULT_RECIPE = "recipe.yml"
 LIBRARY_DEFAULT_PATH = recipes.LIBRARY_DEFAULT_PATH
 RECIPE_FILE_TYPE_PREFERENCE = [
-    recipes.DatasetType.parquet,
     recipes.DatasetType.pg_dump,
+    recipes.DatasetType.parquet,
     recipes.DatasetType.csv,
 ]
 

--- a/products/template/sql/_sources.yml
+++ b/products/template/sql/_sources.yml
@@ -4,6 +4,45 @@ sources:
   - name: tdb_sources
     schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
     tables:
+      - name: nypl_libraries
+        columns:
+          - name: name
+            tests:
+              - unique
+              - not_null
+          - name: wkb_geometry
+            tests:
+              - not_null
+
+      - name: bpl_libraries
+        columns:
+          - name: title
+            tests:
+              - unique
+              - not_null
+          - name: wkb_geometry
+            tests:
+              - not_null
+
+      - name: qpl_libraries
+        columns:
+          - name: name
+            tests:
+              - unique
+              - not_null
+          - name: wkb_geometry
+            tests:
+              - dbt_utils.at_least_one
+
+      - name: dpr_parksproperties
+        columns:
+          - name: signname
+            tests:
+              - not_null
+          - name: wkb_geometry
+            tests:
+              - not_null
+
       - name: dpr_greenthumb
         description: >
           NYC DPR Greenthumb locations
@@ -12,4 +51,16 @@ sources:
             description: Primary key of the dpr_greenthumb table
             tests:
               - unique
+              - not_null
+          - name: wkb_geometry
+            tests:
+              - not_null
+
+      - name: lpc_landmarks
+        columns:
+          - name: lm_name
+            tests:
+              - not_null
+          - name: wkb_geometry
+            tests:
               - not_null


### PR DESCRIPTION
resolves #554

## changes
- for all Template DB source tables, test their key and geometry columns
  - These tests error [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7700891161/job/20985754617#step:10:109) (rather than pass or fail) because expected column names can't be found. This happens before any product sql queries are run (e.g. staging.sql) and seems like a preferable way for a build to react to the problem.
- return pgdump to its former glory as the preferred source data file format

## relevant builds on this branch
- all products [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7701094151)
- Template DB in tests [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7701912670/job/20989058328?pr=557)

## screenshots
### TDB source versions before changes
<img width="362" alt="Screenshot 2024-01-29 at 1 50 43 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/2efa2684-c56c-44cc-9a94-833888880a33">

### TDB source versions after changes
<img width="358" alt="Screenshot 2024-01-29 at 1 58 03 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/15d3348d-9b3f-4ddd-8979-199cac88a9a6">
