### PR TITLE
add cpdb_dcpattributes exports back in

### DIFF
--- a/products/cpdb/bash/05_export.sh
+++ b/products/cpdb/bash/05_export.sh
@@ -3,7 +3,7 @@ source bash/config.sh
 
 set_error_traps
 
-run_sql_file sql/_create_export.sql -v ccp_v=$ccp_v
+run_sql_file sql/_create_export.sql
 python3 python/checkbook_spending_by_year.py
 
 mkdir -p output && (
@@ -20,6 +20,8 @@ mkdir -p output && (
     cp ../source_data_versions.csv ./
     cp ../build_metadata.json ./
 
+    shp_export cpdb_dcpattributes_pts MULTIPOINT &
+    shp_export cpdb_dcpattributes_poly MULTIPOLYGON &
     shp_export cpdb_projects_pts MULTIPOINT &
     shp_export cpdb_projects_poly MULTIPOLYGON &
 

--- a/products/cpdb/sql/_create_export.sql
+++ b/products/cpdb/sql/_create_export.sql
@@ -1,13 +1,19 @@
+DROP TABLE IF EXISTS cpdb_dcpattributes_pts;
+SELECT * INTO cpdb_dcpattributes_pts
+FROM cpdb_dcpattributes
+WHERE ST_GEOMETRYTYPE(geom) = 'ST_MultiPoint';
+
+DROP TABLE IF EXISTS cpdb_dcpattributes_poly;
+SELECT * INTO cpdb_dcpattributes_poly
+FROM cpdb_dcpattributes
+WHERE ST_GEOMETRYTYPE(geom) = 'ST_MultiPolygon';
+
 DROP TABLE IF EXISTS cpdb_projects_pts;
 SELECT * INTO cpdb_projects_pts
 FROM cpdb_projects_shp
-WHERE
-    ccpversion = :'ccp_v'
-    AND ST_GEOMETRYTYPE(geom) = 'ST_MultiPoint';
+WHERE ST_GEOMETRYTYPE(geom) = 'ST_MultiPoint';
 
 DROP TABLE IF EXISTS cpdb_projects_poly;
 SELECT * INTO cpdb_projects_poly
 FROM cpdb_projects_shp
-WHERE
-    ccpversion = :'ccp_v'
-    AND ST_GEOMETRYTYPE(geom) = 'ST_MultiPolygon';
+WHERE ST_GEOMETRYTYPE(geom) = 'ST_MultiPolygon';


### PR DESCRIPTION
At some point in #102, I decided we didn't need these. We do for qa purposes, and it does no harm to keep them in the internal distribution. I've added them back