### PR TITLE
Fix missing push to latest in publish

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -246,6 +246,14 @@ def publish(
     source = draft_key.path + "/"
     target = f"{draft_key.product}/publish/{version}/"
     s3.copy_folder(BUCKET, source, target, acl, max_files=max_files)
+    if latest:
+        s3.copy_folder(
+            BUCKET,
+            source,
+            f"{draft_key.product}/publish/latest/",
+            acl,
+            max_files=max_files,
+        )
     if not keep_draft:
         s3.delete(BUCKET, source)
 


### PR DESCRIPTION
A troublesome bug - we need to make sure this hasn't led to GIS publishing older datasets