### PR TITLE
Add Historic Datasets to Green Fast Track

### DIFF
--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -67,7 +67,7 @@ def get_dataset(dataset: FeatureServer, crs: int) -> dict:
     object_id_resp = query_dataset(dataset, obj_params)
     object_ids = cast(list[int], object_id_resp["properties"]["objectIds"])
 
-    gjson = {"type": "FeatureCollection", "crs": crs, "features": []}
+    features = []
 
     with Progress(
         SpinnerColumn(spinner_name="earth"),
@@ -89,8 +89,6 @@ def get_dataset(dataset: FeatureServer, crs: int) -> dict:
             params["objectIds"] = object_ids[i : i + CHUNK_SIZE]
             chunk = query_dataset(dataset, params)
             progress.update(task, completed=i + CHUNK_SIZE)
-            gjson["features"] += [
-                _downcase_properties_keys(feat) for feat in chunk["features"]
-            ]
+            features += [_downcase_properties_keys(feat) for feat in chunk["features"]]
 
-    return gjson
+    return {"type": "FeatureCollection", "crs": crs, "features": features}

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -37,14 +37,10 @@ class FeatureServer(BaseModel, extra="forbid", use_enum_values=True):
 
 def get_metadata(dataset: FeatureServer) -> dict:
     resp = requests.get(f"{dataset.url}", params={"f": "pjson"})
-    resp.raise_for_status()  # TODO: AR: this didn't seem to work for a 400, which returned
-    # │ │ metadata = {                                       │                       │
-    # │ │            │   'error': {                          │                       │
-    # │ │            │   │   'code': 400,                    │                       │
-    # │ │            │   │   'message': 'Invalid URL',       │                       │
-    # │ │            │   │   'details': ['Invalid URL']      │                       │
-    # │ │            │   }                                   │                       │
-    # │ │            }         return resp.json()
+    resp.raise_for_status()
+    error = resp.json().get("error")  # 200 responses might contain error details
+    if error:
+        raise Exception(f"Error fetching ESRI Server metadata: {error}")
     return resp.json()
 
 

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -85,10 +85,16 @@ def get_dataset(dataset: FeatureServer, crs: int) -> dict:
             f"[green]Downloading [bold]{dataset.name}[/bold]", total=len(object_ids)
         )
 
+        def _downcase_properties_keys(feat):
+            feat["properties"] = {k.lower(): v for k, v in feat["properties"].items()}
+            return feat
+
         for i in range(0, len(object_ids), CHUNK_SIZE):
             params["objectIds"] = object_ids[i : i + CHUNK_SIZE]
             chunk = query_dataset(dataset, params)
             progress.update(task, completed=i + CHUNK_SIZE)
-            gjson["features"] += chunk["features"]
+            gjson["features"] += [
+                _downcase_properties_keys(feat) for feat in chunk["features"]
+            ]
 
     return gjson

--- a/dcpy/library/templates/lpc_scenic_landmarks.yml
+++ b/dcpy/library/templates/lpc_scenic_landmarks.yml
@@ -1,0 +1,31 @@
+dataset:
+  name: lpc_scenic_landmarks
+  acl: public-read
+  source:
+    socrata:
+      uid: qexa-qpj6
+      format: csv
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+      - "GEOM_POSSIBLE_NAMES=the_geom"
+    geometry:
+      SRS: EPSG:4326
+      type: MULTIPOLYGON
+
+  destination:
+    geometry:
+      SRS: EPSG:4326
+      type: MULTIPOLYGON
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: >
+      Provides boundary information regarding all scenic landmarks that have been calendared,
+      heard, or designated by the Landmarks Preservation Commission, or for which an LP number has been issued.
+    url: "https://data.cityofnewyork.us/Housing-Development/Scenic-Landmarks/qexa-qpj6/about_data"
+    dependents: []

--- a/dcpy/library/templates/nysshpo_archaeological_buffer_areas.yml
+++ b/dcpy/library/templates/nysshpo_archaeological_buffer_areas.yml
@@ -1,0 +1,22 @@
+dataset:
+  name: nysshpo_archaeological_buffer_areas
+  acl: public-read
+  source:
+    arcgis_feature_server:
+      server: nys_parks
+      name: Archaeological_Buffer_Areas
+      layer: 14
+    geometry:
+      SRS: EPSG:3857
+      type: MULTIPOLYGON
+
+  destination:
+    geometry:
+      SRS: EPSG:2263
+      type: MULTIPOLYGON
+
+  info:
+    description: |
+      ## Buffer areas that are a specified distance around archaeological sites that SHPO has inventoried.
+      This feature class comprises areas that are a specified distance around archaeological sites that SHPO has inventoried.
+    url: https://services.arcgis.com/1xFZPtKn1wKC6POA/ArcGIS/rest/services/Archaeological_Buffer_Areas/FeatureServer/14

--- a/dcpy/library/templates/nysshpo_register_historic_places.yml
+++ b/dcpy/library/templates/nysshpo_register_historic_places.yml
@@ -1,0 +1,37 @@
+dataset:
+  name: nysshpo_register_historic_places
+  acl: public-read
+  source:
+    url:
+      path: https://data.ny.gov/resource/iisn-hnyv.csv
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+      - "GEOM_POSSIBLE_NAMES=Georeference"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: >
+      The New York State Office of Parks, Recreation and Historic Preservation (OPRHP)
+      oversees more than 250 state parks, historic sites, recreational trails, golf courses,
+      boat launches and more, encompassing nearly 350,000 acres, that are visited by 74
+      million people annually. These facilities contribute to the economic vitality and
+      quality of life of local communities and directly support New York’s tourism industry.
+      Parks also provide a place for families and children to be active and exercise, promoting
+      healthy lifestyles. The agency is responsible for the operation and stewardship of
+      the state park system as well as advancing a statewide parks, historic preservation, and open space mission.
+    url: https://health.data.ny.gov/api/views/iisn-hnyv/rows.csv
+    dependents: []

--- a/products/green_fast_track/recipe.yml
+++ b/products/green_fast_track/recipe.yml
@@ -18,6 +18,7 @@ inputs:
     - name: dcp_lion
     # historic
     - name: lpc_landmarks
+    - name: lpc_scenic_landmarks
     # Other
     - name: dcp_edesignation_csv
   missing_versions_strategy: find_latest

--- a/products/green_fast_track/recipe.yml
+++ b/products/green_fast_track/recipe.yml
@@ -16,6 +16,8 @@ inputs:
     - name: panynj_lga_65db
     - name: dcm_arterial_highways
     - name: dcp_lion
+    # historic
+    - name: lpc_landmarks
     # Other
     - name: dcp_edesignation_csv
   missing_versions_strategy: find_latest

--- a/products/green_fast_track/recipe.yml
+++ b/products/green_fast_track/recipe.yml
@@ -19,6 +19,7 @@ inputs:
     # historic
     - name: lpc_landmarks
     - name: lpc_scenic_landmarks
+    - name: nysshpo_register_historic_places
     # Other
     - name: dcp_edesignation_csv
   missing_versions_strategy: find_latest


### PR DESCRIPTION
Adds a few Green Fast Track datasets, and fixes some issues with the ESRI connector. (specifics in the commit message bodies) 

Most importantly, feeding geojson with mixed case column names to gdal causes those columns to be null in the output format. 