### PR TITLE
CEQR: Add air quality-related recipes 

### DIFF
--- a/dcpy/library/templates/dep_cats_permits.yml
+++ b/dcpy/library/templates/dep_cats_permits.yml
@@ -1,0 +1,30 @@
+dataset:
+  name: dep_cats_permits
+  acl: public-read
+  source:
+    socrata:
+      uid: f4rp-2kvy
+      format: csv
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    geometry:
+      SRS: null
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ### Department of Environmental Protection (DEP)
+      Clean Air Tracking System (CATS) is online application with end-to-end process where NYC Residents can submit for New Boiler Registration, Boiler Registration Renewal, Affidavit, Amendment, Boiler Work Permits, Inspection requests, Emergency Engine, Generator Registration, Gas Stations, Industrial Work Permits. For additional context, please go to this link: https://a826-web01.nyc.gov/DEP.BoilerInformationExt/ as the external source to this dataset.
+    url: "https://data.cityofnewyork.us/Environment/Clean-Air-Tracking-System-CATS-Permits/f4rp-2kvy/"
+    dependents: []

--- a/dcpy/library/templates/dep_cats_permits.yml
+++ b/dcpy/library/templates/dep_cats_permits.yml
@@ -2,9 +2,12 @@ dataset:
   name: dep_cats_permits
   acl: public-read
   source:
-    socrata:
-      uid: f4rp-2kvy
-      format: csv
+    # TODO: implement Socrata API
+    # socrata:
+    #   uid: f4rp-2kvy
+    #   format: csv
+    url:
+      path: https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data/dep_cats_permits/{{ version }}/dep_cats_permits.csv
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -25,6 +28,11 @@ dataset:
   info:
     description: |
       ### Department of Environmental Protection (DEP)
-      Clean Air Tracking System (CATS) is online application with end-to-end process where NYC Residents can submit for New Boiler Registration, Boiler Registration Renewal, Affidavit, Amendment, Boiler Work Permits, Inspection requests, Emergency Engine, Generator Registration, Gas Stations, Industrial Work Permits. For additional context, please go to this link: https://a826-web01.nyc.gov/DEP.BoilerInformationExt/ as the external source to this dataset.
+      Clean Air Tracking System (CATS) is online application with end-to-end process where NYC Residents can submit for New Boiler Registration, 
+      Boiler Registration Renewal, Affidavit, Amendment, Boiler Work Permits, Inspection requests, Emergency Engine, Generator Registration, 
+      Gas Stations, Industrial Work Permits. 
+      For additional context, please go to this link: https://a826-web01.nyc.gov/DEP.BoilerInformationExt/ as the external source to this dataset.
+
+      # TODO: Implement ingestion via Socrata API and cleaning through data-library. In the meantime, we are ingesting clean data from edm-publishing bucket created during CEQR product build.
     url: "https://data.cityofnewyork.us/Environment/Clean-Air-Tracking-System-CATS-Permits/f4rp-2kvy/"
     dependents: []

--- a/dcpy/library/templates/nysdec_state_facility_permits.yml
+++ b/dcpy/library/templates/nysdec_state_facility_permits.yml
@@ -1,0 +1,33 @@
+dataset:
+  name: nysdec_state_facility_permits
+  acl: public-read
+  source:
+    url:
+      path: https://data.ny.gov/resource/2wgt-bc53.csv
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+      - "GEOM_POSSIBLE_NAMES=georeference"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## New York State Department of Environmental Conservation
+      Owners or operators of emission sources that are subject to 6 NYCRR Subpart 201-5 must obtain a State facility permit. 
+      Draft permits are official versions of permits whose initial development is complete, public notice given, and made available for public review and comment.
+      These permits are prepared by the Division of Air Resources regional staff.
+    url: "https://data.ny.gov/Energy-Environment/Issued-State-Facility-Air-Permits/2wgt-bc53/"
+    dependents: []

--- a/dcpy/library/templates/nysdec_state_facility_permits.yml
+++ b/dcpy/library/templates/nysdec_state_facility_permits.yml
@@ -3,19 +3,25 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://data.ny.gov/resource/2wgt-bc53.csv
+      # TODO: implement data ingestion directly from API
+      # path: https://data.ny.gov/resource/2wgt-bc53.csv
+      path: https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data/nysdec_state_facility_permits/{{ version }}/nysdec_state_facility_permits.csv
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
-      - "GEOM_POSSIBLE_NAMES=georeference"
+      # - "GEOM_POSSIBLE_NAMES=georeference"
     geometry:
-      SRS: EPSG:4326
-      type: POINT
+      SRS: null
+      type: NONE
+      # SRS: EPSG:4326
+      # type: POINT
 
   destination:
     geometry:
