### PR TITLE
add gdal to build image requirements

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - python/**
+      - docker/**
+      - pyproject.toml
   workflow_dispatch:
     inputs:
       base:

--- a/docker/build-base/requirements.txt
+++ b/docker/build-base/requirements.txt
@@ -2,6 +2,7 @@ boto3
 census
 contextily
 dbt-postgres
+gdal
 geoalchemy2
 geopandas
 Jinja2

--- a/docker/build-geosupport/requirements.txt
+++ b/docker/build-geosupport/requirements.txt
@@ -1,6 +1,7 @@
 boto3
 census
 contextily
+gdal
 geoalchemy2
 geopandas
 Jinja2


### PR DESCRIPTION
Fix's @alexrichey issue of no gdal in the build containers. They do currently install dcpy's reqs in addition to their own req.txts, but I had to take gdal out of dcpy's reqs for some weirdness - to get this install working, I use piptools to compile dcpy's reqs using our constraints.txt. However, this fails if gdal binary isn't installed (if we did it outside of the build images before building them in an action), and for some reason hangs indefinitely when done as part of the docker image build (3+ hours). Simple enough to just have all dcpy reqs defined except gdal, and have the build images explicitly install it. Just weird