### PR TITLE
FacDB - fix issues in 24v1

### DIFF
--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -130,7 +130,7 @@ def dfta_contracts(df: pd.DataFrame):
     df = Function1B(
         street_name_field="parsed_sname",
         house_number_field="parsed_hnum",
-        zipcode_field="program_zipcode",
+        zipcode_field="postcode",
     ).geocode_a_dataframe(df)
     return df
 

--- a/products/facilities/recipe.yml
+++ b/products/facilities/recipe.yml
@@ -82,7 +82,6 @@ inputs:
     - name: dycd_service_sites
     - name: fbop_corrections
     - name: fdny_firehouses
-    - name: nysomh_mentalhealth
     - name: dep_wwtc
       version: "20210413"
     - name: dfta_contracts


### PR DESCRIPTION
Related to #461.

## What
During the 24v1 review, GIS identified this issue:
* `dfta_contracts`: SENIOR SERVICES facsubgrp dropped from 75 to zero record count

## Why
When creating the `qc_diff` table used in the QA review, we filter out records with empty values in the `geom` column. It appears that `dfta_contracts` records weren't getting geocoded by `geosupport` in the beginning of the build. Specifically, the source zip code column name changed in this data version, and our code silently failed, returning empty values from `geosupport`

**Solution**: fix zip code column name  

#### Build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8852190924/job/24310349837).

As can be seen, now `dfta_contracts` records are getting geocoded: `count_new` is not zero.
![image](https://github.com/NYCPlanning/data-engineering/assets/144725249/70e2b235-218f-48d1-bdc6-d3110ae95836)

Old records for comparison: 
<img width="885" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/37c044ef-5070-47e9-adee-4eec8ab682e1">
