### PR TITLE
add export and upload to CEQR Survey

### DIFF
--- a/.github/workflows/ceqr_survey_build.yml
+++ b/.github/workflows/ceqr_survey_build.yml
@@ -62,13 +62,4 @@ jobs:
         run: python3 -m dcpy.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
 
       - name: Build
-        run: |
-          echo "Setup dbt"
-          dbt deps
-          dbt debug
-
-          echo "Test source data"
-          dbt test --select "source:*"
-
-          echo "Build all tables"
-          dbt build --full-refresh
+        run: ./bash/build.sh

--- a/.github/workflows/ceqr_survey_build.yml
+++ b/.github/workflows/ceqr_survey_build.yml
@@ -63,3 +63,6 @@ jobs:
 
       - name: Build
         run: ./bash/build.sh
+
+      - name: Export
+        run: ./bash/export.sh

--- a/.github/workflows/ceqr_survey_build.yml
+++ b/.github/workflows/ceqr_survey_build.yml
@@ -66,3 +66,6 @@ jobs:
 
       - name: Export
         run: ./bash/export.sh
+
+      - name: Upload
+        run: python3 -m dcpy.connectors.edm.publishing upload --product db-ceqr-survey --acl public-read

--- a/products/ceqr_survey/bash/build.sh
+++ b/products/ceqr_survey/bash/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+source ../../bash/utils.sh
+set_error_traps
+
+echo "Setup dbt"
+dbt deps
+dbt debug
+
+echo "Test source data"
+dbt test --select "source:*"
+
+echo "Build all tables"
+dbt build --full-refresh

--- a/products/ceqr_survey/bash/export.sh
+++ b/products/ceqr_survey/bash/export.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+source ../../bash/utils.sh
+set_error_traps
+
+fgdb_filename=ceqr_survery_output
+
+rm -rf output
+
+echo "Export product tables"
+mkdir -p output && (
+    cd output
+
+    echo "Copy metadata files"
+    cp ../source_data_versions.csv .
+    cp ../build_metadata.json .
+    
+    # TODO export all relevant source data (e.g. buffered and original geometries of Title V permits)
+    echo "Generate FileGeodatabase ${fgdb_filename}"
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON ceqr_survey_bbls ceqr_survey_bbls ${default_srs}
+
+    fgdb_export_partial ${fgdb_filename} POINT cats_permits_points cats_permits_points ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON cats_permits_lots cats_permits_lots ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON cats_permits_buffered cats_permits_buffered ${default_srs} -update
+
+    fgdb_export_partial ${fgdb_filename} POINT state_facility_permits_points state_facility_permits_points ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON state_facility_permits_lots state_facility_permits_lots ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON state_facility_permits_buffered state_facility_permits_buffered ${default_srs} -update
+
+    fgdb_export_partial ${fgdb_filename} POINT title_v_permits_points title_v_permits_points ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON title_v_permits_lots title_v_permits_lots ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON title_v_permits_buffered title_v_permits_buffered ${default_srs} -update
+
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON airports airports ${default_srs} -update
+
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON arterial_highways_buffered arterial_highways_buffered ${default_srs} -update
+
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON elevated_railways_buffered elevated_railways_buffered ${default_srs} -update
+    
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON vent_towers_buffered vent_towers_buffered ${default_srs} -update
+    
+    fgdb_export_partial ${fgdb_filename} NONE ceqr_variables ceqr_variables ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} NONE source_data_versions source_data_versions ${default_srs} -update
+
+    fgdb_export_cleanup ${fgdb_filename}
+)
+
+zip -r output/output.zip output

--- a/products/ceqr_survey/models/product/_product_models.yml
+++ b/products/ceqr_survey/models/product/_product_models.yml
@@ -75,3 +75,23 @@ models:
       - name: '"(E) Designations - HazMat"'
         data_type: string
       - name: geom
+
+  - name: cats_permits_points
+  - name: cats_permits_lots
+  - name: cats_permits_buffered
+
+  - name: state_facility_permits_points
+  - name: state_facility_permits_lots
+  - name: state_facility_permits_buffered
+
+  - name: title_v_permits_points
+  - name: title_v_permits_lots
+  - name: title_v_permits_buffered
+
+  - name: airports
+
+  - name: arterial_highways_buffered
+
+  - name: elevated_railways_buffered
+
+  - name: vent_towers_buffered

