### PR TITLE
fix monthly CATS permits action

### DIFF
--- a/.github/ISSUE_TEMPLATE/dep-monthly.md
+++ b/.github/ISSUE_TEMPLATE/dep-monthly.md
@@ -3,11 +3,6 @@ name: Monthly Run DEP CATS permits
 about: Approve a push of DEP CATS data to production.
 title: "[publish] dep_cats_permits"
 labels: 'data update'
-assignees:
-    - ileoyu
-    - OmarOrtiz1
-    - jpiacentinidcp
-    - rtblair
 ---
 
 A fresh run of dep_cats_permits is complete! 🎉

--- a/.github/ISSUE_TEMPLATE/dep-monthly.md
+++ b/.github/ISSUE_TEMPLATE/dep-monthly.md
@@ -1,19 +1,21 @@
 ---
 name: Monthly Run DEP CATS permits
-about: Approve a push of DEP CATS data to production.
-title: "[publish] dep_cats_permits"
+about: Scheduled DEP CATS permits build succeeded.
+title: "`dep_cats_permits` ready for QA"
 labels: 'data update'
 ---
 
-A fresh run of dep_cats_permits is complete! 🎉
-## Staging files output:
-- [ ] [version.txt](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/version.txt)
-- [ ] [dep_cats_permits.zip](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/dep_cats_permits.zip)
-- [ ] [dep_cats_permits.csv](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/dep_cats_permits.csv)
-- [ ] [ReadMe_DEPCATS.pdf](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/ReadMe_DEPCATS.pdf)
+A scheduled run of `dep_cats_permits` is complete! 🎉
 
-## Next Steps: 
-If you have manually checked above files and they seem to be ok, comment `[publish]` under this issue. 
-This would allow github actions to move staging files to production. 
-Feel free to close this issue once all complete. Thanks!
+## Staging files in Digital Ocean
 
