### PR TITLE
check dbt projects in PR tests

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -98,9 +98,6 @@ jobs:
           ./bash/docker_container_setup.sh
           ./bash/build_env_setup.sh
 
-      - name: Temp install pre-commit
-        run: python3 -m pip install pre-commit
-
       - name: Check dbt files
         run: |
           export BUILD_ENGINE_DB=db-green-fast-track

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -52,7 +52,7 @@ jobs:
           sqlfluff lint products/knownprojects/ --templater=jinja
           sqlfluff lint products/pluto/pluto_build/sql/
           sqlfluff lint products/zoningtaxlots/sql/
-          export BUILD_ENGINE_DB=db-ceqr-survey
+          export BUILD_ENGINE_DB=db-green-fast-track
           sqlfluff lint products/green_fast_track/models --templater=dbt
 
   mypy:
@@ -69,6 +69,46 @@ jobs:
           mypy products/facilities
           mypy products/template
   
+  dbt_checkpoint:
+    name: Check dbt files
+    runs-on: ubuntu-22.04
+    container: nycplanning/dev:${{ inputs.image_tag }}
+    env:
+      BUILD_NAME: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+          AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+          BUILD_ENGINE_HOST: "op://Data Engineering/EDM_DATA/server"
+          BUILD_ENGINE_USER: "op://Data Engineering/EDM_DATA/username"
+          BUILD_ENGINE_PASSWORD: "op://Data Engineering/EDM_DATA/password"
+          BUILD_ENGINE_PORT: "op://Data Engineering/EDM_DATA/port"
+
+      - name: Setup build environment
+        run: |
+          ./bash/docker_container_setup.sh
+          ./bash/build_env_setup.sh
+
+      - name: Temp install pre-commit
+        run: python3 -m pip install pre-commit
+
+      - name: Check dbt files
+        run: |
+          export BUILD_ENGINE_DB=db-green-fast-track
+          dbt deps --profiles-dir products/green_fast_track --project-dir products/green_fast_track
+          dbt seed --profiles-dir products/green_fast_track --project-dir products/green_fast_track
+          dbt docs generate --profiles-dir products/green_fast_track --project-dir products/green_fast_track
+          pre-commit run --all-files
+
   template-db:
     if: (inputs.path_filter == '') || contains(inputs.path_filter, 'template')
     uses: ./.github/workflows/template_test.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/dbt-checkpoint/dbt-checkpoint
+    rev: v1.2.0
+    hooks:
+      # Green Fast Track
+      - id: check-script-semicolon
+        name: Green Fast Track - Model scripts have no semicolon
+        files: ^products/green_fast_track/models/
+        args: ["--manifest", "products/green_fast_track/target/manifest.json"]
+
+      # - id: check-model-has-properties-file
+      #   name: Green Fast Track - Models have a properties file
+      #   files: ^products/green_fast_track/models/
+      #   args: ["--manifest", "products/green_fast_track/target/manifest.json"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         files: ^products/green_fast_track/models/
         args: ["--manifest", "products/green_fast_track/target/manifest.json"]
 
-      # - id: check-model-has-properties-file
-      #   name: Green Fast Track - Models have a properties file
-      #   files: ^products/green_fast_track/models/
-      #   args: ["--manifest", "products/green_fast_track/target/manifest.json"]
+      - id: check-model-has-properties-file
+        name: Green Fast Track - Models have a properties file
+        files: ^products/green_fast_track/models/
+        args: ["--manifest", "products/green_fast_track/target/manifest.json"]

--- a/products/green_fast_track/models/staging/_staging_models.yml
+++ b/products/green_fast_track/models/staging/_staging_models.yml
@@ -1,0 +1,10 @@
+version: 2
+
+models:
+  - name: stg__nysdec_state_facility_permits
+  - name: stg__dcm_arterial_highways
+  - name: stg__dcp_air_quality_vent_towers_buffered
+  - name: stg__dep_cats_permits
+  - name: stg__panynj_airports
+  - name: stg__pluto
+  - name: stg__nysdec_title_v_facility_permits

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -70,6 +70,8 @@ cffi==1.16.0
     # via
     #   cryptography
     #   dbt-core
+cfgv==3.4.0
+    # via pre-commit
 chardet==5.2.0
     # via
     #   diff-cover
@@ -139,6 +141,8 @@ diagrams==0.23.4
     # via -r python/requirements.in
 diff-cover==8.0.3
     # via sqlfluff
+distlib==0.3.8
+    # via virtualenv
 duckdb==0.10.0
     # via leafmap
 et-xmlfile==1.1.0
@@ -148,7 +152,9 @@ executing==2.0.1
 faker==23.1.0
     # via -r python/requirements.in
 filelock==3.13.1
-    # via gdown
+    # via
+    #   gdown
+    #   virtualenv
 fiona==1.9.5
     # via geopandas
 folium==0.14.0
@@ -184,6 +190,8 @@ graphviz==0.20.1
     #   diagrams
 greenlet==3.0.3
     # via sqlalchemy
+identify==2.5.35
+    # via pre-commit
 idna==3.6
     # via
     #   dbt-core
@@ -204,7 +212,7 @@ ipykernel==6.22.0
     # via -r python/requirements.in
 ipyleaflet==0.18.2
     # via leafmap
