### PR TITLE
improve CPDB table `cpdb_adminbounds`

### DIFF
--- a/products/cpdb/sql/attributes_maprojid_after.sql
+++ b/products/cpdb/sql/attributes_maprojid_after.sql
@@ -1,26 +1,34 @@
 DROP TABLE IF EXISTS cpdb_adminbounds;
 CREATE TABLE cpdb_adminbounds AS (
-    SELECT * FROM attributes_maprojid_cd
-    UNION ALL
-    SELECT * FROM attributes_maprojid_censustracts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_congressionaldistricts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_councildistricts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_firecompanies
-    UNION ALL
-    SELECT * FROM attributes_maprojid_municipalcourtdistricts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_policeprecincts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_schooldistricts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_stateassemblydistricts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_statesenatedistricts
-    UNION ALL
-    SELECT * FROM attributes_maprojid_trafficanalysiszones
+    WITH all_records AS (
+        SELECT * FROM attributes_maprojid_cd
+        UNION ALL
+        SELECT * FROM attributes_maprojid_censustracts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_congressionaldistricts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_councildistricts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_firecompanies
+        UNION ALL
+        SELECT * FROM attributes_maprojid_municipalcourtdistricts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_policeprecincts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_schooldistricts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_stateassemblydistricts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_statesenatedistricts
+        UNION ALL
+        SELECT * FROM attributes_maprojid_trafficanalysiszones
+    )
+    SELECT DISTINCT
+        feature_id,
+        admin_boundary_type,
+        admin_boundary_id
+    FROM all_records
+    ORDER BY feature_id, admin_boundary_type, admin_boundary_id
 );
 
 DROP TABLE attributes_maprojid_cd;


### PR DESCRIPTION
related to #779 

successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8838220002/job/24268840606). all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-cpdb-admin-bounds)

The table `cpdb_adminbounds` has duplicate records.

The records count of the table decreased from ~120K to ~103K. I checked a project which is an example of the issue (`feature_id = '039LQNFPFAO'`) and the duplicates are gone.

Would love to add a test (`dbt`) to enforce our expectations and improve the queries that go into this table, but GIS needed this table ASAP and we can iterate.

## screenshots
Before
![Screenshot 2024-04-25 at 3 39 36 PM](https://github.com/NYCPlanning/data-engineering/assets/7444289/5e70d4cc-f3e3-4ae9-a517-5edd7978955f)

After
![Screenshot 2024-04-25 at 3 40 00 PM](https://github.com/NYCPlanning/data-engineering/assets/7444289/7619aba5-1397-4635-a31e-bf75b208da66)