--- a/products/ceqr_survey/models/product/airports.sql
+++ b/products/ceqr_survey/models/product/airports.sql
@@ -1,0 +1,1 @@
+SELECT * FROM {{ ref('stg__panynj_airports') }}

--- a/products/ceqr_survey/models/product/arterial_highways_buffered.sql
+++ b/products/ceqr_survey/models/product/arterial_highways_buffered.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_id,
+    variable_type,
+    buffer
+FROM {{ ref('stg__dcm_arterial_highways') }}

--- a/products/ceqr_survey/models/product/cats_permits_buffered.sql
+++ b/products/ceqr_survey/models/product/cats_permits_buffered.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    buffer
+FROM {{ ref('int__dep_cats_permits') }}

--- a/products/ceqr_survey/models/product/cats_permits_lots.sql
+++ b/products/ceqr_survey/models/product/cats_permits_lots.sql
@@ -1,0 +1,6 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int__dep_cats_permits') }}
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPolygon'

--- a/products/ceqr_survey/models/product/cats_permits_points.sql
+++ b/products/ceqr_survey/models/product/cats_permits_points.sql
@@ -1,0 +1,6 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int__dep_cats_permits') }}
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_Point'

--- a/products/ceqr_survey/models/product/elevated_railways_buffered.sql
+++ b/products/ceqr_survey/models/product/elevated_railways_buffered.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    buffer
+FROM {{ ref('int__elevated_railways') }}

--- a/products/ceqr_survey/models/product/state_facility_permits_buffered.sql
+++ b/products/ceqr_survey/models/product/state_facility_permits_buffered.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    buffer
+FROM {{ ref('int__nysdec_state_facility_permits') }}

--- a/products/ceqr_survey/models/product/state_facility_permits_lots.sql
+++ b/products/ceqr_survey/models/product/state_facility_permits_lots.sql
@@ -1,0 +1,6 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int__nysdec_state_facility_permits') }}
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPolygon'

--- a/products/ceqr_survey/models/product/state_facility_permits_points.sql
+++ b/products/ceqr_survey/models/product/state_facility_permits_points.sql
@@ -1,0 +1,6 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int__nysdec_state_facility_permits') }}
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_Point'

--- a/products/ceqr_survey/models/product/title_v_permits_buffered.sql
+++ b/products/ceqr_survey/models/product/title_v_permits_buffered.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    buffer
+FROM {{ ref('int__nysdec_title_v_facility_permits') }}

--- a/products/ceqr_survey/models/product/title_v_permits_lots.sql
+++ b/products/ceqr_survey/models/product/title_v_permits_lots.sql
@@ -1,0 +1,6 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int__nysdec_title_v_facility_permits') }}
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPolygon'

--- a/products/ceqr_survey/models/product/title_v_permits_points.sql
+++ b/products/ceqr_survey/models/product/title_v_permits_points.sql
@@ -1,0 +1,6 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int__nysdec_title_v_facility_permits') }}
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_Point'

--- a/products/ceqr_survey/models/product/vent_towers_buffered.sql
+++ b/products/ceqr_survey/models/product/vent_towers_buffered.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_id,
+    variable_type,
+    buffer
+FROM {{ ref('stg__dcp_air_quality_vent_towers_buffered') }}


### PR DESCRIPTION
resolves #590 

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-ceqr-survery-export)

## screenshots from QGIS
### primary BBL table
<img width="1184" alt="Screenshot 2024-02-22 at 4 10 02 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/193c10f9-84aa-4df4-ad70-b7f76abf409d">

### all buffered sources
<img width="1339" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/26c437fe-855c-4f55-a994-48bdd3bfd1e7">

### example of points, lots, and buffered layers for State Facility Permits
<img width="1290" alt="Screenshot 2024-02-22 at 4 11 42 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/7b0bee9c-4993-45d0-bf81-808d4f963de3">

## notes
Exporting to FGDB normalizes column names (see [build logs](https://github.com/NYCPlanning/data-engineering/actions/runs/7998531029/job/21844857587#step:8:23) and gdal [source code](https://github.com/naturalatlas/node-gdal/blob/master/deps/libgdal/gdal/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp#L1659)). We may want to preempt this by using column names that already conforms to the normalization.