### PR TITLE
include source data file type in build metadata

### DIFF
--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -26,6 +26,8 @@ def import_dataset(
 
     if ds.version == "latest" or ds.version is None:
         raise Exception(f"Cannot import a dataset without a resolved version: {ds}")
+    if ds.file_type is None:
+        raise Exception(f"Cannot import a dataset without a resolved file type: {ds}")
     if ds.preprocessor is not None:
         preproc_mod = importlib.import_module(ds.preprocessor.module)
         preproc_func = getattr(preproc_mod, ds.preprocessor.function)

--- a/dcpy/builds/load.py
+++ b/dcpy/builds/load.py
@@ -48,7 +48,6 @@ def load_source_data(
     recipe_path: Path, version: str | None = None, repeat: bool = False
 ):
     recipe_lock_path = plan.plan(recipe_path, version, repeat)
-    plan.write_source_data_versions(recipe_file=Path(recipe_lock_path))
     recipe = plan.recipe_from_yaml(Path(recipe_lock_path))
 
     plan.write_source_data_versions(recipe_file=Path(recipe_lock_path))

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -130,12 +130,9 @@ def import_dataset(
     preprocessor: Callable[[str, pd.DataFrame], pd.DataFrame] | None = None,
 ):
     """Import a recipe to local data library folder and build engine."""
-    if ds.file_type is None:
-        ds.assign_file_type([DatasetType.parquet, DatasetType.pg_dump, DatasetType.csv])
-
     ds_table_name = import_as or ds.name
     logger.info(
-        f"Importing {ds.name} into {pg_client.database}.{pg_client.schema}.{ds_table_name}"
+        f"Importing {ds.name} {ds.file_type} into {pg_client.database}.{pg_client.schema}.{ds_table_name}"
     )
 
     local_dataset_path = fetch_dataset(ds, local_library_dir)


### PR DESCRIPTION
related to #544 

When we plan a recipe, we resolve the versions and file types of source data. While investigating source data changes, it's helpful to know what file type was used for each.

The failing test is not due to these changes and was the motivation for them.

## screenshots
<img width="919" alt="Screenshot 2024-01-29 at 12 49 29 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/4a2485ca-6f4a-467c-b3ed-c4221c371cf0">
