### PR TITLE
Get publishing version from build metadata

### DIFF
--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -50,6 +50,7 @@ def test_upload(create_buckets, create_temp_filesystem, mock_data_constants):
 
 
 def test_publish(create_buckets, create_temp_filesystem, mock_data_constants):
+    """Tests publish function as well as get_version and get_latest_version"""
     data_path = mock_data_constants["TEST_DATA_DIR"]
     publishing.upload(output_path=data_path, draft_key=draft_key, acl=TEST_ACL)
     publishing.publish(draft_key=draft_key, acl=TEST_ACL)

--- a/products/colp/bash/04_export.sh
+++ b/products/colp/bash/04_export.sh
@@ -13,7 +13,7 @@ mkdir -p output && (
     cp ../source_data_versions.csv .
     cp ../build_metadata.json .
 
-    echo "[$(date)] ${DATE}" > version.txt
+    echo "${DATE}" > version.txt
 )
 
 mkdir -p output/qaqc && (

--- a/products/developments/bash/05_export.sh
+++ b/products/developments/bash/05_export.sh
@@ -93,7 +93,7 @@ mkdir -p output
     display "Export source data versions and build metadata"
     csv_export source_data_versions
     cp ../build_metadata.json ./
-    echo "[$(date)] ${VERSION}" > version.txt
+    echo "${VERSION}" > version.txt
 
 )
 

--- a/products/pluto/pluto_build/06_export.sh
+++ b/products/pluto/pluto_build/06_export.sh
@@ -19,8 +19,7 @@ ls | grep -v pluto_changes.zip | xargs rm
 cp ../../source_data_versions.csv ./
 cp ../../build_metadata.json ./
 
-echo "version: ${VERSION}" > version.txt
-echo "date: ${DATE}" >> version.txt
+echo "${VERSION}" > version.txt
 
 echo "Exporting gdbs and shapefiles"
 


### PR DESCRIPTION
Pretty self explanatory - get version from build_metadata.json instead of from version.txt.

Figure we'll still keep the version.txt, it's nice to have. But also have it be consistent across products now