### PR TITLE
Ingest: Clean up & Simplify Tests

### DIFF
--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -1,5 +1,4 @@
 from pathlib import Path
 
 TMP_DIR = Path("tmp")
-PARQUET_PATH = Path("tmp") / "tmp.parquet"
 TEMPLATE_DIR = Path(__file__).parent / "templates"

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -11,11 +11,13 @@ def run(dataset: str, version: str | None = None):
     extract.download_file_from_source(
         config.source, config.raw_filename, config.version
     )
+    file_path = TMP_DIR / config.raw_filename
 
     # archive to edm-recipes/raw_datasets
-    recipes.archive_raw_dataset(config, TMP_DIR / config.raw_filename)
+    recipes.archive_raw_dataset(config, file_path)
 
-    transform.to_parquet(config)
+    # convert raw data to parquet format
+    transform.to_parquet(config.file_format, file_path)
 
     ## logic to apply transformations based on parsed config/template. Something like this
     # for step in config.processing.steps:

--- a/dcpy/lifecycle/ingest/templates/bpl_libraries.yml
+++ b/dcpy/lifecycle/ingest/templates/bpl_libraries.yml
@@ -6,7 +6,7 @@ source:
   endpoint: https://www.bklynlibrary.org/locations/json
   format: json
 file_format:
-  format: json # TODO: implement json as a format for transform.to_parquet
+  type: json # TODO: implement json as a format for transform.to_parquet
 
 library_dataset:
   name: bpl_libraries

--- a/dcpy/lifecycle/ingest/templates/dca_operatingbusinesses.yml
+++ b/dcpy/lifecycle/ingest/templates/dca_operatingbusinesses.yml
@@ -6,7 +6,7 @@ source:
   uid: w7w3-xahh
   format: csv
 file_format:
-  format: csv
+  type: csv
   geometry:
     geom_column: location
     crs: EPSG:4326

--- a/dcpy/lifecycle/ingest/templates/dcp_addresspoints.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_addresspoints.yml
@@ -5,7 +5,7 @@ source:
   name: dcp_address_points
 file_format:
   unzipped_filename: dcp_address_points.shp
-  format: shapefile
+  type: shapefile
   crs: EPSG:2263
 
 library_dataset:

--- a/dcpy/lifecycle/ingest/templates/dcp_atomicpolygons.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_atomicpolygons.yml
@@ -5,7 +5,7 @@ source:
   url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyap_{{ version }}.zip
 file_format:
   unzipped_filename: nyap_{{ version }}/nyap.shp
-  format: shapefile
+  type: shapefile
   crs: EPSG:2263
 
 library_dataset:

--- a/dcpy/lifecycle/ingest/templates/dcp_pad.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_pad.yml
@@ -4,7 +4,7 @@ source:
   type: file_download
   url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pad_{{ version }}.zip
 file_format:
-  format: csv # TODO: this is not exactly correct. Need to think how to convert to parquet
+  type: csv # TODO: this is not exactly correct. Need to think how to convert to parquet
 
 library_dataset:
   name: dcp_pad

--- a/dcpy/lifecycle/ingest/templates/doe_pepmeetingurls.yml
+++ b/dcpy/lifecycle/ingest/templates/doe_pepmeetingurls.yml
@@ -5,7 +5,7 @@ source:
   connector: dummy
   function: dummy
 file_format:
-  format: csv
+  type: csv
 
 library_dataset:
   name: doe_pepmeetingurls

--- a/dcpy/lifecycle/ingest/templates/fisa_capitalcommitments.yml
+++ b/dcpy/lifecycle/ingest/templates/fisa_capitalcommitments.yml
@@ -4,7 +4,7 @@ source:
   type: local_file
   path: .library/upload/AICP_OREQ_CAPPLN_PJCP.asc
 file_format:
-  format: csv # TODO: this is not exactly correct. Need to think how to convert to parquet
+  type: csv # TODO: this is not exactly correct. Need to think how to convert to parquet
 
 library_dataset:
   name: fisa_capitalcommitments

