### PR TITLE
clean up python reqs, dcpy install

### DIFF
--- a/bash/docker_container_setup.sh
+++ b/bash/docker_container_setup.sh
@@ -11,6 +11,6 @@ else
     export workspace=/__w/data-engineering/data-engineering
 fi 
 
-python3 -m pip install $option . -c ./python/constraints.txt
+python3 -m pip install $option . -c ./python/constraints.txt --no-deps
 
 git config --global --add safe.directory $workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ requires-python = ">=3.11"
 dependencies = [
     "beautifulsoup4",
     "boto3",
-    "botocore",
     "faker",
     "GDAL",
     "geopandas",
@@ -111,19 +110,17 @@ dependencies = [
     "openpyxl",
     "pandas",
     "psycopg2_binary",
+    "pyarrow",
     "pydantic",
     "python-dotenv",
-    "python_dateutil",
     "pytz",
     "PyYAML",
     "rich",
-    "setuptools",
     "SQLAlchemy",
     "typer",
     "urllib3",
     "usaddress",
     "xlrd",
-    "pyarrow",
 ]
 
 [tool.setuptools.packages.find]

--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -46,9 +46,7 @@ botocore==1.34.79
     #   moto
     #   s3transfer
 botocore-stubs==1.34.69
-    # via
-    #   -r python/requirements.in
-    #   boto3-stubs
+    # via boto3-stubs
 bqplot==0.12.43
     # via leafmap
 branca==0.7.1
@@ -254,7 +252,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.3.2
+joblib==1.4.0
     # via
     #   contextily
     #   scikit-learn
@@ -312,7 +310,7 @@ minimal-snowplow-tracker==0.0.2
     # via dbt-core
 more-itertools==10.2.0
     # via dbt-semantic-interfaces
-moto==5.0.4
+moto==5.0.5
     # via -r python/requirements.in
 msal==1.23.0
     # via -r python/requirements.in
@@ -432,7 +430,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-py-partiql-parser==0.5.2
+py-partiql-parser==0.5.4
     # via moto
 pyarrow==15.0.2
     # via

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -2,7 +2,6 @@ black==23.1.0
 beautifulsoup4>=4.9.3
 boto3>=1.28.1
 boto3-stubs[s3]>=1.28.1
-botocore-stubs
 cached-property==1.5.2
 contextily==1.3.0
 dbt-postgres
@@ -41,8 +40,8 @@ PyYAML>=6.0.1
 types-PyYAML>=6.0.1
 rich>=13.4.2
 socrata-py==1.1.13
-sqlalchemy-stubs==0.4
 sqlalchemy==2.0.15
+sqlalchemy-stubs==0.4
 sqlfluff @ git+https://github.com/fvankrieken/sqlfluff@main
 sqlfluff-templater-dbt
 streamlit==1.*

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -46,9 +46,7 @@ botocore==1.34.79
     #   moto
     #   s3transfer
 botocore-stubs==1.34.69
-    # via
-    #   -r python/requirements.in
-    #   boto3-stubs
+    # via boto3-stubs
 bqplot==0.12.43
     # via leafmap
 branca==0.7.1
@@ -254,7 +252,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.3.2
+joblib==1.4.0
     # via
     #   contextily
     #   scikit-learn
@@ -312,7 +310,7 @@ minimal-snowplow-tracker==0.0.2
     # via dbt-core
 more-itertools==10.2.0
     # via dbt-semantic-interfaces
-moto[s3]==5.0.4
+moto[s3]==5.0.5
     # via -r python/requirements.in
 msal==1.23.0
     # via -r python/requirements.in
@@ -432,7 +430,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-py-partiql-parser==0.5.2
+py-partiql-parser==0.5.4
     # via moto
 pyarrow==15.0.2
     # via


### PR DESCRIPTION
Had an odd failed job [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8602897170/job/23573973198)

Couple things going on. For some reason, during dcpy install in container, it's uninstalling and reinstalling some python packages. On top of this, python isn't finding those packages when trying to use them.

I thought there might be some weird dependency issue causing the need/desire from pip to reinstall them, so I tried to clean up the requirements. This doesn't seem to have made a change, so I'm trying to force `--no-deps` when installing dcpy in the build image. Going to run a test build to see if this resolves issue

[Issue resolved now](https://github.com/NYCPlanning/data-engineering/actions/runs/8603394140/job/23575198124)