### PR TITLE
GFT: Add shadows recipes

### DIFF
--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -15,11 +15,15 @@ from rich.progress import (
 class Server(StrEnum):
     nys_clearinghouse = "nys_clearinghouse"
     nys_parks = "nys_parks"
+    nps = "nps"
+    nyc = "nyc"
 
 
 servers = {
     "nys_clearinghouse": {"id": "DZHaqZm9cxOD4CWM", "subdomain": "services6"},
     "nys_parks": {"id": "1xFZPtKn1wKC6POA"},
+    "nps": {"id": "fBc8EJBxQRMcHlei", "subdomain": "services1"},
+    "nyc": {"id": "GfwWNkhOj9bNBqoJ", "subdomain": "services5"},
 }
 
 

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -16,14 +16,14 @@ class Server(StrEnum):
     nys_clearinghouse = "nys_clearinghouse"
     nys_parks = "nys_parks"
     nps = "nps"
-    nyc = "nyc"
+    dcp = "dcp"
 
 
 servers = {
     "nys_clearinghouse": {"id": "DZHaqZm9cxOD4CWM", "subdomain": "services6"},
     "nys_parks": {"id": "1xFZPtKn1wKC6POA"},
     "nps": {"id": "fBc8EJBxQRMcHlei", "subdomain": "services1"},
-    "nyc": {"id": "GfwWNkhOj9bNBqoJ", "subdomain": "services5"},
+    "dcp": {"id": "GfwWNkhOj9bNBqoJ", "subdomain": "services5"},
 }
 
 

--- a/dcpy/library/templates/dcp_waterfront_access_map_pow.yml
+++ b/dcpy/library/templates/dcp_waterfront_access_map_pow.yml
@@ -1,0 +1,33 @@
+dataset:
+  name: dcp_waterfront_access_map_pow
+  acl: public-read
+  source:
+    arcgis_feature_server:
+      server: nyc
+      name: nypubliclyownedwaterfront
+      layer: 0
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:2263
+      type: POLYGON
+
+  destination:
+    geometry:
+      SRS: EPSG:2263
+      type: POLYGON
+    options:
+      - "PRECISION=NO"
+      - "OVERWRITE=YES"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Publicly Owned Waterfront
+
+      City, State, and Federally owned public parks and facilities that provide waterfront parkland and open space for public enjoyment.
+    url: https://www.nyc.gov/site/planning/data-maps/open-data/dwn-waterfront.page
+    dependents: []

--- a/dcpy/library/templates/dcp_waterfront_access_map_pow.yml
+++ b/dcpy/library/templates/dcp_waterfront_access_map_pow.yml
@@ -3,7 +3,7 @@ dataset:
   acl: public-read
   source:
     arcgis_feature_server:
-      server: nyc
+      server: dcp
       name: nypubliclyownedwaterfront
       layer: 0
     options:

--- a/dcpy/library/templates/dcp_waterfront_access_map_wpaa.yml
+++ b/dcpy/library/templates/dcp_waterfront_access_map_wpaa.yml
@@ -1,0 +1,33 @@
+dataset:
+  name: dcp_waterfront_access_map_wpaa
+  acl: public-read
+  source:
+    arcgis_feature_server:
+      server: nyc
+      name: nywpaa_accesspoints
+      layer: 0
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:2263
+      type: POINT
+
+  destination:
+    geometry:
+      SRS: EPSG:2263
+      type: POINT
+    options:
+      - "PRECISION=NO"
+      - "OVERWRITE=YES"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Waterfront Public Access Areas (WPAAs)
+
+      Waterfront Public Access Areas (WPAAs) are privately owned waterfront zoning lots where publicly accessible open space is provided to and along the shoreline for public enjoyment.
+    url: https://www.nyc.gov/site/planning/data-maps/open-data/dwn-waterfront.page
+    dependents: []

--- a/dcpy/library/templates/dcp_waterfront_access_map_wpaa.yml
+++ b/dcpy/library/templates/dcp_waterfront_access_map_wpaa.yml
@@ -3,7 +3,7 @@ dataset:
   acl: public-read
   source:
     arcgis_feature_server:
-      server: nyc
+      server: dcp
       name: nywpaa_accesspoints
       layer: 0
     options:

--- a/dcpy/library/templates/nysparks_parks_polygons.yml
+++ b/dcpy/library/templates/nysparks_parks_polygons.yml
@@ -1,0 +1,34 @@
+dataset:
+  name: nysparks_parks_polygons
+  acl: public-read
+  source:
+    arcgis_feature_server:
+      server: nys_parks
+      name: NYS_Park_Polygons
+      layer: 0
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:26918
+      type: POLYGON
+
+  destination:
+    geometry:
+      SRS: EPSG:4326
+      type: POLYGON
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## New York State Office of Parks, Recreation and Historic Preservation Property
+
+      This service contains the NY state park boundary polygon data, current to August 2022.  Data is updated on a regular basis and should be requested from NY State Parks if current data is needed for your project.
+      All boundaries are shown as approximate.
+    url: https://data.gis.ny.gov/datasets/nysparks::ny-state-parks-property/about
+    dependents: []

--- a/dcpy/library/templates/usnps_parks.yml
+++ b/dcpy/library/templates/usnps_parks.yml
@@ -2,14 +2,15 @@ dataset:
   name: usnps_parks
   acl: public-read
   source:
-    url:
-      path: s3://edm-recipes/inbox/usnps/{{ version }}/Administrative_Boundaries_of_National_Park_System_Units.zip
-      subpath: Administrative_Boundaries_of_National_Park_System_Units/Administrative_Boundaries_of_National_Park_System_Units.shp
+    arcgis_feature_server:
+      server: nps
+      name: NPS_Land_Resources_Division_Boundary_and_Tract_Data_Service
+      layer: 2
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4269
+      SRS: EPSG:3857
       type: POLYGON
 
   destination:
@@ -30,5 +31,7 @@ dataset:
       NPS Director's Order #25 states: "Land status maps will be prepared to identify the ownership of the lands within the authorized boundaries of the park unit. These maps, showing ownership and acreage, are the 'official record' of the acreage of Federal and non-federal lands within the park boundaries. While these maps are the official record of the lands and acreage within the unit's authorized boundaries, they are not of survey quality and not intended to be used for survey purposes." As such this data is intended for use as a tool for GIS analysis. It is in no way intended for engineering or legal purposes. The data accuracy is checked against best available sources which may be dated and vary by location. NPS assumes no liability for use of this data. The boundary polygons LRD creates represent the current legislated boundary of a given NPS unit. NPS does not necessarily have full fee ownership or hold another interest (easement, right of way, etc...) in all parcels contained within this boundary. Equivalently NPS may own or have an interest in parcels outside the legislated boundary of a given unit. In order to obtain complete information about current NPS interests both inside and outside the units legislated boundary, the tracts file created by LRD should be used in conjunction with this boundary file created by LRD.
 
       DATA IS UPDATED ON A QUARTERLY BASIS
-    url: https://irma.nps.gov/DataStore/Reference/Profile/2302064
+
+      NOTE: we changed the data source on 3/15/2024.
+    url: https://public-nps.opendata.arcgis.com/datasets/nps::nps-boundary-1/about
     dependents: []

--- a/products/green_fast_track/recipe.yml
+++ b/products/green_fast_track/recipe.yml
@@ -23,6 +23,13 @@ inputs:
     - name: nysshpo_register_historic_places
     - name: nysshpo_historic_buildings_points
     - name: nysshpo_historic_buildings_polygons
+    # Shadows
+    - name: dpr_parksproperties
+    - name: dcp_pops
+    - name: dcp_waterfront_access_map_wpaa
+    - name: dcp_waterfront_access_map_pow
+    - name: nysparks_parks_polygons
+    - name: usnps_parks
     # Other
     - name: dcp_edesignation_csv
   missing_versions_strategy: find_latest


### PR DESCRIPTION
Fixes #674.

### Notes: 
* For [WPAA / Public Waterfront](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-waterfront.page), we need 2 layers, `WAM_wpaa` & `WAM_publicly_owned_waterfront`. The original plan was to: 
    * 1) create 2 recipes and 
    * 2) download 1 shapefile/geodabase and use a subpath to the needed layers. 

    I decided to use the ArcGis connector to individual layers instead because it's reduces the need to download a file locally and we don't need to specify a version. Perhaps we can use the same approach for other Bytes recipes.

* Created #690 issue to investigate potentially duplicated recipes. Not relevant to this PR or GFT.

### Feedback needed on:
* Recipe names for waterfront access datasets. Currently named as `dcp_waterfront_access_map_pow` & `dcp_waterfront_access_map_wpaa`