### PR TITLE
improve Template DB

### DIFF
--- a/products/template/metadata.yml
+++ b/products/template/metadata.yml
@@ -11,27 +11,27 @@ each_row_is_a: Interesting place in NYC
 
 columns:
   - name: place_name
-    description:  A Place Name
+    description: The name of the Place
     display_name: Place Name
     data_type: text
 
   - name: bbl
-    description: The BBL
+    description: The Borough-Block-Lot (BBL) of the Place
     display_name: BBL
     data_type: bbl
 
   - name: place_type
-    description: The type of the Place.
+    description: The type of the Place
     display_name: Place Type
     data_type: text
 
   - name: borough
-    description: The Borough
+    description: The borough of the Place
     display_name: Borough
     data_type: text
 
   - name: wkb_geometry
-    description: The Geom
+    description: The geometry of the Place
     display_name: Geometry
     data_type: wkb
 
@@ -40,8 +40,15 @@ dataset_package:
     - name: primary_csv
       filename: templatedb.csv
       type: csv
-    - name: primary_shapefile
-      filename: template.shp.zip
+    - name: shapefile_points
+      filename: templatedb_points.shp.zip
+      type: shapefile
+      overrides:
+        columns:
+          wkb_geometry:
+            name: the_geom
+    - name: shapefile_polygons
+      filename: templatedb_polygons.shp.zip
       type: shapefile
       overrides:
         columns:
@@ -57,10 +64,9 @@ destinations:
     type: socrata
     four_four: "b7pm-uzu7"
     datasets:
-      - primary_shapefile
+      - shapefile_points
     attachments:
       - source_data_versions.csv
-    omit_columns: [dcpedited, uid]
     column_details:
       the_geom:
         api_name: wkb_geometry

--- a/products/template/sql/_intermediate_models.yml
+++ b/products/template/sql/_intermediate_models.yml
@@ -46,7 +46,3 @@ models:
           combination_of_columns:
             - landmark_name
             - wkb_geometry
-          config:
-            severity: error
-            error_if: ">50"
-            warn_if: ">0"

--- a/products/template/sql/_intermediate_models.yml
+++ b/products/template/sql/_intermediate_models.yml
@@ -22,17 +22,14 @@ models:
       - name: space_name
         tests:
           - not_null
+      - name: borough
       - name: wkb_geometry
     tests:
       - dbt_utils.unique_combination_of_columns:
           name: green_spaces_unique_compound_key
           combination_of_columns:
             - space_name
-            - wkb_geometry
-          config:
-            severity: error
-            error_if: ">50"
-            warn_if: ">0"
+            - borough
 
   - name: historic_landmarks
     description: "All historic landmarks in NYC"

--- a/products/template/sql/_sources.yml
+++ b/products/template/sql/_sources.yml
@@ -39,6 +39,9 @@ sources:
           - name: signname
             tests:
               - not_null
+          - name: borough
+            tests:
+              - not_null
           - name: wkb_geometry
             tests:
               - not_null
@@ -51,6 +54,9 @@ sources:
             description: Primary key of the dpr_greenthumb table
             tests:
               - unique
+              - not_null
+          - name: borough
+            tests:
               - not_null
           - name: wkb_geometry
             tests:

--- a/products/template/sql/green_spaces.sql
+++ b/products/template/sql/green_spaces.sql
@@ -6,7 +6,7 @@ CREATE TABLE green_spaces AS
 
     greenthumb_gardens AS (SELECT * FROM stg_dpr_greenthumb),
 
-    final AS (
+    all_green_spaces AS (
         SELECT
             space_name,
             wkb_geometry
@@ -18,7 +18,17 @@ CREATE TABLE green_spaces AS
             wkb_geometry
         FROM
             greenthumb_gardens
+    ),
+
+    -- NOTE this causes all records in a borough named "Park" being merged
+    merged_geometries AS (
+        SELECT
+            space_name,
+            ST_UNION(wkb_geometry) AS wkb_geometry
+        FROM
+            all_green_spaces
+        GROUP BY space_name
     )
 
-    SELECT * FROM final
+    SELECT * FROM merged_geometries
 );

--- a/products/template/sql/green_spaces.sql
+++ b/products/template/sql/green_spaces.sql
@@ -1,4 +1,3 @@
--- TODO determine the Borough of each green space
 CREATE TABLE green_spaces AS
 (
     WITH
@@ -9,25 +8,45 @@ CREATE TABLE green_spaces AS
     all_green_spaces AS (
         SELECT
             space_name,
+            borough,
             wkb_geometry
         FROM
             parks_properties
         UNION ALL
         SELECT
             space_name,
+            borough,
             wkb_geometry
         FROM
             greenthumb_gardens
+    ),
+
+    standardized_values AS (
+        SELECT
+            space_name,
+            CASE
+                WHEN borough = 'B' THEN 'Brooklyn'
+                WHEN borough = 'M' THEN 'Manhattan'
+                WHEN borough = 'Q' THEN 'Queens'
+                WHEN borough = 'R' THEN 'Staten Island'
+                WHEN borough = 'X' THEN 'Bronx'
+                ELSE borough
+            END
+            AS borough,
+            wkb_geometry
+        FROM
+            all_green_spaces
     ),
 
     -- NOTE this causes all records in a borough named "Park" being merged
     merged_geometries AS (
         SELECT
             space_name,
+            borough,
             ST_UNION(wkb_geometry) AS wkb_geometry
         FROM
-            all_green_spaces
-        GROUP BY space_name
+            standardized_values
+        GROUP BY space_name, borough
     )
 
     SELECT * FROM merged_geometries

--- a/products/template/sql/historic_landmarks.sql
+++ b/products/template/sql/historic_landmarks.sql
@@ -23,14 +23,16 @@ CREATE TABLE historic_landmarks AS
             boroughs ON landmarks_reprojected.borough_name_short = boroughs.name_short
     ),
 
