### PR TITLE
Add dcp_lion to library, elevated railways to `ceqr_survey`

### DIFF
--- a/dcpy/library/ingest.py
+++ b/dcpy/library/ingest.py
@@ -81,10 +81,19 @@ def translator(func):
             fields=dataset.destination.fields,
         )
 
-        layerName = srcDS.GetLayer(0).GetName()
+        if srcDS.GetLayerCount() > 1:
+            if dataset.source.layer_name:
+                src_layer = dataset.source.layer_name
+            else:
+                raise Exception(
+                    "Multiple layers in source dataset found, must specify one in recipe."
+                )
+        else:
+            src_layer = srcDS.GetLayer(0).GetName()
+
         sql = dataset.destination.sql
         if sql:
-            sql = sql.replace("@filename", layerName)
+            sql = sql.replace("@filename", src_layer)
 
         # Create postgres database schema and table version if needed
         if output_format == "PostgreSQL":
@@ -131,6 +140,7 @@ def translator(func):
                 dstSRS=dataset.destination.geometry.SRS,
                 srcSRS=srcSRS,
                 geometryType=dataset.destination.geometry.type,
+                layers=[src_layer],
                 layerName=layerName,
                 accessMode="overwrite",
                 makeValid=True,

--- a/dcpy/library/templates/dcp_lion.yml
+++ b/dcpy/library/templates/dcp_lion.yml
@@ -1,0 +1,31 @@
+dataset:
+  name: dcp_lion
+  acl: public-read
+  source:
+    url:
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyclion_{{ version }}.zip
+      subpath: lion/lion.gdb
+    layer_name: lion
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:2263
+      type: MULTILINESTRING
+
+  destination:
+    geometry:
+      SRS: EPSG:2263
+      type: MULTILINESTRING
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ### LION
+      A single line street base map representing the city's streets and other linear geographic features, 
+      along with feature names and address ranges for each addressable street segment
+    url: https://www.nyc.gov/site/planning/data-maps/open-data/dwn-lion.page

--- a/dcpy/library/validator.py
+++ b/dcpy/library/validator.py
@@ -45,6 +45,7 @@ class SourceSection(BaseModel):
     url: Url | None = None
     script: Script | None = None
     socrata: Socrata | None = None
+    layer_name: str | None = None
     geometry: GeometryType | None = None
     options: list[str] | None = None
     gdalpath: str | None = None

--- a/products/ceqr_survey/models/_sources.yml
+++ b/products/ceqr_survey/models/_sources.yml
@@ -33,3 +33,16 @@ sources:
           - name: wkb_geometry
             tests:
               - dbt_utils.at_least_one
+
+      - name: dcp_lion
+        columns:
+          - name: street
+            tests:
+              - not_null
+          - name: row_type
+            tests:
+              - not_null
+          - name: shape
+            tests:
+              - not_null
+

--- a/products/ceqr_survey/models/intermediate/_intermediate_models.yml
+++ b/products/ceqr_survey/models/intermediate/_intermediate_models.yml
@@ -1,4 +1,4 @@
 version: 2
 
 models:
-  - name: stg__all_buffers
+  - name: int__elevated_railways

--- a/products/ceqr_survey/models/intermediate/int__elevated_railways.sql
+++ b/products/ceqr_survey/models/intermediate/int__elevated_railways.sql
@@ -1,0 +1,18 @@
+WITH dcp_lion AS (
+    SELECT * FROM {{ source('ceqr_survey_sources', 'dcp_lion') }}
+),
+
+filtered AS (
+    SELECT
+        street,
+        ST_UNION(shape) AS geom
+    FROM dcp_lion
+    WHERE row_type IN ('2', '3', '4', '5', '6', '7')
+    GROUP BY street
+)
+
+SELECT
+    'elevated_railway' AS variable,
+    street AS id,
+    ST_BUFFER(geom, 1500) AS geom
+FROM filtered

--- a/products/ceqr_survey/recipe.yml
+++ b/products/ceqr_survey/recipe.yml
@@ -12,5 +12,5 @@ inputs:
     # - name: dcp_vent_towers Doesn't exist yet
     # Noise
     # - name: dcp_digital_city_map Doesn't exist yet
-    # - name: dcp_lion Doesn't exist yet
+    - name: dcp_lion
   missing_versions_strategy: find_latest


### PR DESCRIPTION
Part of #486, #575 

Resulting table
<img width="477" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/42c67ea6-4f90-4ff7-b249-db7cdb14c0b7">

A bit interesting that things like airtrain are included. There are 56 distinct segments, so might be worth making sure that all of them are appropriate. See row_type description in [lion metadata](https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/lion_metadata.pdf) (page 32)