### PR TITLE
improve GFT tests

### DIFF
--- a/products/green_fast_track/bash/export.sh
+++ b/products/green_fast_track/bash/export.sh
@@ -14,7 +14,6 @@ mkdir -p output && (
     cp ../source_data_versions.csv .
     cp ../build_metadata.json .
     
-    # TODO export all relevant source data (e.g. buffered and original geometries of Title V permits)
     echo "Generate FileGeodatabase ${fgdb_filename}"
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON green_fast_track_bbls green_fast_track_bbls ${default_srs}
 

--- a/products/green_fast_track/models/intermediate/buffers/_buffers_models.yml
+++ b/products/green_fast_track/models/intermediate/buffers/_buffers_models.yml
@@ -5,10 +5,10 @@ models:
     description: Union of all buffered flag tables
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
       - name: raw_geom
         tests:
@@ -21,10 +21,10 @@ models:
   - name: int_buffers__dcm_arterial_highways
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -39,10 +39,10 @@ models:
       Buffered geometries for lots with potenitally unpermitted industrial emissions based on land use
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -56,10 +56,10 @@ models:
     description: Buffered geometries for cats permits
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -73,10 +73,10 @@ models:
     description: Buffered geometries for elevated/exposed railways
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
       - name: raw_geom
         tests:
@@ -89,10 +89,10 @@ models:
     description: Buffered geometries for state facility permits
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -106,10 +106,10 @@ models:
     description: Buffered geometries for title V facility permits
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -122,10 +122,10 @@ models:
   - name: int_buffers__dcp_air_quality_vent_towers
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -139,10 +139,10 @@ models:
     description: Buffered geometries for selected NYC Parks owned properties
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -156,10 +156,10 @@ models:
     description: Buffered geometries for tax lots with POPS
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -173,10 +173,10 @@ models:
     description: Buffered geometries for Publicly Owned Waterfront (pow) areas
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -190,10 +190,10 @@ models:
     description: Buffered geometries for Waterfront Public Access Areas (wpaa)
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -207,10 +207,10 @@ models:
     description: Buffered geometries for NYS Parks owned properties
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom
@@ -224,10 +224,10 @@ models:
     description: Buffered geometries for Federal Parks owned properties
     columns:
       - name: variable_type
-        test:
+        tests:
           - not_null
       - name: variable_id
-        test:
+        tests:
           - not_null
           - unique
       - name: raw_geom

--- a/products/green_fast_track/models/intermediate/flags/_flags_models.yml
+++ b/products/green_fast_track/models/intermediate/flags/_flags_models.yml
@@ -12,6 +12,9 @@ models:
         data_type: string
         tests:
           - not_null
+          - dbt_expectations.expect_column_distinct_values_to_equal_set:
+              name: int_flags__all_variable_type_set
+              value_set: '{{ dbt_utils.get_column_values(table=ref("variables"), column="variable_type") }}'
       - name: variable_id
         data_type: string
         tests:

--- a/products/green_fast_track/models/intermediate/flags/_flags_models.yml
+++ b/products/green_fast_track/models/intermediate/flags/_flags_models.yml
@@ -6,15 +6,15 @@ models:
     columns:
       - name: bbl
         data_type: string
-        test:
+        tests:
           - not_null
       - name: variable_type
         data_type: string
-        test:
+        tests:
           - not_null
       - name: variable_id
         data_type: string
-        test:
+        tests:
           - not_null
       - name: distance
         data_type: float
@@ -30,15 +30,15 @@ models:
     columns:
       - name: bbl
         data_type: string
-        test:
+        tests:
           - not_null
       - name: variable_type
         data_type: string
-        test:
+        tests:
           - not_null
       - name: variable_id
         data_type: string
-        test:
+        tests:
           - not_null
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -55,10 +55,10 @@ models:
       tests:
         - not_null
     - name: variable_type
-      test:
+      tests:
         - not_null
     - name: variable_id
-      test:
+      tests:
         - not_null
 
   - name: int_flags__spatial
@@ -68,19 +68,19 @@ models:
     columns:
       - name: bbl
         data_type: string
-        test:
+        tests:
           - not_null
       - name: variable_type
         data_type: string
-        test:
+        tests:
           - not_null
       - name: variable_id
         data_type: string
-        test:
+        tests:
           - not_null
       - name: distance
         data_type: float
-        test:
+        tests:
           - not_null
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/products/green_fast_track/models/intermediate/flags/_flags_models.yml
+++ b/products/green_fast_track/models/intermediate/flags/_flags_models.yml
@@ -15,6 +15,8 @@ models:
           - dbt_expectations.expect_column_distinct_values_to_equal_set:
               name: int_flags__all_variable_type_set
               value_set: '{{ dbt_utils.get_column_values(table=ref("variables"), column="variable_type") }}'
+              config:
+                severity: warn
       - name: variable_id
         data_type: string
         tests:

--- a/products/green_fast_track/packages.yml
+++ b/products/green_fast_track/packages.yml
@@ -1,3 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.1.1
+  - package: calogica/dbt_expectations
+    version: 0.10.3


### PR DESCRIPTION
related to #664 

This adds a new test which checks that all defined GFT variables appear in the model `int_flags__all`.

Link [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8482365421/job/23241473450#step:7:502) to the test (accurately) failing.

Screenshot below shows outputs of the test (accurately) failing because we recently added Shadows data and aren't using it yet.

<img width="698" alt="Screenshot 2024-03-29 at 3 57 59 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/f1a9ee99-9a23-4486-bb90-f79aa2b5ba42">

![Screenshot 2024-03-29 at 10 33 54 AM](https://github.com/NYCPlanning/data-engineering/assets/7444289/043b122c-8717-4369-b75d-99f8f6806570)