### PR TITLE
Clean whitespace and spaces when importing df to postgres

### DIFF
--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -157,7 +157,8 @@ def import_dataset(
 
         # make column names more sql-friendly
         columns = {
-            column: column.replace("-", "_").replace("'", "_") for column in df.columns
+            column: column.strip().replace("-", "_").replace("'", "_").replace(" ", "_")
+            for column in df.columns
         }
         df.rename(columns=columns, inplace=True)
         pg_client.insert_dataframe(df, ds_table_name)

--- a/dcpy/library/sources.py
+++ b/dcpy/library/sources.py
@@ -5,7 +5,7 @@ from osgeo import gdal
 from .utils import parse_engine
 
 
-def format_field_names(dataset: gdal.Dataset, fields: list):
+def format_field_names(dataset: gdal.Dataset, fields: list[str] | None = None):
     """
     dataset: Given source data source, usually a local file / s3 url
     fields: a list of predefined field names
@@ -14,6 +14,7 @@ def format_field_names(dataset: gdal.Dataset, fields: list):
     otherwise, change all field names to lower case connected by underscore
     """
     assert dataset, "dataset: gdal.Dataset shouldn't be None"
+    fields = fields or []
     layer = dataset.GetLayer(0)
     layerDefn = layer.GetLayerDefn()
 
@@ -70,6 +71,5 @@ def generic_source(
         path, gdal.OF_VECTOR, open_options=options, allowed_drivers=allowed_drivers
     )
     assert dataset, f"{path} is invalid"
-    if fields:
-        dataset = format_field_names(dataset, fields)
+    dataset = format_field_names(dataset, fields)
     return dataset


### PR DESCRIPTION
Resolves #556 

Run after fix - https://github.com/NYCPlanning/data-engineering/actions/runs/7700283326

Stupider bug than I thought it was - was affecting pg_dumps to. I simply got rid of the call that fixes field names by accident