-ipython==8.22.1
+ipython==8.22.2
     # via
     #   ipykernel
     #   ipywidgets
@@ -328,6 +336,8 @@ networkx==3.2.1
     # via
     #   dbt-core
     #   mapclassify
+nodeenv==1.8.0
+    # via pre-commit
 numerize==0.12
     # via -r python/requirements.in
 numpy==1.26.4
@@ -395,6 +405,7 @@ platformdirs==4.2.0
     # via
     #   black
     #   jupyter-core
+    #   virtualenv
 plotly==5.19.0
     # via
     #   -r python/requirements.in
@@ -403,6 +414,8 @@ pluggy==1.4.0
     # via
     #   diff-cover
     #   pytest
+pre-commit==3.6.2
+    # via -r python/requirements.in
 probableparsing==0.0.1
     # via usaddress
 prompt-toolkit==3.0.43
@@ -505,6 +518,7 @@ pyyaml==6.0.1
     #   dbt-core
     #   dbt-semantic-interfaces
     #   moto
+    #   pre-commit
     #   responses
     #   sqlfluff
 pyzmq==25.1.2
@@ -700,6 +714,8 @@ usaddress==0.5.10
     # via -r python/requirements.in
 validators==0.22.0
     # via streamlit
+virtualenv==20.25.1
+    # via pre-commit
 watchdog==4.0.0
     # via streamlit
 wcwidth==0.2.13

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -27,6 +27,7 @@ openpyxl==3.1.2
 pandas
 pandas-stubs
 plotly==5.*
+pre-commit
 psycopg2-binary==2.9.5
 types-psycopg2
 pyarrow

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -70,6 +70,8 @@ cffi==1.16.0
     # via
     #   cryptography
     #   dbt-core
+cfgv==3.4.0
+    # via pre-commit
 chardet==5.2.0
     # via
     #   diff-cover
@@ -139,6 +141,8 @@ diagrams==0.23.4
     # via -r python/requirements.in
 diff-cover==8.0.3
     # via sqlfluff
+distlib==0.3.8
+    # via virtualenv
 duckdb==0.10.0
     # via leafmap
 et-xmlfile==1.1.0
@@ -148,7 +152,9 @@ executing==2.0.1
 faker==23.1.0
     # via -r python/requirements.in
 filelock==3.13.1
-    # via gdown
+    # via
+    #   gdown
+    #   virtualenv
 fiona==1.9.5
     # via geopandas
 folium==0.14.0
@@ -184,6 +190,8 @@ graphviz==0.20.1
     #   diagrams
 greenlet==3.0.3
     # via sqlalchemy
+identify==2.5.35
+    # via pre-commit
 idna==3.6
     # via
     #   dbt-core
@@ -204,7 +212,7 @@ ipykernel==6.22.0
     # via -r python/requirements.in
 ipyleaflet==0.18.2
     # via leafmap
-ipython==8.22.1
+ipython==8.22.2
     # via
     #   ipykernel
     #   ipywidgets
@@ -328,6 +336,8 @@ networkx==3.2.1
     # via
     #   dbt-core
     #   mapclassify
+nodeenv==1.8.0
+    # via pre-commit
 numerize==0.12
     # via -r python/requirements.in
 numpy==1.26.4
@@ -395,6 +405,7 @@ platformdirs==4.2.0
     # via
     #   black
     #   jupyter-core
+    #   virtualenv
 plotly==5.19.0
     # via
     #   -r python/requirements.in
@@ -403,6 +414,8 @@ pluggy==1.4.0
     # via
     #   diff-cover
     #   pytest
+pre-commit==3.6.2
+    # via -r python/requirements.in
 probableparsing==0.0.1
     # via usaddress
 prompt-toolkit==3.0.43
@@ -505,6 +518,7 @@ pyyaml==6.0.1
     #   dbt-core
     #   dbt-semantic-interfaces
     #   moto
+    #   pre-commit
     #   responses
     #   sqlfluff
 pyzmq==25.1.2
@@ -700,6 +714,8 @@ usaddress==0.5.10
     # via -r python/requirements.in
 validators==0.22.0
     # via streamlit
+virtualenv==20.25.1
+    # via pre-commit
 watchdog==4.0.0
     # via streamlit
 wcwidth==0.2.13


### PR DESCRIPTION
We discussed and would like to start applying [Code Conventions](https://github.com/NYCPlanning/data-engineering/wiki/Code-Conventions) for our dbt projects.

Although we use sqlfluff to lint sql files, it's limited to the formatting of queries and can't check things that involve compiled dbt sql files and properties yaml files.

[`dbt-checkpoint`](https://github.com/dbt-checkpoint/dbt-checkpoint) is a set of pre-commit hooks that can be used locally and in CI to check that our dbt files adhere to the rules we choose to enforce ([dbt blog](https://docs.getdbt.com/blog/enforcing-rules-pre-commit-dbt)).

example of new tests failing [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8127931481/job/22213314373#step:7:56) due to some models not being listed in a properties yaml file (no `_staging_models.yml`) and then passing [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8127953377/job/22213358437#step:7:56) after the file is added with all model names in it
