### PR TITLE
add projects with no budget data csv output

### DIFF
--- a/products/cpdb/bash/05_export.sh
+++ b/products/cpdb/bash/05_export.sh
@@ -16,6 +16,7 @@ mkdir -p output && (
     csv_export ccp_budgets cpdb_budgets &
     csv_export checkbook_spending_by_year &
     csv_export geospatial_check &
+    csv_export cpdb_projects_without_budget_data &
 
     cp ../source_data_versions.csv ./
     cp ../build_metadata.json ./

--- a/products/cpdb/sql/projects.sql
+++ b/products/cpdb/sql/projects.sql
@@ -133,6 +133,30 @@ SELECT
     spent_total_checkbooknyc
 FROM cpdb_projects_geom;
 
+DROP TABLE IF EXISTS cpdb_projects_without_budget_data;
+CREATE TABLE cpdb_projects_without_budget_data AS
+SELECT
+    ccpversion,
+    maprojid,
+    magencyacro,
+    magency,
+    magencyname,
+    description,
+    projectid,
+    mindate,
+    maxdate,
+    typecategory,
+    plannedcommit_ccnonexempt,
+    plannedcommit_ccexempt,
+    plannedcommit_citycost,
+    plannedcommit_nccstate,
+    plannedcommit_nccfederal,
+    plannedcommit_nccother,
+    plannedcommit_noncitycost,
+    plannedcommit_total
+FROM cpdb_projects
+WHERE adopt_total IS NULL;
+
 CREATE VIEW cpdb_projects_shp AS
 SELECT
     ccpversion,


### PR DESCRIPTION
Continuing #102 #289

CP requested an additional output for projects that are missing budget data. This ideally will have a follow up in the QA app but will be easier to test when we actually have a published dataset to compare to

[Passing build](https://github.com/NYCPlanning/data-engineering/actions/runs/7907280451)

[New csv](https://nyc3.digitaloceanspaces.com/edm-publishing/db-cpdb/draft/fvk-cpdb-additional-qa-output/cpdb_projects_without_budget_data.csv) that has missing rows, confirmed that it has correct project ids