-    final AS (
+    merged_geometries AS (
         SELECT
             landmark_name,
             borough,
             bbl,
-            wkb_geometry
-        FROM landmarks_borough_names
+            ST_UNION(wkb_geometry) AS wkb_geometry
+        FROM
+            landmarks_borough_names
+        GROUP BY landmark_name, borough, bbl
     )
 
-    SELECT * FROM final
+    SELECT * FROM merged_geometries
 );

--- a/products/template/sql/product/_product_models.yml
+++ b/products/template/sql/product/_product_models.yml
@@ -13,24 +13,10 @@ models:
       - name: wkb_geometry
         tests:
           - not_null:
-              where: "bbl is not null"
+              where: bbl is not null
     tests:
       - dbt_utils.unique_combination_of_columns:
-          name: templatedb_unique_compound_key_1
+          name: templatedb_unique_compound_key
           combination_of_columns:
             - place_name
-            - bbl
-          config:
-            severity: error
-            error_if: ">5000"
-            warn_if: ">0"
-      - dbt_utils.unique_combination_of_columns:
-          name: templatedb_unique_compound_key_2
-          combination_of_columns:
-            - place_name
-            - bbl
-            - wkb_geometry
-          config:
-            severity: error
-            error_if: ">50"
-            warn_if: ">0"
+            - borough

--- a/products/template/sql/product/_product_models.yml
+++ b/products/template/sql/product/_product_models.yml
@@ -20,3 +20,4 @@ models:
           combination_of_columns:
             - place_name
             - borough
+            - bbl

--- a/products/template/sql/product/templatedb.sql
+++ b/products/template/sql/product/templatedb.sql
@@ -8,7 +8,7 @@ CREATE TABLE templatedb AS
 
     historic_landmarks AS (SELECT * FROM historic_landmarks),
 
-    final AS (
+    all_records AS (
         SELECT
             library_name AS place_name,
             'library' AS place_type,
@@ -33,8 +33,22 @@ CREATE TABLE templatedb AS
             bbl,
             wkb_geometry
         FROM historic_landmarks
+    ),
+
+    standardized_geometry_types AS (
+        SELECT
+            place_name,
+            place_type,
+            borough,
+            bbl,
+            CASE
+                WHEN ST_GEOMETRYTYPE(wkb_geometry) = 'ST_Polygon' THEN ST_MULTI(wkb_geometry)
+                WHEN ST_ISEMPTY(wkb_geometry) THEN NULL
+                ELSE wkb_geometry
+            END AS wkb_geometry
+        FROM all_records
     )
 
-    SELECT * FROM final
+    SELECT * FROM standardized_geometry_types
     ORDER BY borough ASC, place_name ASC
 );

--- a/products/template/sql/product/templatedb.sql
+++ b/products/template/sql/product/templatedb.sql
@@ -21,7 +21,7 @@ CREATE TABLE templatedb AS
         SELECT
             space_name AS place_name,
             'green space' AS place_type,
-            NULL AS borough,
+            borough AS borough,
             NULL AS bbl,
             wkb_geometry
         FROM green_spaces

--- a/products/template/sql/staging.sql
+++ b/products/template/sql/staging.sql
@@ -18,11 +18,13 @@ FROM qpl_libraries;
 
 CREATE TABLE stg_dpr_parksproperties AS SELECT
     signname AS space_name,
+    borough,
     wkb_geometry
 FROM dpr_parksproperties;
 
 CREATE TABLE stg_dpr_greenthumb AS SELECT
     gardenname AS space_name,
+    borough,
     wkb_geometry
 FROM dpr_greenthumb;
 

--- a/products/template/tests/test_build.py
+++ b/products/template/tests/test_build.py
@@ -35,10 +35,12 @@ def test_export_draft():
 def test_export_files():
     expected_export_file_names = [
         "source_data_versions.csv",
+        "build_metadata.json",
         "templatedb.csv",
+        "templatedb_polygons.shp.zip",
+        "templatedb_points.shp.zip",
     ]
     actual_files = s3.get_filenames(
         publishing.BUCKET, f"{PRODUCT_S3_NAME}/draft/{BUILD_NAME}/"
     )
-    for file_name in expected_export_file_names:
-        assert file_name in actual_files
+    assert set(actual_files) == set(expected_export_file_names)


### PR DESCRIPTION
resolves #268 

End-to-end test failing [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8101460990/job/22141825321?pr=619#step:7:60) due to exported metadata files and new shapefiles, passing [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8101704638/job/22142602432#step:7:28)

I imagine we'd like to have any new "make shapefiles" code to be in our utils. But for the urgency of using this in the ongoing GIS automation/metadata work, I kept it in the Template DB codebase for now.