### PR TITLE
Add CATS, State Facility, and Title V models to `ceqr_survey`

### DIFF
--- a/products/ceqr_survey/models/_sources.yml
+++ b/products/ceqr_survey/models/_sources.yml
@@ -100,6 +100,32 @@ sources:
           - name: facility_name
             tests:
               - dbt_utils.at_least_one
-          - name: wkb_geometry
+          - name: geom
+            tests:
+              - not_null
+
+      - name: nysdec_state_facility_permits
+        columns:
+          - name: permit_id
+            tests:
+              - unique
+              - not_null
+          - name: facility_name
             tests:
               - dbt_utils.at_least_one
+          - name: geom
+            tests:
+              - not_null
+
+      - name: dep_cats_permits
+        columns:
+          - name: applicationid
+            tests:
+              - unique
+              - not_null
+          - name: status
+            tests:
+              - not_null
+          - name: geom
+            tests:
+              - not_null

--- a/products/ceqr_survey/models/intermediate/_intermediate_models.yml
+++ b/products/ceqr_survey/models/intermediate/_intermediate_models.yml
@@ -25,12 +25,12 @@ models:
 
   - name: int__edesignation_flags
     description: Flags related to edesignation
-    columns: 
+    columns:
       - name: bbl
         tests:
           - not_null
       - name: variable
-        test: 
+        test:
           - not_null
       - name: id
         test:
@@ -38,13 +38,55 @@ models:
 
   - name: int__elevated_railways
     description: Buffered geometries for elevated/exposed railways
-    columns: 
+    columns:
       - name: variable
-        test: 
+        test:
           - not_null
       - name: id
         test:
           - not_null
+      - name: geom
+        tests:
+          - not_null
+
+  - name: int__nysdec_state_facility_permits
+    description: Buffered geometries for state facility permits
+    columns:
+      - name: variable
+        test:
+          - not_null
+      - name: id
+        test:
+          - not_null
+          - unique
+      - name: geom
+        tests:
+          - not_null
+
+  - name: int__nysdec_title_v_facility_permits
+    description: Buffered geometries for title V facility permits
+    columns:
+      - name: variable
+        test:
+          - not_null
+      - name: id
+        test:
+          - not_null
+          - unique
+      - name: geom
+        tests:
+          - not_null
+
+  - name: int__stg__dep_cats_permits
+    description: Buffered geometries for cats permits
+    columns:
+      - name: variable
+        test:
+          - not_null
+      - name: id
+        test:
+          - not_null
+          - unique
       - name: geom
         tests:
           - not_null

--- a/products/ceqr_survey/models/intermediate/int__dep_cats_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__dep_cats_permits.sql
@@ -32,10 +32,7 @@ final AS (
     SELECT
         variable,
         id,
-        (CASE
-            WHEN bbl_geom IS NULL THEN ST_BUFFER(permit_geom, 400)
-            ELSE ST_BUFFER(bbl_geom, 400)
-        END) AS geom
+        ST_BUFFER(COALESCE(bbl_geom, permit_geom), 400) AS geom
     FROM cats_permits_with_pluto
 )
 

--- a/products/ceqr_survey/models/intermediate/int__dep_cats_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__dep_cats_permits.sql
@@ -3,8 +3,8 @@
 WITH cats_permits AS (
     SELECT
         variable,
-        applicationid as id,
-        geom as permit_geom
+        applicationid AS id,
+        geom AS permit_geom
     FROM
         {{ ref('stg__dep_cats_permits') }}
 ),

