### PR TITLE
Use socrata api for dot_pedplazas template

### DIFF
--- a/dcpy/library/templates/dot_pedplazas.yml
+++ b/dcpy/library/templates/dot_pedplazas.yml
@@ -2,9 +2,9 @@ dataset:
   name: dot_pedplazas
   acl: public-read
   source:
-    url:
-      path: .library/upload/Plazas.zip
-      subpath: Plazas/Plazas.shp
+    socrata:
+      uid: k5k6-6jex
+      format: geojson
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -26,17 +26,6 @@ dataset:
   info:
     description: |
       ###  DOT Pedestrial Plazas
-      Recieved from DOT via email update
-            Source data has been sent in two ways:
-      * Individual zipped shapefile
-      * Part of geodatabase
-      If the data is sent via a geodatabse, there are some additional steps 
-      to load the data into data-library: 
-      1. Open the geodatabase in a GIS program (QGIS or ArcGIS)
-      2. Export individual shapefile following naming convention established in template.yml
-       * Make sure to save the file in the proper epsg (2263) which data-library converts to 4326
-      3. If not already compressed, compress shapefile, rename following naming convetnions in template 
-      and move into library/tmp/dot_xxxx.zip
-      4. Follow steps to update latest data in data-library
-    url:
+      A file with all DOT pedestrian plaza locations across New York City.
+    url: "https://data.cityofnewyork.us/Transportation/NYC-DOT-Pedestrian-Plazas/k5k6-6jex/about_data"
     dependents: []

--- a/products/facilities/README.md
+++ b/products/facilities/README.md
@@ -124,6 +124,9 @@ To see if a dataset needs to be uploaded, check date last updated in open data/b
 - [ ] dfta_contracts https://data.cityofnewyork.us/Social-Services/Department-for-the-Aging-NYC-Aging-All-Contracted-/cqc8-am9x
   NOTE: `providertype` column has two types of meal categories. One of them, **CITY MEALS ADMINISTRATIVE SERVICES CONTRACTS**, should only have one record (city meals). If there are more records in this category, need to revise code in `dfta_contracts.sql`.
 - [ ] doe_busroutesgarages https://data.cityofnewyork.us/Transportation/Routes/8yac-vygm
+
+- [ ] dot_pedplazas https://data.cityofnewyork.us/Transportation/Routes/k5k6-6jex
+
 - [ ] sca_enrollment_capacity https://data.cityofnewyork.us/Education/Enrollment-Capacity-And-Utilization-Reports-Target/8b9a-pywy
 - [ ] dohmh_daycare https://data.cityofnewyork.us/Health/DOHMH-Childcare-Center-Inspections/dsg6-ifza
 - [ ] dpr_parksproperties https://nycopendata.socrata.com/Recreation/Parks-Properties/enfh-gkve
@@ -209,15 +212,10 @@ library archive --s3 --name foodbankny_foodbanks --latest --version 20240108 --o
 - [ ] dot_ferryterminals
 - [ ] dot_mannedfacilities
 - [ ] dot_publicparking
-- [ ] dot_pedplazas
 - [ ] doe_universalprek (https://maps.nyc.gov/prek/data/pka/pka.csv)
 
 ## Last step
 
 - [ ] dcp_pops
-  Source: Download from POPs app, available on DCP Commons. Be sure to only take the public version.
-  *Be sure to do this source last, as the OpenData release of POPs needs to be in sync*
-
-## TODO
-
-- Ped Plazas can now be pulled from open data via data-library (https://data.cityofnewyork.us/Transportation/NYC-DOT-Pedestrian-Plazas/k5k6-6jex)
+Source: Download from POPs app, available on DCP Commons. Be sure to only take the public version.
+*Be sure to do this source last, as the OpenData release of POPs needs to be in sync*


### PR DESCRIPTION
Resolves #570. 

Currently `dot_pedplazas` recipe is only used in FacDB builds. 

### Notes: 
* Comparing the two `20231212` versions received via email and from OpenData, both tables are the same (column names, column values, record count) except that the OpenData version is missing `ntaname` column. There is no impact on FacDB build as the `ntaname` column is not used. 
* In the data-library template, I chose geojson instead of csv format because the csv format version seemed to be corrupted: 

<img width="1336" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/8fda062a-d671-4b36-8af2-e08c6d9f9210">

* Successful data-library run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7761963566). Note, the output from this run is `20231212` version in DO. The `latest` directory contains the same version outputs but the one received from DOT. I didn't overwrite the files in `latest` as we are in the process of FacDB 24v1 release which uses latest version.

* Successful FacDB build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7762006968). 

*NOTE TO MYSELF*: need to unpin version for `dot_pedplazas` in FacDB recipe.