### PR TITLE
use latest Open Data sources in EDDE

### DIFF
--- a/products/edde/ingest/data_library/datasets.yml
+++ b/products/edde/ingest/data_library/datasets.yml
@@ -1,9 +1,9 @@
 datasets:
   - name: lpc_historic_district_areas
-    version: 20230227
+    version: 20240424
   - name: doi_evictions
-    version: 20230406
+    version: 20240424
   - name: hpd_hny_units_by_building
-    version: 20230213
+    version: 20240319
   - name: dcp_housing
-    version: '22Q2'
+    version: '23Q2'

--- a/products/edde/ingest/housing_security/DHS_shelter.py
+++ b/products/edde/ingest/housing_security/DHS_shelter.py
@@ -7,7 +7,7 @@ import requests
 
 def load_DHS_shelter(year: int) -> pd.DataFrame:
     url = "https://data.cityofnewyork.us/resource/ur7y-ziyb.json"
-    timestamp = datetime(year, 3, 31).isoformat()
+    timestamp = datetime(year, 6, 30).isoformat()
     query_str = f"?report_date={timestamp}"
 
     res = requests.get(f"{url}{query_str}")


### PR DESCRIPTION
related to #520 

data library runs for [doi_evictions](https://github.com/NYCPlanning/data-engineering/actions/runs/8823153951) and [lpc_historic_district_areas](https://github.com/NYCPlanning/data-engineering/actions/runs/8823179421)

will run builds on main after merging so outputs are in expected S3 folder for AE

## relevant action runs

Categories run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8823420566)

Census run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8823419785)