### PR TITLE
missing version flag in bytes quarterly update workflow, cleanup from source data dashboard

### DIFF
--- a/.github/workflows/cbbr_build.yml
+++ b/.github/workflows/cbbr_build.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/ceqr_build.yml
+++ b/.github/workflows/ceqr_build.yml
@@ -26,7 +26,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup python
         uses: actions/setup-python@v4.5.0

--- a/.github/workflows/checkbook_build.yml
+++ b/.github/workflows/checkbook_build.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
         working-directory: products/checkbook
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/colp_build.yml
+++ b/.github/workflows/colp_build.yml
@@ -45,7 +45,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Load Secrets
       uses: 1password/load-secrets-action@v1

--- a/.github/workflows/cpdb_build.yml
+++ b/.github/workflows/cpdb_build.yml
@@ -33,7 +33,7 @@ jobs:
       BUILD_ENGINE_DB: db-cpdb
       BUILD_NAME: ${{ inputs.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -30,7 +30,7 @@ jobs:
           - dsny_frequencies
           - dpr_park_access_zone
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -41,6 +41,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup ...
         working-directory: ./

--- a/.github/workflows/data_library_quarterly.yml
+++ b/.github/workflows/data_library_quarterly.yml
@@ -65,6 +65,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup ...
         working-directory: ./

--- a/.github/workflows/data_library_quarterly.yml
+++ b/.github/workflows/data_library_quarterly.yml
@@ -54,7 +54,7 @@ jobs:
           - dcp_stateassemblydistricts
           - dcp_statesenatedistricts
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/data_library_quarterly.yml
+++ b/.github/workflows/data_library_quarterly.yml
@@ -6,7 +6,6 @@ on:
       version:
         description: 'The quarterly version name (e.g. 21b, has to be all lower case)'
         required: true
-        default: 21c
       dev_image: 
         description: "Use dev image specific to this branch? (If exists)"
         type: boolean
@@ -72,4 +71,4 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Library Archive
-        run: library archive --name ${{ matrix.dataset }} --latest --s3
+        run: library archive --name ${{ matrix.dataset }} --version ${{ inputs.version }} --latest --s3

--- a/.github/workflows/data_library_single.yml
+++ b/.github/workflows/data_library_single.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       AWS_S3_BUCKET: edm-recipes
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/data_library_single.yml
+++ b/.github/workflows/data_library_single.yml
@@ -44,6 +44,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup ...
         working-directory: ./

--- a/.github/workflows/developments_build.yml
+++ b/.github/workflows/developments_build.yml
@@ -33,7 +33,7 @@ jobs:
         BUILD_ENGINE_DB: db-devdb
         BUILD_NAME: ${{ inputs.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -36,6 +36,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup ...
         run: ./bash/docker_container_setup.sh
@@ -80,6 +81,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup ...
         working-directory: ./

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -25,7 +25,7 @@ jobs:
           - dob_jobapplications
           - hpd_hny_units_by_building
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -70,7 +70,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         working-directory: docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -61,7 +61,7 @@ jobs:
         shell: bash
         working-directory: docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         working-directory: docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         working-directory: docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -124,7 +124,7 @@ jobs:
         shell: bash
         working-directory: docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:

--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -33,7 +33,7 @@ jobs:
         BUILD_ENGINE_DB: db-facilities
         BUILD_NAME: ${{ inputs.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/factfinder_build.yml
+++ b/.github/workflows/factfinder_build.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       BUILD_NAME: ${{ inputs.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/green_fast_track_build.yml
+++ b/.github/workflows/green_fast_track_build.yml
@@ -32,7 +32,7 @@ jobs:
       BUILD_ENGINE_DB: db-green-fast-track
       BUILD_NAME: ${{ inputs.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/knownprojects_build.yml
+++ b/.github/workflows/knownprojects_build.yml
@@ -24,7 +24,7 @@ jobs:
       BUILD_ENGINE_DB: kpdb
       BUILD_NAME: ${{ inputs.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/nightly_qa.yml
+++ b/.github/workflows/nightly_qa.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,7 +32,7 @@ jobs:
     container:
       image: nycplanning/build-base:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: |
             dcpy 

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -37,7 +37,7 @@ jobs:
       BUILD_NAME: ${{ inputs.build_name }}
       BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/pluto_input_cama.yml
+++ b/.github/workflows/pluto_input_cama.yml
@@ -30,7 +30,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/pluto_input_cama.yml
+++ b/.github/workflows/pluto_input_cama.yml
@@ -41,6 +41,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
           SSH_PRIVATE_KEY_GINGER: "op://Data Engineering/DOF_SFTP/private key"
           GINGER_HOST: "op://Data Engineering/DOF_SFTP/url"
           GINGER_USER: "op://Data Engineering/DOF_SFTP/username"

--- a/.github/workflows/pluto_input_numbldgs.yml
+++ b/.github/workflows/pluto_input_numbldgs.yml
@@ -18,7 +18,7 @@ jobs:
       AWS_S3_BUCKET: edm-recipes
       API_TOKEN: ${{ secrets.API_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/pluto_input_numbldgs.yml
+++ b/.github/workflows/pluto_input_numbldgs.yml
@@ -29,6 +29,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Run Container Setup
         working-directory: ./

--- a/.github/workflows/pluto_input_pts.yml
+++ b/.github/workflows/pluto_input_pts.yml
@@ -30,7 +30,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/pluto_input_pts.yml
+++ b/.github/workflows/pluto_input_pts.yml
@@ -41,6 +41,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
           SSH_PRIVATE_KEY_GINGER: "op://Data Engineering/DOF_SFTP/private key"
           GINGER_HOST: "op://Data Engineering/DOF_SFTP/url"
           GINGER_USER: "op://Data Engineering/DOF_SFTP/username"

--- a/.github/workflows/pluto_publish_mvt.yml
+++ b/.github/workflows/pluto_publish_mvt.yml
@@ -56,7 +56,7 @@ jobs:
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
           BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: finish container setup
         working-directory: ./

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
     container:
       image: nycplanning/build-base:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: |
             dcpy 

--- a/.github/workflows/publish_generate_mvt.yml
+++ b/.github/workflows/publish_generate_mvt.yml
@@ -46,7 +46,7 @@ jobs:
     container:
       image: nycplanning/dev:latest 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: 'dcpy'
 

--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/qa_deploy.yml
+++ b/.github/workflows/qa_deploy.yml
@@ -11,7 +11,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -36,7 +36,7 @@ jobs:
       DOCKER_IMAGE_NAME: nycplanning/qa-streamlit:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:

--- a/.github/workflows/socrata_publish_dataset.yml
+++ b/.github/workflows/socrata_publish_dataset.yml
@@ -35,7 +35,7 @@ jobs:
     container:
       image: nycplanning/build-base:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/stale_builds.yml
+++ b/.github/workflows/stale_builds.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       GHP_TOKEN: ${{ github.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         working-directory: products/template
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: nycplanning/dev:${{ inputs.image_tag || 'latest'}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -56,7 +56,7 @@ jobs:
     container:
       image: nycplanning/dev:${{ inputs.image_tag || 'latest' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/zap_export.yml
+++ b/.github/workflows/zap_export.yml
@@ -36,7 +36,7 @@ jobs:
             open: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ failure() && (github.event_name == 'schedule') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: .github
       - name: Create issue on failure

--- a/.github/workflows/zap_single_visible.yml
+++ b/.github/workflows/zap_single_visible.yml
@@ -27,7 +27,7 @@ jobs:
       EDM_DATA_ZAP_SCHEMA: export_single_${{ github.event_name }}_${{ github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/zoningtaxlots_build.yml
+++ b/.github/workflows/zoningtaxlots_build.yml
@@ -33,7 +33,7 @@ jobs:
       BUILD_ENGINE_DB: db-ztl
       BUILD_NAME: ${{ inputs.build_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -50,6 +50,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup
         working-directory: ./

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -39,7 +39,7 @@ jobs:
           - dof_shoreline
           - dof_condo
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/apps/qa/Dockerfile
+++ b/apps/qa/Dockerfile
@@ -8,6 +8,8 @@ COPY . .
 RUN python3 -m pip install . -c constraints.txt
 RUN python3 -m pip install -r requirements.txt -c constraints.txt
 
+ENV DEPLOY=true
+
 RUN rm -rf dcpy
 
 EXPOSE 8501

--- a/apps/qa/bash/docker_build_and_publish.sh
+++ b/apps/qa/bash/docker_build_and_publish.sh
@@ -11,6 +11,14 @@ cp $ROOT_DIR/pyproject.toml $PROJECT_DIR
 cp $ROOT_DIR/python/constraints.txt $PROJECT_DIR
 cp -r $ROOT_DIR/dcpy $PROJECT_DIR
 
+# copy in recipe files so source datasets can be determined
+# ideally these eventually live in common folder (such as somewhere in dcpy)
+for product in $(find products -maxdepth 1 -mindepth 1 -type d);
+do
+    recipe=$ROOT_DIR/$product/recipe.yml
+    [ -f "$recipe" ] && mkdir -p $PROJECT_DIR/$product && cp $recipe $PROJECT_DIR/$product/recipe.yml
+done
+
 # Build image - Once we reach some sort of MVP, maybe worth starting versioning. For now, just latest
 docker_login
 build_and_publish_docker_image $PROJECT_DIR nycplanning/qa-streamlit latest

--- a/apps/qa/src/__init__.py
+++ b/apps/qa/src/__init__.py
@@ -1,11 +1,7 @@
 from pathlib import Path
 
-from dotenv import load_dotenv
-
 APP_PATH = Path(__file__).parent.parent
 ROOT_PATH = APP_PATH.parent.parent
-
-load_dotenv(ROOT_PATH / ".env")
 
 QAQC_DB = "edm-qaqc"
 QAQC_DB_SCHEMA_SOURCE_DATA = "source_data"

--- a/apps/qa/src/pages/source_data/helpers.py
+++ b/apps/qa/src/pages/source_data/helpers.py
@@ -1,13 +1,15 @@
+import os
 from typing import Dict
 
-from src import ROOT_PATH
+from src import ROOT_PATH, APP_PATH
 
 from dcpy.connectors.edm import recipes
 from dcpy.builds import plan
 
 
 def get_source_datasets(product: str) -> list[str]:
-    recipe = plan.recipe_from_yaml(ROOT_PATH / "products" / product / "recipe.yml")
+    root = APP_PATH if "DEPLOY" in os.environ else ROOT_PATH
+    recipe = plan.recipe_from_yaml(root / "products" / product / "recipe.yml")
     return [dataset.name for dataset in recipe.inputs.datasets]
 
 

--- a/dcpy/library/archive.py
+++ b/dcpy/library/archive.py
@@ -126,7 +126,4 @@ class Archive:
             if clean:
                 os.remove(_file)
 
-        if push:
-            recipes.log_metadata(config)
-
         return config

--- a/dcpy/library/cli.py
+++ b/dcpy/library/cli.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.table import Table
 import typer
 
+from dcpy.connectors.edm import recipes
 from . import aws_s3_bucket
 from .archive import Archive
 from .s3 import S3
@@ -36,8 +37,9 @@ def archive(
         typer.echo(message)
     else:
         a = Archive()
+        config: recipes.Config | None = None
         for output_format in output_formats:
-            a(
+            config = a(
                 path=path,
                 output_format=output_format,
                 push=push,
@@ -49,6 +51,9 @@ def archive(
                 postgres_url=postgres_url,
                 version=version,
             )
+        assert config
+        if push:
+            recipes.log_metadata(config)
 
 # fmt: off
 @app.command()

--- a/dcpy/library/templates/dcp_pad.yml
+++ b/dcpy/library/templates/dcp_pad.yml
@@ -3,7 +3,7 @@ dataset:
   acl: public-read
   source:
     script:
-      path: "https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pad{{ version }}.zip"
+      path: "https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pad_{{ version }}.zip"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"


### PR DESCRIPTION
Initial issue was missing version flag in `library` call as well as a pad filepath change. See failure [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8097894008/job/22130006267) and success [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8098384482) 

Then I needed a bit of cleanup from source data dashboard pr #560 
- add secret for edm server for library workflows
- cleanup deployment of qa app (I think I dropped a commit by accident in my pr?). [Successful deploy](https://github.com/NYCPlanning/data-engineering/actions/runs/8099354488), [working source dashboard](https://de-qaqc.nycplanningdigital.com/?page=Source+Data)
- only log once per cli call
