### PR TITLE
GHA maintenance

### DIFF
--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -1,7 +1,7 @@
 name: Compile python requirements
 on:
   schedule: 
-  - cron: 0 5 * * SUN
+  - cron: 0 17 * * SAT
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,9 @@ jobs:
           - dev
     steps:
       - uses: actions/checkout@v4
-        if: contains(needs.check_changes.outputs.push_changes, 'docker')
+        if: contains(needs.check_changes.outputs.pr_changes, 'docker') && contains(needs.check_changes.outputs.push_changes, 'docker')
       - name: Load Secrets
-        if: contains(needs.check_changes.outputs.push_changes, 'docker')
+        if: contains(needs.check_changes.outputs.pr_changes, 'docker') && contains(needs.check_changes.outputs.push_changes, 'docker')
         uses: 1password/load-secrets-action@v1
         with:
           export-env: true
@@ -109,7 +109,7 @@ jobs:
           DOCKER_USERNAME: "op://Data Engineering/Dockerhub/username"
           DOCKER_PASSWORD: "op://Data Engineering/Dockerhub/password"
       - name: publish images
-        if: contains(needs.check_changes.outputs.push_changes, 'docker')
+        if: contains(needs.check_changes.outputs.pr_changes, 'docker') && contains(needs.check_changes.outputs.push_changes, 'docker')
         working-directory: docker
         run: ./publish.sh "${{ matrix.image }}" "${{ needs.set_docker_image_tag.outputs.tag }}"
 


### PR DESCRIPTION
1. closes #622 , move python compile job to noon on saturdays
2. fix logic around docker images. Logic was right in assigning tag, but in case of "changes since last push to pr", missed case of a rebase from main which changes python/docker stuff. In this case, but when there are NO pr changes, nothing should happen because they should still be using latest. So just need to check if there are BOTH push and pr changes before building dev images