--- a/products/ceqr_survey/models/intermediate/int__dep_cats_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__dep_cats_permits.sql
@@ -1,0 +1,42 @@
+-- int__dep_cats_permits.sql
+
+WITH cats_permits AS (
+    SELECT
+        variable,
+        applicationid as id,
+        geom as permit_geom
+    FROM
+        {{ ref('stg__dep_cats_permits') }}
+),
+
+pluto AS (
+    SELECT geom
+    FROM {{ ref('stg__pluto') }}
+),
+
+cats_permits_with_pluto AS (
+    SELECT
+        s.variable,
+        s.id,
+        s.permit_geom,
+        p.geom AS bbl_geom
+
+    FROM cats_permits AS s
+    LEFT JOIN pluto AS p ON ST_WITHIN(s.permit_geom, p.geom)
+
+),
+
+-- create buffer of 400 feet around tax lot (bbl_geom column). 
+-- If tax lot is null, create buffer around point (geom column)
+final AS (
+    SELECT
+        variable,
+        id,
+        (CASE
+            WHEN bbl_geom IS NULL THEN ST_BUFFER(permit_geom, 400)
+            ELSE ST_BUFFER(bbl_geom, 400)
+        END) AS geom
+    FROM cats_permits_with_pluto
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/models/intermediate/int__nysdec_state_facility_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__nysdec_state_facility_permits.sql
@@ -32,10 +32,7 @@ final AS (
     SELECT
         variable,
         id,
-        (CASE
-            WHEN bbl_geom IS NULL THEN ST_BUFFER(permit_geom, 1000)
-            ELSE ST_BUFFER(bbl_geom, 1000)
-        END) AS geom
+        ST_BUFFER(COALESCE(bbl_geom, permit_geom), 1000) AS geom
     FROM state_facility_permits_with_pluto
 )
 

--- a/products/ceqr_survey/models/intermediate/int__nysdec_state_facility_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__nysdec_state_facility_permits.sql
@@ -1,0 +1,42 @@
+-- int__nysdec_state_facility_permits.sql
+
+WITH state_facility_permits AS (
+    SELECT
+        variable,
+        permit_id as id,
+        geom as permit_geom
+    FROM
+        {{ ref('stg__nysdec_state_facility_permits') }}
+),
+
+pluto AS (
+    SELECT geom
+    FROM {{ ref('stg__pluto') }}
+),
+
+state_facility_permits_with_pluto AS (
+    SELECT
+        s.variable,
+        s.id,
+        s.permit_geom,
+        p.geom AS bbl_geom
+
+    FROM state_facility_permits AS s
+    LEFT JOIN pluto AS p ON ST_WITHIN(s.permit_geom, p.geom)
+
+),
+
+-- create buffer of 1,000 feet around tax lot (bbl_geom column). 
+-- If tax lot is null, create buffer around point (geom column)
+final AS (
+    SELECT
+        variable,
+        id,
+        (CASE
+            WHEN bbl_geom IS NULL THEN ST_BUFFER(permit_geom, 1000)
+            ELSE ST_BUFFER(bbl_geom, 1000)
+        END) AS geom
+    FROM state_facility_permits_with_pluto
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/models/intermediate/int__nysdec_state_facility_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__nysdec_state_facility_permits.sql
@@ -3,8 +3,8 @@
 WITH state_facility_permits AS (
     SELECT
         variable,
-        permit_id as id,
-        geom as permit_geom
+        permit_id AS id,
+        geom AS permit_geom
     FROM
         {{ ref('stg__nysdec_state_facility_permits') }}
 ),

--- a/products/ceqr_survey/models/intermediate/int__nysdec_title_v_facility_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__nysdec_title_v_facility_permits.sql
@@ -3,8 +3,8 @@
 WITH title_v_facility_permits AS (
     SELECT
         variable,
-        permit_id as id,
-        geom as permit_geom
+        permit_id AS id,
+        geom AS permit_geom
     FROM
         {{ ref('stg__nysdec_title_v_facility_permits') }}
 ),

--- a/products/ceqr_survey/models/intermediate/int__nysdec_title_v_facility_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__nysdec_title_v_facility_permits.sql
@@ -32,10 +32,7 @@ final AS (
     SELECT
         variable,
         id,
-        (CASE
-            WHEN bbl_geom IS NULL THEN ST_BUFFER(permit_geom, 1000)
-            ELSE ST_BUFFER(bbl_geom, 1000)
-        END) AS geom
+        ST_BUFFER(COALESCE(bbl_geom, permit_geom), 1000) AS geom
     FROM title_v_facility_permits_with_pluto
 )
 

--- a/products/ceqr_survey/models/intermediate/int__nysdec_title_v_facility_permits.sql
+++ b/products/ceqr_survey/models/intermediate/int__nysdec_title_v_facility_permits.sql
@@ -1,0 +1,42 @@
+-- int__nysdec_title_v_facility_permits.sql
+
+WITH title_v_facility_permits AS (
+    SELECT
+        variable,
+        permit_id as id,
+        geom as permit_geom
+    FROM
+        {{ ref('stg__nysdec_title_v_facility_permits') }}
+),
+
+pluto AS (
+    SELECT geom
+    FROM {{ ref('stg__pluto') }}
+),
+
+title_v_facility_permits_with_pluto AS (
+    SELECT
+        t.variable,
+        t.id,
+        t.permit_geom,
+        p.geom AS bbl_geom
+
+    FROM title_v_facility_permits AS t
+    LEFT JOIN pluto AS p ON ST_WITHIN(t.permit_geom, p.geom)
+
+),
+
+-- create buffer of 1,000 feet around tax lot (bbl_geom column). 
+-- If tax lot is null, create buffer around point (geom column)
+final AS (
+    SELECT
+        variable,
+        id,
+        (CASE
+            WHEN bbl_geom IS NULL THEN ST_BUFFER(permit_geom, 1000)
+            ELSE ST_BUFFER(bbl_geom, 1000)
+        END) AS geom
+    FROM title_v_facility_permits_with_pluto
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/models/staging/stg__dcp_air_quality_vent_towers_buffered.sql
+++ b/products/ceqr_survey/models/staging/stg__dcp_air_quality_vent_towers_buffered.sql
@@ -1,6 +1,7 @@
 WITH vents_raw AS (
 
-    SELECT * FROM {{ source('ceqr_survey_sources', 'dcp_air_quality_vent_towers') }}
+    SELECT *
+    FROM {{ source('ceqr_survey_sources', 'dcp_air_quality_vent_towers') }}
 
 )
 

--- a/products/ceqr_survey/models/staging/stg__dep_cats_permits.sql
+++ b/products/ceqr_survey/models/staging/stg__dep_cats_permits.sql
@@ -9,9 +9,9 @@ final AS (
         'cats_permits' AS variable,
         applicationid,
         status,
-        st_transform(geom::geometry, 2263) as geom
+        st_transform(geom::geometry, 2263) AS geom
     FROM source
-    WHERE UPPER(status) IN ('EXPIRED', 'CURRENT')
+    WHERE upper(status) IN ('EXPIRED', 'CURRENT')
 )
 
 SELECT * FROM final

--- a/products/ceqr_survey/models/staging/stg__dep_cats_permits.sql
+++ b/products/ceqr_survey/models/staging/stg__dep_cats_permits.sql
@@ -1,0 +1,17 @@
+-- stg__dep_cats_permits.sql
+
+WITH source AS (
+    SELECT * FROM {{ source('ceqr_survey_sources', 'dep_cats_permits') }}
+),
+
+final AS (
+    SELECT
+        'cats_permits' AS variable,
+        applicationid,
+        status,
+        st_transform(geom::geometry, 2263) as geom
+    FROM source
+    WHERE UPPER(status) IN ('EXPIRED', 'CURRENT')
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/models/staging/stg__nysdec_state_facility_permits.sql
+++ b/products/ceqr_survey/models/staging/stg__nysdec_state_facility_permits.sql
@@ -10,7 +10,7 @@ final AS (
         'state_facility_permits' AS variable,
         permit_id,
         facility_name,
-        st_transform(geom::geometry, 2263) as geom
+        st_transform(geom::geometry, 2263) AS geom
     FROM source
 )
 

--- a/products/ceqr_survey/models/staging/stg__nysdec_state_facility_permits.sql
+++ b/products/ceqr_survey/models/staging/stg__nysdec_state_facility_permits.sql
@@ -1,0 +1,17 @@
+-- stg__nysdec_state_facility_permits.sql
+
+WITH source AS (
+    SELECT *
+    FROM {{ source('ceqr_survey_sources', 'nysdec_state_facility_permits') }}
+),
+
+final AS (
+    SELECT
+        'state_facility_permits' AS variable,
+        permit_id,
+        facility_name,
+        st_transform(geom::geometry, 2263) as geom
+    FROM source
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/models/staging/stg__nysdec_title_v_facility_permits.sql
+++ b/products/ceqr_survey/models/staging/stg__nysdec_title_v_facility_permits.sql
@@ -1,0 +1,17 @@
+-- stg__nysdec_title_v_facility_permits.sql
+
+WITH source AS (
+    SELECT *
+    FROM {{ source('ceqr_survey_sources', 'nysdec_title_v_facility_permits') }}
+),
+
+final AS (
+    SELECT
+        'title_v_facility_permits' AS variable,
+        permit_id,
+        facility_name,
+        st_transform(geom::geometry, 2263) as geom
+    FROM source
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/models/staging/stg__nysdec_title_v_facility_permits.sql
+++ b/products/ceqr_survey/models/staging/stg__nysdec_title_v_facility_permits.sql
@@ -10,7 +10,7 @@ final AS (
         'title_v_facility_permits' AS variable,
         permit_id,
         facility_name,
-        st_transform(geom::geometry, 2263) as geom
+        st_transform(geom::geometry, 2263) AS geom
     FROM source
 )
 


### PR DESCRIPTION
Related to #575.

### What: 
Create air-quality intermediate tables aka "models" for: 
* cats permits
* state facility permits
* title V facility permits

All three models have the following resulting columns: `variable`, `id`, and `geom` (which is **buffered** geometry). The three tables have the same logic (except different distance buffer).

### Commits:
1) Add sources of these datasets to dbt project, specifying required columns and tests. <--- 🚨 NEED FEEDBACK on validation tests here.

2) Create staging models of these datasets: select needed columns, add custom `variable` column, transform geometry to `2263` projection, and filter if needed (applicable to cats permits).

3) Create intermediate tables with buffered geometry in 2 steps: 
    * spatially join with pluto to add tax lot geometry
    * create `geom` buffered column by applying buffer to tax lot geom column or to the original point geom column. The latter happens if original point wasn't mapped to a tax lot.
 
<--- 🚨 NEED FEEDBACK on the spatial queries.

### Successful run: 
* [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7980369506/job/21789858966)
    * it fails a test for `dcm_arterial_highways` source model which is outside of this PR. 

### Notes: 
* All 3 source datasets have same column "geom" and it's in hex-encoded WKB format (ex: `0101000020E6100000BE1589096A7852C0657094BC3A534440`). Casting to geometry sql data type converts the column to `Point`. 