### PR TITLE
GFT: Modify test for NYC Properties source

### DIFF
--- a/products/green_fast_track/seeds/nyc_parks_properties_categories.csv
+++ b/products/green_fast_track/seeds/nyc_parks_properties_categories.csv
@@ -23,3 +23,5 @@ Schoolyard (Playground),TRUE
 Tracking Only, FALSE
 Retired, FALSE
 Pending Acquisition, FALSE
+Operations, FALSE
+Retired N/A, FALSE


### PR DESCRIPTION
### Motivation
Nightly QA [failed](https://github.com/NYCPlanning/data-engineering/actions/runs/8683699995/job/23810123325) for Green Fast Track data product. A source data test failed for DPR Park Properties because new unexpected values in the `typecategory` column were detected. These new values are: `Operations` & `Retired N/A`. 

### Solution
Add the new values to the seed csv file with expected `typecategory` values. Successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8691809329/job/23834934531)

### 🚨 Action needed
@croswell81 & @jackrosacker, tagging both of you here. It seems that [DPR Park Properties](https://data.cityofnewyork.us/Recreation/Parks-Properties/enfh-gkve/about_data) added new values in the `typecategory` column which we use for filtering records in GFT. These values are not in their data [dictionary](https://docs.google.com/document/d/1NExNJF5YKID04oOopi0fHainRuGG3Pz_jKSrMujPsPk/edit). Could you please confirm we should exclude DPR Park records with the values `Operations` & `Retired N/A`?

Edit: `typecategory` column, not `subcategory`