--- a/dcpy/lifecycle/ingest/templates/nysdoh_nursinghomes.yml
+++ b/dcpy/lifecycle/ingest/templates/nysdoh_nursinghomes.yml
@@ -6,7 +6,7 @@ source:
   uid: izta-vnpq
   format: csv
 file_format:
-  format: csv
+  type: csv
   geometry:
     geom_column: Location
     crs: EPSG:4326

--- a/dcpy/lifecycle/ingest/templates/nysed_nonpublicenrollment.yml
+++ b/dcpy/lifecycle/ingest/templates/nysed_nonpublicenrollment.yml
@@ -4,7 +4,7 @@ source:
   type: file_download
   url: https://www.p12.nysed.gov/irs/statistics/nonpublic/enrollment-by-grade-nonpublic-{{ version }}.xlsx
 file_format:
-  format: xlsx
+  type: xlsx
   tab_name: NonPubEnroll_byGrade_{{ version[2:] }} # TODO: need to confirm jinja works
 
 library_dataset:

--- a/dcpy/lifecycle/ingest/transform.py
+++ b/dcpy/lifecycle/ingest/transform.py
@@ -62,9 +62,7 @@ def to_parquet(
         gdf = gdf.rename_geometry(OUTPUT_GEOM_COLUMN)
 
     gdf.to_parquet(output_file_path, index=False)
-    logger.info(
-        f"✅ Converted raw data to parquet file and saved as {output_file_path}"
-    )
+    logger.info(f"✅ Converted raw data to parquet file and saved as {output_file_path}")
 
 
 class Preprocessors:

--- a/dcpy/models/file.py
+++ b/dcpy/models/file.py
@@ -24,7 +24,7 @@ class Geometry(BaseModel):
 
 
 class Csv(BaseModel, extra="forbid"):
-    format: Literal["csv"]
+    type: Literal["csv"]
     unzipped_filename: str | None = None
     encoding: str = "utf-8"
     delimiter: str | None = None
@@ -32,7 +32,7 @@ class Csv(BaseModel, extra="forbid"):
 
 
 class Xlsx(BaseModel, extra="forbid"):
-    format: Literal["xlsx"]
+    type: Literal["xlsx"]
     unzipped_filename: str | None = None
     tab_name: str
     encoding: str = "utf-8"
@@ -40,14 +40,14 @@ class Xlsx(BaseModel, extra="forbid"):
 
 
 class Shapefile(BaseModel, extra="forbid"):
-    format: Literal["shapefile"]
+    type: Literal["shapefile"]
     unzipped_filename: str | None = None
     encoding: str = "utf-8"
     crs: str
 
 
 class Geodatabase(BaseModel, extra="forbid"):
-    format: Literal["geodatabase"]
+    type: Literal["geodatabase"]
     unzipped_filename: str | None = None
     layer: str | None = None
     encoding: str = "utf-8"
@@ -56,7 +56,7 @@ class Geodatabase(BaseModel, extra="forbid"):
 
 # TODO: implement JSON and GEOJSON
 class Json(BaseModel):
-    format: Literal["json"]
+    type: Literal["json"]
     unzipped_filename: str | None = None
 
 

--- a/dcpy/test/connectors/edm/test_recipes.py
+++ b/dcpy/test/connectors/edm/test_recipes.py
@@ -61,7 +61,7 @@ def test_archive_raw_dataset(create_buckets, create_temp_filesystem: Path):
         source=ingest.ScriptSource(
             type="script", connector="dummy", function="dummy"
         ),  # easiest to mock
-        file_format=file.Csv(format="csv"),  # easiest to mock
+        file_format=file.Csv(type="csv"),  # easiest to mock
     )
     recipes.archive_raw_dataset(config, tmp_file)
     assert s3.exists(

--- a/dcpy/test/lifecycle/ingest/resources/transform_to_parquet_template.yml
+++ b/dcpy/test/lifecycle/ingest/resources/transform_to_parquet_template.yml
@@ -1,12 +1,12 @@
 # csv non-spatial case
 - file_name: test.csv
   file_format:
-    format: csv
+    type: csv
 
 # csv spatial case (1 geom column, i.e. point or polygon geom)
 - file_name: test.csv
   file_format:
-    format: csv
+    type: csv
     geometry:
       geom_column: wkt
       crs: EPSG:4326
@@ -14,7 +14,7 @@
 # csv zipped case
 - file_name: test.csv.zip
   file_format:
-    format: csv
+    type: csv
     unzipped_filename: test.csv
     geometry:
       geom_column: wkt
@@ -23,7 +23,7 @@
 # csv spatial case (2 geom columns, i.e. longitude and latitude columns)
 - file_name: test2.csv
   file_format:
-    format: csv
+    type: csv
     geometry:
       crs: EPSG:4326
       geom_column:
@@ -32,24 +32,24 @@
 
 - file_name: test/test.shp
   file_format:
-    format: shapefile
+    type: shapefile
     crs: EPSG:4326
 
 # shapefile zipped case
 - file_name: test.zip
   file_format:
-    format: shapefile
+    type: shapefile
     crs: EPSG:4326
     unzipped_filename: "test/test.shp"
 
 - file_name: test.gdb
   file_format:
-    format: geodatabase
+    type: geodatabase
     crs: EPSG:4326
 
 # geodatabase zipped case
 - file_name: test.gdb.zip
   file_format:
-    format: geodatabase
+    type: geodatabase
     crs: EPSG:4326
     unzipped_filename: "test.gdb"

--- a/dcpy/test/lifecycle/ingest/resources/transform_to_parquet_template.yml
+++ b/dcpy/test/lifecycle/ingest/resources/transform_to_parquet_template.yml
@@ -1,11 +1,11 @@
 # csv non-spatial case
 - file_name: test.csv
-  to_parquet_config:
+  file_format:
     format: csv
 
 # csv spatial case (1 geom column, i.e. point or polygon geom)
 - file_name: test.csv
-  to_parquet_config:
+  file_format:
     format: csv
     geometry:
       geom_column: wkt
@@ -13,7 +13,7 @@
 
 # csv zipped case
 - file_name: test.csv.zip
-  to_parquet_config:
+  file_format:
     format: csv
     unzipped_filename: test.csv
     geometry:
@@ -22,7 +22,7 @@
 
 # csv spatial case (2 geom columns, i.e. longitude and latitude columns)
 - file_name: test2.csv
-  to_parquet_config:
+  file_format:
     format: csv
     geometry:
       crs: EPSG:4326
@@ -31,25 +31,25 @@
         y: latitude
 
 - file_name: test/test.shp
-  to_parquet_config:
+  file_format:
     format: shapefile
     crs: EPSG:4326
 
 # shapefile zipped case
 - file_name: test.zip
-  to_parquet_config:
+  file_format:
     format: shapefile
     crs: EPSG:4326
     unzipped_filename: "test/test.shp"
 
 - file_name: test.gdb
-  to_parquet_config:
+  file_format:
     format: geodatabase
     crs: EPSG:4326
 
 # geodatabase zipped case
 - file_name: test.gdb.zip
-  to_parquet_config:
+  file_format:
     format: geodatabase
     crs: EPSG:4326
     unzipped_filename: "test.gdb"

--- a/dcpy/test/lifecycle/ingest/resources/transform_to_parquet_template.yml
+++ b/dcpy/test/lifecycle/ingest/resources/transform_to_parquet_template.yml
@@ -1,35 +1,55 @@
 # csv non-spatial case
-- format: csv
+- file_name: test.csv
+  to_parquet_config:
+    format: csv
 
-# csv spatial case
-- format: csv
-  geometry:
-    geom_column: wkt
+# csv spatial case (1 geom column, i.e. point or polygon geom)
+- file_name: test.csv
+  to_parquet_config:
+    format: csv
+    geometry:
+      geom_column: wkt
+      crs: EPSG:4326
+
+# csv zipped case
+- file_name: test.csv.zip
+  to_parquet_config:
+    format: csv
+    unzipped_filename: test.csv
+    geometry:
+      geom_column: wkt
+      crs: EPSG:4326
+
+# csv spatial case (2 geom columns, i.e. longitude and latitude columns)
+- file_name: test2.csv
+  to_parquet_config:
+    format: csv
+    geometry:
+      crs: EPSG:4326
+      geom_column:
+        x: longitude
+        y: latitude
+
+- file_name: test/test.shp
+  to_parquet_config:
+    format: shapefile
     crs: EPSG:4326
 
-- format: csv
-  unzipped_filename: "test.csv"
-  geometry:
-    geom_column: wkt
+# shapefile zipped case
+- file_name: test.zip
+  to_parquet_config:
+    format: shapefile
+    crs: EPSG:4326
+    unzipped_filename: "test/test.shp"
+
+- file_name: test.gdb
+  to_parquet_config:
+    format: geodatabase
     crs: EPSG:4326
 
-- format: csv
-  geometry:
+# geodatabase zipped case
+- file_name: test.gdb.zip
+  to_parquet_config:
+    format: geodatabase
     crs: EPSG:4326
-    geom_column:
-      x: longitude
-      y: latitude
-
-- format: shapefile
-  crs: EPSG:4326
-
-- format: shapefile
-  crs: EPSG:4326
-  unzipped_filename: "test/test.shp"
-
-- format: geodatabase
-  crs: EPSG:4326
-
-- format: geodatabase
-  crs: EPSG:4326
-  unzipped_filename: "test.gdb"
+    unzipped_filename: "test.gdb"

--- a/dcpy/test/lifecycle/ingest/test_transform.py
+++ b/dcpy/test/lifecycle/ingest/test_transform.py
@@ -1,103 +1,69 @@
-from datetime import date
 import geopandas as gpd
 import pandas as pd
 import pytest
-from typing import cast
 import yaml
+from pydantic import TypeAdapter, BaseModel
 
-from dcpy.models import file
-from dcpy.models.lifecycle.ingest import Template
-from dcpy.models.lifecycle.ingest import LocalFileSource, Config, FunctionCall
+from dcpy.models.file import Format
+from dcpy.models.lifecycle.ingest import FunctionCall
 from dcpy.lifecycle.ingest import (
-    configure,
     transform,
     PARQUET_PATH,
 )
 
 from dcpy.utils import data
-from . import RESOURCES, TEST_DATA_DIR, FAKE_VERSION
+from . import RESOURCES, TEST_DATA_DIR
+
+
+class TestConfig(BaseModel):
+    """
+    Test pydentic class used to validate input yaml file
+    """
+
+    file_name: str
+    to_parquet_config: Format
 
 
 def get_fake_data_configs():
     """
-    Returns a list of Config objects
-    that represent data files in resources/test_data directory
+    Returns a list of dicts that represent data files in resources/test_data directory.
+    Each dict contains a file.Format object and a path to the test data.
     """
     with open(RESOURCES / "transform_to_parquet_template.yml") as f:
-        configs = yaml.safe_load(f)
+        configs = TypeAdapter(list[TestConfig]).validate_python(yaml.safe_load(f))
 
     test_files = []
 
     for config in configs:
-        match config["format"]:
-            case "csv":
-                if "unzipped_filename" in config:
-                    file_name = "test.csv.zip"
-                else:
-                    if config.get("geometry", None) and isinstance(
-                        config["geometry"]["geom_column"], dict
-                    ):
-                        file_name = (
-                            "test2.csv"  # case when geom_column has x and y values
-                        )
-                    else:
-                        file_name = "test.csv"
-            case "shapefile":
-                if "unzipped_filename" in config:
-                    file_name = "test.zip"
-                else:
-                    file_name = "test/test.shp"
-            case "geodatabase":
-                if "unzipped_filename" in config:
-                    file_name = "test.gdb.zip"
-                else:
-                    file_name = "test.gdb"
-            case _:
-                raise ValueError(f"Unknown data format {config['format']}")
-
+        format = config.to_parquet_config
+        file_name = config.file_name
         local_file_path = RESOURCES / TEST_DATA_DIR / file_name
 
-        source = LocalFileSource(type="local_file", path=local_file_path)
-
-        template = Template(
-            name="test",
-            acl="public-read",
-            source=source,
-            file_format=config,
-        )
-
-        ingest_config = Config(
-            version=FAKE_VERSION,
-            archival_timestamp=date.today(),
-            raw_filename=file_name,
-            **template.model_dump(),
-        )
-        test_files.append(ingest_config)
+        test_files.append({"format": format, "local_file_path": local_file_path})
 
     return test_files
 
 
 # TODO: implement tests for json, and geojson format
-@pytest.mark.parametrize("config", get_fake_data_configs())
-def test_transform_to_parquet(config: Config):
+@pytest.mark.parametrize("file", get_fake_data_configs())
+def test_to_parquet(file: dict):
     """
-    Test the transform_to_parquet function.
+    Test the to_parquet function.
 
     Checks:
         - Checks if the function creates expected parquet file.
         - Checks if the saved Parquet file contains the expected data.
     """
 
-    source = cast(LocalFileSource, config.source)
-    file_path = source.path
-
-    transform.to_parquet(config=config, local_data_path=file_path)
+    transform.to_parquet(
+        file_format_config=file["format"], local_data_path=file["local_file_path"]
+    )
 
     assert PARQUET_PATH.is_file()
 
     output_df = pd.read_parquet(PARQUET_PATH)
     raw_df = data.read_data_to_df(
-        data_format=config.file_format, local_data_path=file_path
+        data_format=file["format"], local_data_path=file["local_file_path"]
     )
 
     # rename geom column & translate geometry to wkb format to match parquet geom column

--- a/dcpy/test/lifecycle/ingest/test_transform.py
+++ b/dcpy/test/lifecycle/ingest/test_transform.py
@@ -19,7 +19,7 @@ class TestConfig(BaseModel):
     """
 
     file_name: str
-    to_parquet_config: Format
+    file_format: Format
 
 
 def get_fake_data_configs():
@@ -33,7 +33,7 @@ def get_fake_data_configs():
     test_files = []
 
     for config in configs:
-        format = config.to_parquet_config
+        format = config.file_format
         file_name = config.file_name
         local_file_path = RESOURCES / TEST_DATA_DIR / file_name
 


### PR DESCRIPTION
Related to #631.

### Motivation
Clean up `to_parquet` fn and its associated tests. 

### Changes
1) Previously,  `to_parquet` fn took in a `recipes.Config` object as its input and then parsed it inside. Given that the Config object is evolving (the structure of Config object may change, i.e. new attributes) and we just need its `file.Format` object, I replaced `recipes.Config` with `file.Format`. This simplifies tests dramatically because we don't need to worry about creating a whole fake `recipes.Config` object to test `to_parquet`. 

2) I removed the part downloading data from s3 from `to_parquet` fn. We already download data in `run.py` before we call `to_parquet`, so the data is already available locally. This change makes  `to_parquet` more atomic. 

3) Update test resources. Previously, we were creating fake `recipes.Config` objects in a test file, and the code started becoming lengthy because of a wide variety of data formats (test cases). So make it more simple, I create custom objects in `transform_to_parquet_template.yml` where each object, i.e. test case, consists of `file.Format` and test file name. I feel it's easier to maintain these tests long term if we have all info about test cases in one place, the yaml file. 