+- [version.txt](https://nyc3.digitaloceanspaces.com/edm-publishing/datasets/dep_cats_permits/staging/version.txt)
+- [dep_cats_permits.zip](https://nyc3.digitaloceanspaces.com/edm-publishing/datasets/dep_cats_permits/staging/dep_cats_permits.zip)
+- [dep_cats_permits.csv](https://nyc3.digitaloceanspaces.com/edm-publishing/datasets/dep_cats_permits/staging/dep_cats_permits.csv)
+- [ReadMe_DEPCATS.pdf](https://nyc3.digitaloceanspaces.com/edm-publishing/datasets/dep_cats_permits/staging/ReadMe_DEPCATS.pdf)
+
+## Next Steps
+
+The ITD QA team will be notified in the `edm-data-operations` repo [here](https://github.com/NYCPlanning/edm-data-operations) of a difference between the staging and production folders.
+
+They will use a github action in that repo to publish staged data which will move staging files to production.

--- a/.github/workflows/ceqr_dep_monthly.yml
+++ b/.github/workflows/ceqr_dep_monthly.yml
@@ -3,32 +3,64 @@ on:
   workflow_dispatch:
   schedule:
     - cron: 0 0 1 * *
-  # repository_dispatch:
-  #   types: [dep_cats_permits]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: products/ceqr
+    container:
+      image: nycplanning/build-geosupport:${{ inputs.image_tag || 'latest' }}
     env:
-      RECIPE_ENGINE: ${{ secrets.RECIPE_ENGINE }}
-      EDM_DATA: ${{ secrets.EDM_DATA }}
-      AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      BUILD_ENGINE_DB: defaultdb
     steps:
-      - uses: actions/checkout@v2
-        
-      - name: Install dependencies
-        shell: bash
-        run: ./ceqr setup
-        
-      - name: Run recipe
-        shell: bash
-        run: ./ceqr run recipe dep_cats_permits
-  
-      - uses: JasonEtco/create-an-issue@v2
-        name: Create Issue to Publish
+      - uses: actions/checkout@v4
+
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+          AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+          AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+
+      - name: Setup build environment
+        working-directory: ./
+        run: |
+          ./bash/docker_container_setup.sh
+
+      - name: Run recipe
+        run: |
+          export EDM_DATA=$BUILD_ENGINE_SERVER/$BUILD_ENGINE_DB
+          python3 -m pip install mdpdf
+          ./ceqr run recipe dep_cats_permits
+
+      - name: Create issue on success
+        if: success()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/ISSUE_TEMPLATE/dep-monthly.md
+
+  create_issue_on_failure:
+    needs: build
+    runs-on: ubuntu-22.04
+    if: ${{ failure() && (github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - name: Create issue on failure
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.workflow }}
+          BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md

--- a/products/ceqr/bin/config.sh
+++ b/products/ceqr/bin/config.sh
@@ -62,6 +62,20 @@ function Upload {
   wait
 }
 
+function Upload_data_operations {
+  STATUS=$(mc stat --json spaces/edm-publishing/datasets/$1/$2 | jq -r '.status')
+  case $STATUS in
+    success) mc rm -r --force spaces/edm-publishing/datasets/$1/$2 ;;
+    error) true ;;
+  esac
+  for file in output/*
+  do
+    name=$(basename $file)
+    mc cp $file spaces/edm-publishing/datasets/$1/$2/$name
+  done
+  wait
+}
+
 function Publish {
   RECIPE=$1
   VERSION=${2:-latest}

--- a/products/ceqr/recipes/dep_cats_permits/build.py
+++ b/products/ceqr/recipes/dep_cats_permits/build.py
@@ -179,7 +179,7 @@ def _output(df: pd.DataFrame):
         "geo_y_coord",
         "geo_function",
     ]
-    df[cols].to_csv(sys.stdout, sep="|", index=False)
+    df[cols].to_csv("output/dep_cats_permits.csv", index=False)
 
 
 def _readme():

--- a/products/ceqr/recipes/dep_cats_permits/create.sql
+++ b/products/ceqr/recipes/dep_cats_permits/create.sql
@@ -55,7 +55,7 @@ CREATE TEMP TABLE dep_cats_permits (
     geo_function text
 );
 
-\COPY dep_cats_permits FROM PSTDIN DELIMITER '|' CSV HEADER;
+\COPY dep_cats_permits FROM 'output/dep_cats_permits.csv' DELIMITER ',' CSV HEADER;
 
 DROP TABLE IF EXISTS :NAME.:"VERSION" CASCADE;
 SELECT 

--- a/products/ceqr/recipes/dep_cats_permits/runner.sh
+++ b/products/ceqr/recipes/dep_cats_permits/runner.sh
@@ -28,7 +28,7 @@ VERSION=$DATE
         # Convert README.md to README.pdf
         mdpdf --output ReadMe_DEPCATS.pdf README.md
     )
-    Upload $NAME $VERSION
-    Upload $NAME latest
+    Upload_data_operations $NAME $VERSION
+    Upload_data_operations $NAME staging
     rm -rf output
 )

--- a/products/ceqr/recipes/dep_cats_permits/runner.sh
+++ b/products/ceqr/recipes/dep_cats_permits/runner.sh
@@ -9,13 +9,13 @@ VERSION=$DATE
     cd $BASEDIR
     mkdir -p output
     python3 build.py
-    psql $EDM_DATA -v NAME=$NAME -v VERSION=$VERSION -f create.sql
+    psql $EDM_DATA --set ON_ERROR_STOP=1 -v NAME=$NAME -v VERSION=$VERSION -f create.sql
 
     (
         cd output
 
         # Export to CSV
-        psql $EDM_DATA -c "\COPY (
+        psql $EDM_DATA --set ON_ERROR_STOP=1 -c "\COPY (
             SELECT * FROM $NAME.\"$VERSION\"
         ) TO stdout DELIMITER ',' CSV HEADER;" > $NAME.csv
 

--- a/products/ceqr/recipes/dep_cats_permits/runner.sh
+++ b/products/ceqr/recipes/dep_cats_permits/runner.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source $(pwd)/bin/config.sh
 BASEDIR=$(dirname $0)
 NAME=$(basename $BASEDIR)
@@ -7,13 +8,7 @@ VERSION=$DATE
 (
     cd $BASEDIR
     mkdir -p output
-
-    docker run --rm\
-        -e EDM_DATA=$EDM_DATA\
-        -v $(pwd)/../:/recipes\
-        -w /recipes/$NAME\
-        --user $UID\
-        nycplanning/docker-geosupport:latest python3 build.py | 
+    python3 build.py
     psql $EDM_DATA -v NAME=$NAME -v VERSION=$VERSION -f create.sql
 
     (
@@ -31,10 +26,7 @@ VERSION=$DATE
         echo "$VERSION" > version.txt
 
         # Convert README.md to README.pdf
-        docker run --rm\
-            -v "`pwd`:/data" \
-            --user `id -u`:`id -g` \
-            pandoc/latex README.md -o ReadMe_DEPCATS.pdf
+        mdpdf --output ReadMe_DEPCATS.pdf README.md
     )
     Upload $NAME $VERSION
     Upload $NAME latest


### PR DESCRIPTION
resolves #639
related to #521

These changes fix the broken github action to build one our CEQR datasets: DEP CATs.

Since this datasets ends up on our CEQR site [here](https://www.ceqr.app/data/air-quality) and the ITD QA team QAs it, these changes ensure the data is uploaded to the new folder `edm-publishing/datasets/dep_cats_permit`.

Runs of github action `ceqr_dep_monthly.yml` from this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/ceqr_dep_monthly.yml)

### outputs in old S3 location

<img width="451" alt="Screenshot 2024-03-26 at 6 53 37 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/99dfd522-6ad8-4fa2-9c85-942ec2374c93">

### outputs in new S3 location

<img width="469" alt="Screenshot 2024-03-26 at 7 13 23 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/6e57d01b-2947-4763-bb2e-597dda325d50">
