### PR TITLE
GFT: update wpaa source and logic

### DIFF
--- a/dcpy/library/templates/dcp_waterfront_access_map_wpaa.yml
+++ b/dcpy/library/templates/dcp_waterfront_access_map_wpaa.yml
@@ -4,19 +4,19 @@ dataset:
   source:
     arcgis_feature_server:
       server: dcp
-      name: nywpaa_accesspoints
+      name: nywpaa
       layer: 0
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
       SRS: EPSG:2263
-      type: POINT
+      type: POLYGON
 
   destination:
     geometry:
       SRS: EPSG:2263
-      type: POINT
+      type: POLYGON
     options:
       - "PRECISION=NO"
       - "OVERWRITE=YES"

--- a/products/green_fast_track/bash/export.sh
+++ b/products/green_fast_track/bash/export.sh
@@ -59,7 +59,7 @@ mkdir -p output && (
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__waterfront_access_pow sources__waterfront_access_pow ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__waterfront_access_pow_buffers sources__waterfront_access_pow_buffers ${default_srs} -update
 
-    fgdb_export_partial ${fgdb_filename} MULTIPOINT sources__waterfront_access_wpaa sources__waterfront_access_wpaa ${default_srs} -update
+    fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__waterfront_access_wpaa sources__waterfront_access_wpaa ${default_srs} -update
     fgdb_export_partial ${fgdb_filename} MULTIPOLYGON sources__waterfront_access_wpaa_buffers sources__waterfront_access_wpaa_buffers ${default_srs} -update
 
     fgdb_export_partial ${fgdb_filename} NONE variables variables ${default_srs} -update

--- a/products/green_fast_track/models/_sources.yml
+++ b/products/green_fast_track/models/_sources.yml
@@ -179,21 +179,16 @@ sources:
           - name: wpaa_id
             tests:
               - not_null
-          - name: wpaa_name
+              - unique
+          - name: name
             tests:
               - not_null
           - name: wkb_geometry
             tests:
               - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: dcp_waterfront_access_map_wpaa_compound_key
-              combination_of_columns:
-                - wpaa_id
-                - wpaa_name
-                - wkb_geometry
-              config:
-                severity: warn
+          - name: status
+            tests:
+              - not_null
 
       - name: dcp_waterfront_access_map_pow
         columns:
@@ -253,7 +248,6 @@ sources:
                 - wkt
               config:
                 severity: warn
-              
 
       - name: dcp_beaches
         columns:

--- a/products/green_fast_track/models/staging/stg__waterfront_access_wpaa.sql
+++ b/products/green_fast_track/models/staging/stg__waterfront_access_wpaa.sql
@@ -9,7 +9,8 @@ final AS (
     SELECT
         'waterfront_access_wpaa' AS variable_type,
         wpaa_id,
-        wpaa_name,
+        name,
+        status,
         st_transform(wkb_geometry, 2263) AS raw_geom
     FROM source
 


### PR DESCRIPTION
Per [this](https://github.com/NYCPlanning/data-engineering/issues/664#issuecomment-2046042495) comment, logic for `wpaa` variable needed additional twists. This PR addresses both "todo" bullet points in the comment.

The following has been implemented:
- [x] update wpaa template with correct source
- [x] update wpaa staging table with correct columns
- [x] filter wpaa for status in buffer intermediate table
- [x] update export geometry for wpaa dataset (previously it was point geom, the new dataset is in polygon)


#### Note
1. Old and new `wpaa` datasets have different geometry types. If I updated `latest` version with new data in recipes, it would yield issues in other ongoing PRs related to GFT. Therefore, I pulled new wpaa data without updating `latest` and fixed the wpaa version in GFT recipe file to work on this PR. Once PR is done: 
    - [x] run data library to update `latest` version for wpaa dataset in recipes
    - [x] remove commit that fixes wpaa version in GFT recipe

2. There is one failing pytest in `dcpy/library`. I didn't touch `dcpy` in this PR, so not sure what it is. The failure should be addressed in a different PR.

#### Successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8666031483/job/23765991635)