### PR TITLE
fix typo in `int__zoning_districts`

### DIFF
--- a/products/green_fast_track/models/intermediate/flags/int__zoning_districts.sql
+++ b/products/green_fast_track/models/intermediate/flags/int__zoning_districts.sql
@@ -33,5 +33,5 @@ generalized_districts AS (
 )
 
 SELECT * FROM generalized_districts
-GROUP BY bbl, zd
-ORDER BY bbl, zd
+GROUP BY bbl, zoning_district_type
+ORDER BY bbl, zoning_district_type


### PR DESCRIPTION
typo from #789 

tested this by successfuly running `dbt build --select int__zoning_districts+` locally on the schema `dm_gft_new_zoning`