### PR TITLE
revise Green Fast Tract

### DIFF
--- a/dcpy/library/templates/dcp_air_quality_vent_towers.yml
+++ b/dcpy/library/templates/dcp_air_quality_vent_towers.yml
@@ -3,7 +3,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://edm-recipes.nyc3.cdn.digitaloceanspaces.com/inbox/dcp_air_quality_vent_towers/{{ version }}/vent_tower.zip
+      path: s3://edm-recipes/inbox/dcp_air_quality_vent_towers/{{ version }}/vent_tower.zip
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"

--- a/products/green_fast_track/bash/build.sh
+++ b/products/green_fast_track/bash/build.sh
@@ -6,8 +6,17 @@ echo "Setup dbt"
 dbt deps
 dbt debug
 
-echo "Test source data"
+echo "Test source tables"
 dbt test --select "source:*"
 
-echo "Build all tables"
-dbt build --full-refresh
+echo "Build seed tables"
+dbt build --select config.materialized:seed
+
+echo "Build staging tables"
+dbt build --select staging
+
+echo "Build intermediate tables"
+dbt build --select intermediate
+
+echo "Build product tables"
+dbt build --select product

--- a/products/green_fast_track/bash/export.sh
+++ b/products/green_fast_track/bash/export.sh
@@ -22,6 +22,9 @@ mkdir -p output && (
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON cats_permits_lots cats_permits_lots ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON cats_permits_buffered cats_permits_buffered ${default_srs} -update
 
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON industrial_sources_lots industrial_sources_lots ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON industrial_sources_buffered industrial_sources_buffered ${default_srs} -update
+
     fgdb_export_partial ${fgdb_filename} POINT state_facility_permits_points state_facility_permits_points ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON state_facility_permits_lots state_facility_permits_lots ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON state_facility_permits_buffered state_facility_permits_buffered ${default_srs} -update

--- a/products/green_fast_track/models/intermediate/_intermediate_models.yml
+++ b/products/green_fast_track/models/intermediate/_intermediate_models.yml
@@ -17,6 +17,25 @@ models:
         tests:
           - not_null
 
+  - name: int__industrial_sources
+    description: | 
+      Buffered geometries for lots with potenitally unpermitted industrial emissions based on land use
+    columns:
+      - name: variable_type
+        test:
+          - not_null
+      - name: variable_id
+        test:
+          - not_null
+          - unique
+      - name: raw_geom
+        tests:
+          - not_null
+      - name: buffer
+        tests:
+          - not_null
+          - is_epsg_2263
+
   - name: int__dep_cats_permits
     description: Buffered geometries for cats permits
     columns:

--- a/products/green_fast_track/models/intermediate/_intermediate_models.yml
+++ b/products/green_fast_track/models/intermediate/_intermediate_models.yml
@@ -166,10 +166,6 @@ models:
         data_type: string
         test:
           - not_null
-      - name: distance
-        data_type: float
-        test:
-          - not_null
     tests:
       - dbt_utils.unique_combination_of_columns:
           name: int__zoning_flags_compound_key

--- a/products/green_fast_track/models/intermediate/int__all_buffers.sql
+++ b/products/green_fast_track/models/intermediate/int__all_buffers.sql
@@ -5,6 +5,7 @@ WITH all_buffers AS (
         ref('int__nysdec_state_facility_permits'),
         ref('int__nysdec_title_v_facility_permits'),
         ref('int__dep_cats_permits'),
+        ref('int__industrial_sources'),
         ref('stg__dcm_arterial_highways'),
         ref('stg__dcp_air_quality_vent_towers_buffered'),
         ref('stg__panynj_airports')

--- a/products/green_fast_track/models/intermediate/int__industrial_sources.sql
+++ b/products/green_fast_track/models/intermediate/int__industrial_sources.sql
@@ -1,0 +1,20 @@
+WITH pluto AS (
+    SELECT
+        bbl,
+        landuse,
+        geom
+    FROM {{ ref('stg__pluto') }}
+),
+
+filtered AS (
+    SELECT *
+    FROM pluto
+    WHERE landuse = '06'
+)
+
+SELECT
+    'industrial_sources' AS variable_type,
+    bbl AS variable_id,
+    geom AS raw_geom,
+    ST_BUFFER(geom, 400) AS buffer
+FROM filtered

--- a/products/green_fast_track/models/product/_product_models.yml
+++ b/products/green_fast_track/models/product/_product_models.yml
@@ -29,6 +29,11 @@ models:
         tests: [not_null]
       - name: '"CATS Permits"'
         data_type: string
+      - name: '"Unpermitted Industrial Sources Flag"'
+        data_type: string
+        tests: [not_null]
+      - name: '"Unpermitted Industrial Sources"'
+        data_type: string
       - name: '"State Facility Permits Flag"'
         data_type: string
         tests: [not_null]
@@ -79,6 +84,9 @@ models:
   - name: cats_permits_points
   - name: cats_permits_lots
   - name: cats_permits_buffered
+
+  - name: industrial_sources_lots
+  - name: industrial_sources_buffered
 
   - name: state_facility_permits_points
   - name: state_facility_permits_lots

--- a/products/green_fast_track/models/product/cats_permits_points.sql
+++ b/products/green_fast_track/models/product/cats_permits_points.sql
@@ -1,6 +1,5 @@
 SELECT
     variable_type,
     variable_id,
-    raw_geom
-FROM {{ ref('int__dep_cats_permits') }}
-WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_Point'
+    permit_geom AS raw_geom
+FROM {{ ref('stg__dep_cats_permits') }}

--- a/products/green_fast_track/models/product/green_fast_track_bbls.sql
+++ b/products/green_fast_track/models/product/green_fast_track_bbls.sql
@@ -28,17 +28,12 @@ flags_ranked AS (
 flags_wide AS (
     SELECT
         {% for row in variables -%}
-            MAX(
-                CASE
-                    WHEN
-                        variable_type = '{{ row["variable_type"] }}'
-                        THEN variable_id
-                END
+            ARRAY_TO_STRING(
+                ARRAY_AGG(variable_id) FILTER (WHERE variable_type = '{{ row["variable_type"] }}'), ', '
             ) AS "{{ row['label'] }}",
         {% endfor %}
         bbl
     FROM flags_ranked
-    WHERE row_number = 1
     GROUP BY bbl
 )
 

--- a/products/green_fast_track/models/product/green_fast_track_bbls.sql
+++ b/products/green_fast_track/models/product/green_fast_track_bbls.sql
@@ -19,6 +19,7 @@ flags_ranked AS (
         bbl,
         variable_type,
         variable_id,
+        distance,
         ROW_NUMBER()
             OVER (PARTITION BY bbl, variable_type ORDER BY distance)
         AS row_number
@@ -28,8 +29,12 @@ flags_ranked AS (
 flags_wide AS (
     SELECT
         {% for row in variables -%}
+            /* construct a comma-separated list of values ordered by distance and name */
             ARRAY_TO_STRING(
-                ARRAY_AGG(variable_id) FILTER (WHERE variable_type = '{{ row["variable_type"] }}'), ', '
+                ARRAY_AGG(variable_id ORDER BY distance ASC, variable_id ASC) FILTER (
+                    WHERE variable_type = '{{ row["variable_type"] }}'
+                ),
+                ', '
             ) AS "{{ row['label'] }}",
         {% endfor %}
         bbl

--- a/products/green_fast_track/models/product/industrial_sources_buffered.sql
+++ b/products/green_fast_track/models/product/industrial_sources_buffered.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    buffer
+FROM {{ ref('int__industrial_sources') }}

--- a/products/green_fast_track/models/product/industrial_sources_lots.sql
+++ b/products/green_fast_track/models/product/industrial_sources_lots.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int__industrial_sources') }}

--- a/products/green_fast_track/models/product/state_facility_permits_points.sql
+++ b/products/green_fast_track/models/product/state_facility_permits_points.sql
@@ -1,6 +1,5 @@
 SELECT
     variable_type,
     variable_id,
-    raw_geom
-FROM {{ ref('int__nysdec_state_facility_permits') }}
-WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_Point'
+    permit_geom AS raw_geom
+FROM {{ ref('stg__nysdec_state_facility_permits') }}

--- a/products/green_fast_track/models/product/title_v_permits_points.sql
+++ b/products/green_fast_track/models/product/title_v_permits_points.sql
@@ -1,6 +1,5 @@
 SELECT
     variable_type,
     variable_id,
-    raw_geom
-FROM {{ ref('int__nysdec_title_v_facility_permits') }}
-WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_Point'
+    permit_geom AS raw_geom
+FROM {{ ref('stg__nysdec_title_v_facility_permits') }}

--- a/products/green_fast_track/models/staging/stg__pluto.sql
+++ b/products/green_fast_track/models/staging/stg__pluto.sql
@@ -19,6 +19,7 @@ final AS (
         spdist1,
         spdist2,
         spdist3,
+        landuse,
         ST_TRANSFORM(wkb_geometry, 2263) AS geom
     FROM mappluto_wi
 )

--- a/products/green_fast_track/recipe.yml
+++ b/products/green_fast_track/recipe.yml
@@ -10,6 +10,7 @@ inputs:
     - name: nysdec_state_facility_permits
     - name: nysdec_title_v_facility_permits
     - name: dcp_air_quality_vent_towers
+      version: 20240201
     # Noise
     # - name: dcp_digital_city_map Doesn't exist yet
     - name: panynj_jfk_65db

--- a/products/green_fast_track/seeds/variables.csv
+++ b/products/green_fast_track/seeds/variables.csv
@@ -2,6 +2,7 @@ variable_type,label,ceqr_category,survey_question,type_ii_criteria_description
 zoning_districts,Zoning Districts,Zoning,2A,"R5-R10, R1-R4, or (C or M)"
 special_coastal_risk_districts,Special Coastal Risk Districts,Zoning,2B,"Any of 3 special purpose district fields in PLUTO contain a CR% value"
 cats_permits,CATS Permits,Air Quality,10,"400 foot buffer"
+industrial_sources,Unpermitted Industrial Sources,Air Quality,10,"Land Use Code = 06 and 400 foot buffer"
 state_facility_permits,State Facility Permits,Air Quality,11,"1,000 foot buffer"
 title_v_permits,Clean Air Act Title V Permits,Air Quality,12,"1,000 foot buffer"
 vent_towers,Vent Towers,Air Quality,13,"75 foot buffer"


### PR DESCRIPTION
related to https://github.com/NYCPlanning/edm-overview/issues/1029

These are changes to the Green Fast Track categories that we've already implemented. These came from discussions with Planning Support and GIS

- export all points, not just points that didn't join to a lot
- export a list of all values that contribute to each flag (e.g. CATS Permit IDs as `abc, xyz`, E-Des as `E-215, E-655`)
- add columns and exports for a new "Unpermitted Industrial Sources" Air Quality variable to flag nearby lots with manufacturing land use
- build in stages to make build logs more readable and useful

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-gft-update)


## notes
- tried to build using the latest Vents data (data library run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8164322120)), but that shapefile only has 1 row so I pinned the Vents version here to the last valid version. following-up with GIS to remake the data
- some lots are near >50 CATS Permits. will follow-up with GIS to determine how to handle those (maybe change value to `10+ values` or something)

## screenshots
<img width="895" alt="Screenshot 2024-03-06 at 9 46 19 AM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/79aef8a8-26cf-4bbd-be97-30354c118e6d">
