### PR TITLE
CEQR - Add zoning flags

### DIFF
--- a/products/ceqr_survey/models/intermediate/_intermediate_models.yml
+++ b/products/ceqr_survey/models/intermediate/_intermediate_models.yml
@@ -150,3 +150,29 @@ models:
             - bbl
             - variable_type
             - variable_id
+
+  - name: int__zoning_flags
+    columns:
+      - name: bbl
+        data_type: string
+        test:
+          - not_null
+      - name: variable_type
+        data_type: string
+        test:
+          - not_null
+      - name: variable_id
+        data_type: string
+        test:
+          - not_null
+      - name: distance
+        data_type: float
+        test:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          name: int__zoning_flags_compound_key
+          combination_of_columns:
+            - bbl
+            - variable_type
+            - variable_id

--- a/products/ceqr_survey/models/intermediate/int__edesignation_flags.sql
+++ b/products/ceqr_survey/models/intermediate/int__edesignation_flags.sql
@@ -4,21 +4,21 @@ WITH dcp_edesignation AS (
 
 SELECT
     bbl,
-    'edesignation_hazmat' AS variable_type,
+    'e_designations_hazmat' AS variable_type,
     enumber AS variable_id
 FROM dcp_edesignation
 WHERE hazmat_code = '1'
 UNION ALL
 SELECT
     bbl,
-    'edesignation_air' AS variable_type,
+    'e_designations_air' AS variable_type,
     enumber AS variable_id
 FROM dcp_edesignation
 WHERE air_code = '1'
 UNION ALL
 SELECT
     bbl,
-    'edesignation_noise' AS variable_type,
+    'e_designations_noise' AS variable_type,
     enumber AS variable_id
 FROM dcp_edesignation
 WHERE noise_code = '1'

--- a/products/ceqr_survey/models/intermediate/int__flags.sql
+++ b/products/ceqr_survey/models/intermediate/int__flags.sql
@@ -5,13 +5,18 @@
     ]
 ) }}
 
---todo - add in 'int__zoning_flags'
---UNION ALL
 SELECT
     bbl,
     variable_type,
     variable_id,
-    NULL AS distance
+    NULL::double precision AS distance
+FROM {{ ref('int__zoning_flags') }}
+UNION ALL
+SELECT
+    bbl,
+    variable_type,
+    variable_id,
+    NULL::double precision AS distance
 FROM {{ ref('int__edesignation_flags') }}
 UNION ALL
 SELECT

--- a/products/ceqr_survey/models/intermediate/int__zoning_flags.sql
+++ b/products/ceqr_survey/models/intermediate/int__zoning_flags.sql
@@ -1,0 +1,77 @@
+WITH pluto AS (
+    SELECT * FROM {{ ref('stg__pluto') }}
+),
+
+zoning_districts_exploded AS (
+    SELECT
+        bbl,
+        UNNEST(ARRAY[zonedist1, zonedist2, zonedist3, zonedist4]) AS zd
+    FROM pluto
+),
+
+zoning_districts_split_exploded AS (
+    SELECT
+        bbl,
+        UNNEST(STRING_TO_ARRAY(zd, '/')) AS zd
+    FROM zoning_districts_exploded
+    WHERE zd IS NOT NULL
+),
+
+zoning_districts_preprocessed AS (
+    SELECT
+        bbl,
+        (REGEXP_MATCH(zd, '^(\w\d+)(?:[^\d].*)?$'))[1] AS zd,
+        zd LIKE 'M%' OR zd LIKE 'C%' AS cmflag
+    FROM zoning_districts_split_exploded
+),
+
+zoning_districts_regrouped AS (
+    SELECT
+        bbl,
+        ARRAY_AGG(zd) <@ ARRAY['R5', 'R6', 'R7', 'R8', 'R9', 'R10'] AS r5_r10,
+        ARRAY_AGG(zd) && ARRAY['R1', 'R2', 'R3', 'R4'] AS r1_r4,
+        BOOL_AND(cmflag) AS c_m
+    FROM zoning_districts_preprocessed
+    GROUP BY bbl
+),
+
+zoning_district_flags AS (
+    SELECT
+        bbl,
+        'zoning_districts' AS variable_type,
+        CASE
+            WHEN r5_r10 THEN 'R5-R10'
+            WHEN r1_r4 THEN 'R1-R4'
+            WHEN c_m THEN 'C or M'
+        END AS variable_id
+    FROM zoning_districts_regrouped
+    WHERE r5_r10 OR r1_r4 OR c_m
+),
+
+special_district_flags AS (
+    SELECT
+        bbl,
+        'special_coastal_risk_districts' AS variable_type,
+        CASE
+            WHEN spdist1 LIKE 'CR%' THEN spdist1
+            WHEN spdist2 LIKE 'CR%' THEN spdist2
+            WHEN spdist3 LIKE 'CR%' THEN spdist3
+        END AS variable_id
+    FROM pluto
+    WHERE
+        spdist1 LIKE 'CR%'
+        OR spdist2 LIKE 'CR%'
+        OR spdist3 LIKE 'CR%'
+)
+
+SELECT
+    bbl,
+    variable_type,
+    variable_id
+FROM zoning_district_flags
+UNION ALL
+SELECT
+    bbl,
+    variable_type,
+    variable_id
+FROM special_district_flags


### PR DESCRIPTION
There's an argument to break up this file. Logic is a little complicated because zd fields look like this
![image](https://github.com/NYCPlanning/data-engineering/assets/9454672/96fda6b3-94b9-4ec1-8845-4ba31877840d)
where we have split districts, subdistricts, etc. Luckily I've written some of this code already for the [AE tilesets for zola](https://github.com/NYCPlanning/data-engineering/blob/main/products/pluto/pluto_build/sql/export_ae_tables.sql)!

If you want to poke around, you can query my branch with stuff like
```
select a.bbl, a.zonedist1, a.zonedist2, a.zonedist3, a.zonedist4, izf.variable_id  from stg__pluto a
left join int__zoning_flags izf on a.bbl = izf.bbl
where b.bbl is null
```

b.bbl is null to see if there are rows that should have a flag that don't. I've also been spot checking bbls. It's looking good! I do need to think a bit about how best to test this logic in a more automated fashion though

[Build action](https://github.com/NYCPlanning/data-engineering/actions/runs/8011426681/job/21884824262)