### PR TITLE
ensure all GFT source data is exported

### DIFF
--- a/products/green_fast_track/bash/export.sh
+++ b/products/green_fast_track/bash/export.sh
@@ -20,10 +20,13 @@ mkdir -p output && (
 
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__airports sources__airports ${default_srs} -update
 
+    fgdb_export_partial ${fgdb_filename} MULTILINESTRING sources__arterial_highways sources__arterial_highways ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__arterial_highways_buffers sources__arterial_highways_buffers ${default_srs} -update
 
+    fgdb_export_partial ${fgdb_filename} MULTILINESTRING sources__elevated_railways sources__elevated_railways ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__elevated_railways_buffers sources__elevated_railways_buffers ${default_srs} -update
     
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__vent_towers sources__vent_towers ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__vent_towers_buffers sources__vent_towers_buffers ${default_srs} -update
 
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__industrial_sources_lots sources__industrial_sources_lots ${default_srs} -update

--- a/products/green_fast_track/models/product/sources/_sources_models.yml
+++ b/products/green_fast_track/models/product/sources/_sources_models.yml
@@ -3,10 +3,13 @@ version: 2
 models:
   - name: sources__airports
 
+  - name: sources__arterial_highways
   - name: sources__arterial_highways_buffers
 
+  - name: sources__elevated_railways
   - name: sources__elevated_railways_buffers
 
+  - name: sources__vent_towers
   - name: sources__vent_towers_buffers
 
   - name: sources__industrial_sources_lots

--- a/products/green_fast_track/models/product/sources/sources__arterial_highways.sql
+++ b/products/green_fast_track/models/product/sources/sources__arterial_highways.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    ST_MULTI(raw_geom) AS raw_geom
+FROM {{ ref('int_buffers__dcm_arterial_highways') }}

--- a/products/green_fast_track/models/product/sources/sources__elevated_railways.sql
+++ b/products/green_fast_track/models/product/sources/sources__elevated_railways.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    ST_MULTI(raw_geom) AS raw_geom
+FROM {{ ref('int_buffers__elevated_railways') }}

--- a/products/green_fast_track/models/product/sources/sources__vent_towers.sql
+++ b/products/green_fast_track/models/product/sources/sources__vent_towers.sql
@@ -1,0 +1,5 @@
+SELECT
+    variable_type,
+    variable_id,
+    raw_geom
+FROM {{ ref('int_buffers__dcp_air_quality_vent_towers') }}


### PR DESCRIPTION
resolves https://github.com/NYCPlanning/edm-overview/issues/1029

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-gft-exports)

## table lineage screenshots

focus on `green_fast_track_bbls`:
![Screenshot 2024-03-19 at 4 30 48 PM](https://github.com/NYCPlanning/data-engineering/assets/7444289/be6fe04f-0b62-4b57-9973-f676df995036)

focus on one of the new exported sources `sources__elevated_railways`:
![Screenshot 2024-03-19 at 4 32 18 PM](https://github.com/NYCPlanning/data-engineering/assets/7444289/a364e679-ea7c-47dd-bc42-06707897e7d9)
