### PR TITLE
Add dbt test for checking projection

### DIFF
--- a/products/ceqr_survey/dbt_project.yml
+++ b/products/ceqr_survey/dbt_project.yml
@@ -3,6 +3,7 @@ name: "dbt_ceqr_survey"
 profile: "dcp-de-postgres"
 
 model-paths: ["models"]
+macro-paths: ["macros"]
 
 tests:
   +store_failures: true

--- a/products/ceqr_survey/macros/test_is_2263_srs.sql
+++ b/products/ceqr_survey/macros/test_is_2263_srs.sql
@@ -1,0 +1,22 @@
+-- tests column values to have 2263 projection (state plane)
+
+{% test is_2263_srs(model, column_name) %}
+
+WITH validation AS (
+    SELECT
+        {{ column_name }} AS geom_column
+    FROM {{ model }}
+),
+
+validation_errors AS (
+    SELECT
+        geom_column
+    FROM validation
+    WHERE ST_SRID(geom_column) != 2263
+
+)
+
+SELECT *
+FROM validation_errors
+
+{% endtest %}

--- a/products/ceqr_survey/macros/test_is_epsg_2263.sql
+++ b/products/ceqr_survey/macros/test_is_epsg_2263.sql
@@ -1,6 +1,6 @@
 -- tests column values to have 2263 projection (state plane)
 
-{% test is_2263_srs(model, column_name) %}
+{% test is_epsg_2263(model, column_name) %}
 
 WITH validation AS (
     SELECT

--- a/products/ceqr_survey/models/_sources.yml
+++ b/products/ceqr_survey/models/_sources.yml
@@ -91,7 +91,7 @@ sources:
           - name: wkb_geometry
             tests:
               - not_null
-              - is_2263_srs:
+              - is_epsg_2263:
                   config:
                     severity: warn
 

--- a/products/ceqr_survey/models/_sources.yml
+++ b/products/ceqr_survey/models/_sources.yml
@@ -91,6 +91,9 @@ sources:
           - name: wkb_geometry
             tests:
               - not_null
+              - is_2263_srs:
+                  config:
+                    severity: warn
 
       - name: nysdec_title_v_facility_permits
         columns:

--- a/products/ceqr_survey/models/intermediate/_intermediate_models.yml
+++ b/products/ceqr_survey/models/intermediate/_intermediate_models.yml
@@ -33,6 +33,7 @@ models:
       - name: buffer
         tests:
           - not_null
+          - is_2263_srs
 
   - name: int__edesignation_flags
     description: Flags related to edesignation

--- a/products/ceqr_survey/models/intermediate/_intermediate_models.yml
+++ b/products/ceqr_survey/models/intermediate/_intermediate_models.yml
@@ -33,7 +33,7 @@ models:
       - name: buffer
         tests:
           - not_null
-          - is_2263_srs
+          - is_epsg_2263
 
   - name: int__edesignation_flags
     description: Flags related to edesignation


### PR DESCRIPTION
## Motivation
Currently our source data has different projections and it takes a bit of work to confirm a geometry projection for a given table. One way is to check target projection in a dataset template in `data-library`. Another way is to use gdal CLI to get the projection. It would be nice to have a test that would check a geometry column to be in state plane (`EPSG:2263`). 

## Approach
You can write custom schema tests in dbt. I wrote my own test that checks a column's projection, and it fails if there is at least 1 record with a projection other than `2263`.

## Commits
1. Create the test in `macros` directory
2. Add the test to 2 tables: `dcp_mappluto_wi` and `int__dep_cats_permits_buffer`. These tablas have different projections, allowing us to check correct behavior from the test. 

#### Successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8055140004/job/22001301833). From this run, you can see that:
* `dcp_mappluto_wi` gets a [warning](https://github.com/NYCPlanning/data-engineering/actions/runs/8055140004/job/22001301833#step:7:75) as expected. 
* `int__dep_cats_permits_buffer ` passes the [test](https://github.com/NYCPlanning/data-engineering/actions/runs/8055140004/job/22001301833#step:7:294).

## TODO
* [ ] After this pr is reviewed, delete the test from pluto table. It's not needed here because pluto geom column gets casted to correct projection in staging.