-      SRS: EPSG:4326
-      type: POINT
+      SRS: null
+      type: NONE
+      # SRS: EPSG:2263
+      # type: POINT
     options:
       - "OVERWRITE=YES"
       - "PRECISION=NO"
@@ -29,5 +35,7 @@ dataset:
       Owners or operators of emission sources that are subject to 6 NYCRR Subpart 201-5 must obtain a State facility permit. 
       Draft permits are official versions of permits whose initial development is complete, public notice given, and made available for public review and comment.
       These permits are prepared by the Division of Air Resources regional staff.
+
+      # TODO: Implement ingestion via API and cleaning through data-library. In the meantime, we are ingesting clean data from edm-publishing bucket created during CEQR product build.
     url: "https://data.ny.gov/Energy-Environment/Issued-State-Facility-Air-Permits/2wgt-bc53/"
     dependents: []

--- a/dcpy/library/templates/nysdec_title_v_facility_permits.yml
+++ b/dcpy/library/templates/nysdec_title_v_facility_permits.yml
@@ -1,0 +1,33 @@
+dataset:
+  name: nysdec_title_v_facility_permits
+  acl: public-read
+  source:
+    url:
+      path: https://data.ny.gov/resource/4n3a-en4b.csv
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+      - "GEOM_POSSIBLE_NAMES=georeference"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## New York State Department of Environmental Conservation
+      Owners or operators of emission sources that are subject to 6 NYCRR Subpart 201-6 must obtain a Title V facility permit. 
+      Draft permits are official versions of permits whose initial development is complete, and that are being noticed and made available for public review and comment. 
+      These permits are prepared by the Division of Air Resources regional staff.
+    url: "https://data.ny.gov/Energy-Environment/Issued-Title-V-Facility-Permits/4n3a-en4b/"
+    dependents: []

--- a/dcpy/library/templates/nysdec_title_v_facility_permits.yml
+++ b/dcpy/library/templates/nysdec_title_v_facility_permits.yml
@@ -3,19 +3,25 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://data.ny.gov/resource/4n3a-en4b.csv
+      # TODO: implement data ingestion directly from API
+      # path: https://data.ny.gov/resource/4n3a-en4b.csv
+      path: https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data/nysdec_title_v_facility_permits/{{ version }}/nysdec_title_v_facility_permits.csv
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
-      - "GEOM_POSSIBLE_NAMES=georeference"
+      # - "GEOM_POSSIBLE_NAMES=georeference"
     geometry:
-      SRS: EPSG:4326
-      type: POINT
+      SRS: null
+      type: NONE
+      # SRS: EPSG:4326
+      # type: POINT
 
   destination:
     geometry:
-      SRS: EPSG:4326
-      type: POINT
+      SRS: null
+      type: NONE
+      # SRS: EPSG:2263
+      # type: POINT
     options:
       - "OVERWRITE=YES"
       - "PRECISION=NO"
@@ -29,5 +35,7 @@ dataset:
       Owners or operators of emission sources that are subject to 6 NYCRR Subpart 201-6 must obtain a Title V facility permit. 
       Draft permits are official versions of permits whose initial development is complete, and that are being noticed and made available for public review and comment. 
       These permits are prepared by the Division of Air Resources regional staff.
+
+      # TODO: Implement ingestion via API and cleaning through data-library. In the meantime, we are ingesting clean data from edm-publishing bucket created during CEQR product build.
     url: "https://data.ny.gov/Energy-Environment/Issued-Title-V-Facility-Permits/4n3a-en4b/"
     dependents: []


### PR DESCRIPTION
Related to #575. 

## Air quality recipes to be added: 
* [x] `dep_cats_permits` (CATS permit variable) 
* [x] `nysdec_state_facility_permits` (State Facility Permit Source variable)
* [x] `nysdec_title_v_facility_permits` (Clean Air Act Title V Permit Source variable)
* [x] `tbd` (Vent tower data variable, would come from GIS) <-- Alex addressed in #589 

## Note
According to the [spreadsheet](https://nyco365.sharepoint.com/:x:/r/sites/NYCPLANNING/itd/edm/_layouts/15/Doc.aspx?sourcedoc=%7BBAE15377-87A6-4188-9637-36A89AC1DF98%7D&file=CEQR_Type_II_Data_Source_Review.xlsx&action=default&mobileredirect=true), the source for the first 3 datasets is https://www.ceqr.app/data/air-quality that are actually pulled from our `publishing` bucket. This recipe implementation uses `publishing` bucket as the the source. 

## Successful data-library runs:
* [`dep_cats_permits`](https://github.com/NYCPlanning/data-engineering/actions/runs/7937488232)
* [`nysdec_state_facility_permits`](https://github.com/NYCPlanning/data-engineering/actions/runs/7937500764)
* [`nysdec_title_v_facility_permits`](https://github.com/NYCPlanning/data-engineering/actions/runs/7937508492)
