### PR TITLE
CEQR Survey: Create `int__spatial_flags` model

### DIFF
--- a/products/ceqr_survey/models/intermediate/_intermediate_models.yml
+++ b/products/ceqr_survey/models/intermediate/_intermediate_models.yml
@@ -116,3 +116,32 @@ models:
       - name: buffer
         tests:
           - not_null
+
+  - name: int__spatial_flags
+    description: |
+      A table featuring spatially joined BBLs with buffered variable types, 
+      including distances to their raw geometry
+    columns:
+      - name: bbl
+        data_type: string
+        test:
+          - not_null
+      - name: variable_type
+        data_type: string
+        test:
+          - not_null
+      - name: variable_id
+        data_type: string
+        test:
+          - not_null
+      - name: distance_from
+        data_type: float
+        test:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          name: int__spatial_flags_compound_key
+          combination_of_columns:
+            - bbl
+            - variable_type
+            - variable_id

--- a/products/ceqr_survey/models/intermediate/int__spatial_flags.sql
+++ b/products/ceqr_survey/models/intermediate/int__spatial_flags.sql
@@ -1,0 +1,32 @@
+-- int__spatial_flags.sql
+
+WITH buffered_flags AS (
+    SELECT
+        variable_type,
+        variable_id,
+        buffer,
+        raw_geom
+    FROM
+        {{ ref('int__all_buffers') }}
+),
+
+pluto AS (
+    SELECT
+        bbl,
+        geom AS bbl_geom
+    FROM {{ ref('stg__pluto') }}
+),
+
+-- Spatially join pluto with buffered flags. 
+-- Calculate distance to raw geometry of the joined flags
+final AS (
+    SELECT
+        p.bbl,
+        b.variable_type,
+        b.variable_id,
+        ST_DISTANCE(p.bbl_geom, b.raw_geom) AS distance
+    FROM buffered_flags AS b INNER JOIN pluto AS p
+        ON ST_INTERSECTS(b.buffer, p.bbl_geom)
+)
+
+SELECT * FROM final

--- a/products/ceqr_survey/models/staging/stg__dcm_arterial_highways.sql
+++ b/products/ceqr_survey/models/staging/stg__dcm_arterial_highways.sql
@@ -1,5 +1,14 @@
 WITH arterial_highways_raw AS (
     SELECT * FROM {{ source('ceqr_survey_sources', 'dcm_arterial_highways') }}
+),
+
+filtered AS (
+    SELECT
+        name,
+        ST_UNION(wkb_geometry) AS wkb_geometry
+    FROM arterial_highways_raw
+    WHERE source = 'Appendix H'
+    GROUP BY name
 )
 
 SELECT
@@ -7,5 +16,4 @@ SELECT
     'arterial_highway' AS variable_type,
     wkb_geometry AS raw_geom,
     ST_BUFFER(wkb_geometry, 75) AS buffer
-FROM arterial_highways_raw
-WHERE source = 'Appendix H'
+FROM filtered


### PR DESCRIPTION
resolves #609.

Link to successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8007242439/job/21870885970). 

Note, there is a test failing for `int__spatial_flags` where it's checking a combination of `bbl` + `variable_id` + `variable_type` for uniqueness. In the process of investigating. Example: 

<img width="690" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/a23bd3ec-847a-4976-8c96-c68e20e2a144">

#### Findings: 
* All the duplicates are of `arterial_highway` variable_type. 
* There are 31 unique duplicates (i.e. 31 records have duplicates).
* These duplicates are coming from `int__all_buffers` table. Though they do seem to have unique geometries & buffers