### PR TITLE
fix typo in overly-eager dev tag deletion

### DIFF
--- a/dcpy/lifecycle/builds/clean_artifacts.py
+++ b/dcpy/lifecycle/builds/clean_artifacts.py
@@ -46,16 +46,16 @@ def delete_stale_schemas(active_build_names: list[str]):
                 logger.info(f"Keeping tests schema {database}.{build_test_schema}")
 
 
-def delete_stale_image_tags(active_build_names: list[str]):
+def delete_stale_image_tags(active_build_names: list[str]) -> None:
     logger.info(f"Potential active branch build names: {active_build_names}")
     DOCKER_IMAGES = ["dev", "build-base", "build-geosupport"]
     for image in DOCKER_IMAGES:
-        tags = requests.get(
+        tags: list[str] = requests.get(
             f"https://hub.docker.com/v2/repositories/nycplanning/{image}/tags?page_size=1000"
         ).json()["results"]
         dev_tags = [tag for tag in tags if tag["name"].startswith("dev-")]
         for tag in dev_tags:
-            if tag[4:] not in active_build_names:
+            if tag.removeprefix("dev-") not in active_build_names:
                 logger.warning(f"Deleting tag {image}:{tag['name']}")
                 # Should we include this file in dcpy? A little odd to rely on this file existing, but it's going to be a bit hacky regardless
                 # The intonation seems a bit finicky so don't really want to implement in python rather than bash

--- a/dcpy/lifecycle/builds/clean_artifacts.py
+++ b/dcpy/lifecycle/builds/clean_artifacts.py
@@ -55,7 +55,7 @@ def delete_stale_image_tags(active_build_names: list[str]):
         ).json()["results"]
         dev_tags = [tag for tag in tags if tag["name"].startswith("dev-")]
         for tag in dev_tags:
-            if tag not in active_build_names:
+            if tag[4:] not in active_build_names:
                 logger.warning(f"Deleting tag {image}:{tag['name']}")
                 # Should we include this file in dcpy? A little odd to rely on this file existing, but it's going to be a bit hacky regardless
                 # The intonation seems a bit finicky so don't really want to implement in python rather than bash

--- a/dcpy/lifecycle/builds/clean_artifacts.py
+++ b/dcpy/lifecycle/builds/clean_artifacts.py
@@ -50,10 +50,10 @@ def delete_stale_image_tags(active_build_names: list[str]) -> None:
     logger.info(f"Potential active branch build names: {active_build_names}")
     DOCKER_IMAGES = ["dev", "build-base", "build-geosupport"]
     for image in DOCKER_IMAGES:
-        tags: list[str] = requests.get(
+        tags = requests.get(
             f"https://hub.docker.com/v2/repositories/nycplanning/{image}/tags?page_size=1000"
         ).json()["results"]
-        dev_tags = [tag for tag in tags if tag["name"].startswith("dev-")]
+        dev_tags: list[str] = [tag for tag in tags if tag["name"].startswith("dev-")]
         for tag in dev_tags:
             if tag.removeprefix("dev-") not in active_build_names:
                 logger.warning(f"Deleting tag {image}:{tag['name']}")

--- a/dcpy/lifecycle/builds/clean_artifacts.py
+++ b/dcpy/lifecycle/builds/clean_artifacts.py
@@ -53,15 +53,17 @@ def delete_stale_image_tags(active_build_names: list[str]) -> None:
         tags = requests.get(
             f"https://hub.docker.com/v2/repositories/nycplanning/{image}/tags?page_size=1000"
         ).json()["results"]
-        dev_tags: list[str] = [tag for tag in tags if tag["name"].startswith("dev-")]
+        dev_tags: list[str] = [
+            tag["name"] for tag in tags if tag["name"].startswith("dev-")
+        ]
         for tag in dev_tags:
             if tag.removeprefix("dev-") not in active_build_names:
-                logger.warning(f"Deleting tag {image}:{tag['name']}")
+                logger.warning(f"Deleting tag {image}:{tag}")
                 # Should we include this file in dcpy? A little odd to rely on this file existing, but it's going to be a bit hacky regardless
                 # The intonation seems a bit finicky so don't really want to implement in python rather than bash
-                subprocess.call(["docker/delete.sh", image, tag["name"]])
+                subprocess.call(["docker/delete.sh", image, tag])
             else:
-                logger.info(f"Keeping tag {image}.{tag['name']}")
+                logger.info(f"Keeping tag {image}.{tag}")
 
 
 app = typer.Typer(add_completion=False)


### PR DESCRIPTION
"dev" image tags created in PRs with changes to python, docker, etc are deleted each week in a recurring job, IF their branch no longer exists.

At least that was intended. To avoid potential collisions with real tags, all dev image tags begin with "dev-". So for this branch, there would be images "build-base:dev-fvk-docker-cleanup". However, cleanup logic was comparing this tag name to JUST the branch name, and since "dev-fvk-docker-cleanup" is not an existing branch, the tag was being deleted everytime.