### PR TITLE
fix `dcm_arterial_highways` tests

### DIFF
--- a/products/ceqr_survey/models/_sources.yml
+++ b/products/ceqr_survey/models/_sources.yml
@@ -20,12 +20,18 @@ sources:
         columns:
           - name: name
             tests:
-              - unique
               - not_null
           - name: wkb_geometry
             tests:
               - unique
               - not_null
+        tests:
+          - dbt_utils.unique_combination_of_columns:
+              name: dcm_arterial_highways_compound_key
+              combination_of_columns:
+                - name
+                - wkb_geometry
+
       - name: dcp_air_quality_vent_towers
         columns:
           - name: bbl
@@ -97,4 +103,3 @@ sources:
           - name: wkb_geometry
             tests:
               - dbt_utils.at_least_one
-


### PR DESCRIPTION
`name` isn't unique in `dcm_arterial_highways` data, but `name + wkb_geometry` is

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-fix-highway-test)

new tests passing [here](https://github.com/NYCPlanning/data-engineering/actions/runs/7980603979/job/21790642751#step:7:89), but build failing due to a bug fixed in #598 