### PR TITLE
add new CEQR Survey product

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
         options:
           - template
           - cbbr
+          - ceqr_survey
           - checkbook
           - colp
           - cpdb
@@ -115,6 +116,17 @@ jobs:
       build_note: ${{ inputs.build_note }}
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
+  ceqr_survey:
+    needs: health_check
+    if: inputs.dataset_name == 'ceqr_survey' || inputs.dataset_name  == 'all'
+    uses: ./.github/workflows/ceqr_survey_build.yml
+    secrets: inherit
+    with:
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      recipe_file: ${{ inputs.recipe_file }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+      version: ${{ inputs.version }}
+      repeat: ${{ inputs.repeat }}
   checkbook:
     needs: health_check
     if: inputs.dataset_name == 'checkbook' || inputs.dataset_name  == 'all'

--- a/.github/workflows/ceqr_survey_build.yml
+++ b/.github/workflows/ceqr_survey_build.yml
@@ -44,6 +44,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
           BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+          BUILD_ENGINE_HOST: "op://Data Engineering/EDM_DATA/server"
+          BUILD_ENGINE_USER: "op://Data Engineering/EDM_DATA/username"
+          BUILD_ENGINE_PASSWORD: "op://Data Engineering/EDM_DATA/password"
+          BUILD_ENGINE_PORT: "op://Data Engineering/EDM_DATA/port"
 
       - name: Setup build environment
         working-directory: ./

--- a/.github/workflows/ceqr_survey_build.yml
+++ b/.github/workflows/ceqr_survey_build.yml
@@ -1,0 +1,67 @@
+name: CEQR Survey - 🏗️ Build
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        type: string
+        required: false
+      build_name:
+        type: string
+        required: true
+      recipe_file:
+        type: string
+        required: true
+      version:
+        type: string
+        required: false
+      repeat:
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: Build CEQR Survery
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: products/ceqr_survey
+    container:
+      image: nycplanning/build-base:${{ inputs.image_tag || 'latest' }}
+    env:
+      BUILD_ENGINE_DB: db-ceqr-survey
+      BUILD_NAME: ${{ inputs.build_name }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+          AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+
+      - name: Setup build environment
+        working-directory: ./
+        run: |
+          ./bash/docker_container_setup.sh
+          ./bash/build_env_setup.sh
+
+      - name: Load
+        env:
+          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
+          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
+        run: python3 -m dcpy.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+
+      - name: Build
+        run: echo "Build HERE"
+
+      - name: Package
+        run: echo "Package HERE"
+
+      - name: Distribute
+        run: echo "Package HERE"

--- a/.github/workflows/ceqr_survey_build.yml
+++ b/.github/workflows/ceqr_survey_build.yml
@@ -66,13 +66,9 @@ jobs:
           echo "Setup dbt"
           dbt deps
           dbt debug
+
           echo "Test source data"
           dbt test --select "source:*"
+
           echo "Build all tables"
           dbt build --full-refresh
-
-      - name: Package
-        run: echo "Package HERE"
-
-      - name: Distribute
-        run: echo "Package HERE"

--- a/.github/workflows/ceqr_survey_build.yml
+++ b/.github/workflows/ceqr_survey_build.yml
@@ -62,7 +62,14 @@ jobs:
         run: python3 -m dcpy.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
 
       - name: Build
-        run: echo "Build HERE"
+        run: |
+          echo "Setup dbt"
+          dbt deps
+          dbt debug
+          echo "Test source data"
+          dbt test --select "source:*"
+          echo "Build all tables"
+          dbt build --full-refresh
 
       - name: Package
         run: echo "Package HERE"

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -31,6 +31,7 @@ jobs:
           sqlfluff lint products/knownprojects/
           sqlfluff lint products/pluto/pluto_build/sql/
           sqlfluff lint products/zoningtaxlots/sql/
+          sqlfluff lint products/ceqr_survey/models --templater=jinja
 
   mypy:
     runs-on: ubuntu-22.04

--- a/products/ceqr_survey/dbt_project.yml
+++ b/products/ceqr_survey/dbt_project.yml
@@ -1,0 +1,16 @@
+name: "dbt_ceqr_survey"
+
+profile: "dcp-de-postgres"
+
+model-paths: ["models"]
+
+tests:
+  +store_failures: true
+  schema: "_tests"
+
+models:
+  dbt_ceqr_survey:
+    staging:
+      +materialized: view
+    product:
+      +materialized: table

--- a/products/ceqr_survey/dbt_project.yml
+++ b/products/ceqr_survey/dbt_project.yml
@@ -12,5 +12,7 @@ models:
   dbt_ceqr_survey:
     staging:
       +materialized: view
+    intermediate:
+      +materialized: view
     product:
       +materialized: table

--- a/products/ceqr_survey/models/_product_models.yml
+++ b/products/ceqr_survey/models/_product_models.yml
@@ -1,0 +1,20 @@
+version: 2
+
+models:
+  - name: ceqr_survey_bbls
+    description: "BBLs and their CEQR Type II variable checks"
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: bbl
+        data_type: string
+        tests:
+          - not_null
+          - unique
+      - name: variable_name
+        data_type: string
+      - name: variable_value
+        data_type: string
+      - name: variable_outcome
+        data_type: boolean

--- a/products/ceqr_survey/models/_sources.yml
+++ b/products/ceqr_survey/models/_sources.yml
@@ -7,6 +7,7 @@ sources:
       - name: dcp_mappluto_wi
         columns:
           - name: bbl
+            tests:
               - unique
               - not_null
           - name: zonedist1

--- a/products/ceqr_survey/models/_sources.yml
+++ b/products/ceqr_survey/models/_sources.yml
@@ -1,0 +1,34 @@
+version: 2
+
+sources:
+  - name: ceqr_survey_sources
+    schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
+    tables:
+      - name: dcp_mappluto_wi
+        columns:
+          - name: bbl
+              - unique
+              - not_null
+          - name: zonedist1
+          - name: zonedist2
+          - name: zonedist3
+          - name: zonedist4
+          - name: spdist1
+          - name: spdist2
+          - name: spdist3
+          - name: wkb_geometry
+            tests:
+              - not_null
+
+      - name: nysdec_title_v_facility_permits
+        columns:
+          - name: permit_id
+            tests:
+              - unique
+              - not_null
+          - name: facility_name
+            tests:
+              - dbt_utils.at_least_one
+          - name: wkb_geometry
+            tests:
+              - dbt_utils.at_least_one

--- a/products/ceqr_survey/models/intermediate/_intermediate_models.yml
+++ b/products/ceqr_survey/models/intermediate/_intermediate_models.yml
@@ -1,0 +1,4 @@
+version: 2
+
+models:
+  - name: stg__all_buffers

--- a/products/ceqr_survey/models/product/ceqr_survey_bbls.sql
+++ b/products/ceqr_survey/models/product/ceqr_survey_bbls.sql
@@ -1,0 +1,15 @@
+WITH bbls AS (
+    SELECT * FROM
+        {{ ref('stg__pluto') }}
+),
+
+ceqr_survery_bbls AS (
+    SELECT
+        bbl,
+        null AS variable_name,
+        true AS variable_outcome,
+        null AS variable_value
+    FROM bbls
+)
+
+SELECT * FROM ceqr_survery_bbls

--- a/products/ceqr_survey/models/staging/stg__pluto.sql
+++ b/products/ceqr_survey/models/staging/stg__pluto.sql
@@ -1,0 +1,18 @@
+WITH mappluto_wi AS (
+
+    SELECT * FROM {{ source('ceqr_survey_sources', 'dcp_mappluto_wi') }}
+
+),
+
+final AS (
+    SELECT
+        cast(bbl AS text) AS bbl,
+        zonedist1,
+        zonedist2,
+        zonedist3,
+        zonedist4,
+        wkb_geometry
+    FROM mappluto_wi
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/packages.yml
+++ b/products/ceqr_survey/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1

--- a/products/ceqr_survey/profiles.yml
+++ b/products/ceqr_survey/profiles.yml
@@ -1,0 +1,14 @@
+config:
+  fail-fast: true
+
+dcp-de-postgres:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('BUILD_ENGINE_HOST') }}"
+      user: "{{ env_var('BUILD_ENGINE_USER') }}"
+      password: "{{ env_var('BUILD_ENGINE_PASSWORD') }}"
+      port: "{{ env_var('BUILD_ENGINE_PORT') | as_number }}"
+      dbname: "{{ env_var('BUILD_ENGINE_DB') }}"
+      schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"

--- a/products/ceqr_survey/recipe.yml
+++ b/products/ceqr_survey/recipe.yml
@@ -1,0 +1,16 @@
+name: CEQR Survey DB
+product: ceqr_survey
+version: 0.0.1
+inputs:
+  datasets:
+    # Zoning
+    - name: dcp_mappluto_wi
+    # Air
+    - name: dep_cats_permits
+    - name: nysdec_state_facility_permits
+    - name: nysdec_title_v_facility_permits
+    # - name: dcp_vent_towers Doesn't exist yet
+    # Noise
+    # - name: dcp_digital_city_map Doesn't exist yet
+    # - name: dcp_lion Doesn't exist yet
+  missing_versions_strategy: find_latest

--- a/products/ceqr_survey/seeds/_seeds.yml
+++ b/products/ceqr_survey/seeds/_seeds.yml
@@ -1,0 +1,19 @@
+version: 2
+
+seeds:
+  - name: ceqr_variables
+    columns:
+      - name: variable_name
+        tests:
+          - not_null
+          - unique
+      - name: variable_label
+        tests:
+          - not_null
+          - unique
+      - name: ceqr_category
+        tests:
+          - not_null
+      - name: type_ii_criteria
+        tests:
+          - not_null

--- a/products/ceqr_survey/seeds/ceqr_variables.csv
+++ b/products/ceqr_survey/seeds/ceqr_variables.csv
@@ -1,0 +1,2 @@
+variable_name,variable_label,ceqr_category,type_ii_criteria
+zoning_districts,Zoning districts,Zoning,"R5-R10, R1-R4, or (C or M)"


### PR DESCRIPTION
resolves #576 

> [!NOTE]
> This is to kickoff the POC of a new data product. We don't know yet what the final table(s) should be. This does not use all source data.

CEQR Survey builds using this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-add-ceqr-survery)

This new product uses `dbt` to build and test data ([docs](https://docs.getdbt.com/reference/references-overview)). Although all build steps are invoked in the new github action, we can easily move it to a python script and/or python utils (see Template DB example [here](https://github.com/NYCPlanning/data-engineering/blob/main/products/template/build_scripts/transform.py).

### screenshot of tables in our DB
<img src="https://github.com/NYCPlanning/data-engineering/assets/7444289/ecc68388-c91c-4713-99a6-f9eeee33a254" width="300">
