### PR TITLE
fix missing GFT lots in exported source data

### DIFF
--- a/products/green_fast_track/bash/export.sh
+++ b/products/green_fast_track/bash/export.sh
@@ -87,7 +87,7 @@ mkdir -p output && (
     export_source sources__natural_resources_buffer
 
     # Historic
-    export_source sources__nyc_historic_buildings_points POINT
+    export_source sources__nyc_historic_buildings_points MULTIPOINT
     export_source sources__nyc_historic_buildings_lots
     export_source sources__nyc_historic_buildings_buffers
     export_source sources__nyc_historic_districts

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__all.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__all.sql
@@ -46,6 +46,7 @@ WITH all_buffers AS (
         ref('int_buffers__lpc_landmarks'),
         ref('stg__nysshpo_archaeological_buffer_areas')
     ],
+    include=["variable_type", "variable_id", "raw_geom", "buffer"],
     column_override={"raw_geom": "geometry", "buffer": "geometry"}
 ) }}
 )

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__dep_cats_permits.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__dep_cats_permits.sql
@@ -28,7 +28,7 @@ final AS (
     SELECT
         variable_type,
         variable_id,
-        raw_geom,
+        ST_MULTI(raw_geom) AS raw_geom,
         ST_BUFFER(raw_geom, 400) AS buffer
     FROM cats_permits_with_pluto
 )

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__lpc_landmarks.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__lpc_landmarks.sql
@@ -50,7 +50,7 @@ buffered_landmarks AS (
         variable_type,
         variable_id,
         bbls,
-        geom AS raw_geom,
+        ST_MULTI(geom) AS raw_geom,
         ST_BUFFER(geom, 90) AS buffer
     FROM grouped_landmarks
 )

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__lpc_landmarks.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__lpc_landmarks.sql
@@ -19,9 +19,9 @@ landmarks_with_pluto AS (
     SELECT
         variable_type,
         variable_id,
+        raw_geom AS point_geom,
         pluto.bbl,
-        pluto.geom,
-        COALESCE(pluto.geom, lpc_landmarks.raw_geom) AS coalesced_geom
+        pluto.geom AS lot_geom
     FROM lpc_landmarks
     -- If, for example, there's a lamppost in a park, we don't want to use the polygon for the entire park.
     LEFT JOIN
@@ -29,20 +29,35 @@ landmarks_with_pluto AS (
         ON ST_CONTAINS(pluto.geom, lpc_landmarks.raw_geom) AND variable_id != 'Historic Street Lampposts'
 ),
 
--- There are a few different cases for deduping.
--- There are landmarks that share a name, e.g. "Historic Lampposts" that won't match to a PLUTO bbl,
--- and should be combined into one geometry, because they lack a unique name for a variable_id.
--- Otherwise we should group by the PLUTO bbl, joining together the names of the individual landmarks
--- when there are multiple per BBL. e.g. The Brooklyn Navy Yard has two buildings within that are both
--- landmarks.
+-- There are a few different cases for deduping:
+--  A. landmarks that share a name, e.g. "Historic Lampposts" that should't match to a PLUTO bbl,
+--      so should be combined into one geometry, because they lack a unique name for a variable_id
+--  B. landmarks that share a name and all are not contained in any lots
+--      so should use the point(s) to buffer
+--  C. landmarks that share a name and all are contained in at least one lot
+--      so should use the lot(s) to buffer
+--  D. landmarks that share a name and some are contained in at least one lot
+--      so should use only the lot(s) to buffer, not both the point(s) and lot(s)
 grouped_landmarks AS (
     SELECT
         variable_type,
         variable_id,
         STRING_AGG(DISTINCT bbl, ', ') AS bbls,
-        ST_UNION(coalesced_geom) AS geom
+        ST_MULTI(ST_UNION(point_geom)) AS point_geom,
+        ST_MULTI(ST_UNION(lot_geom)) AS lot_geom
     FROM landmarks_with_pluto
     GROUP BY variable_type, variable_id
+),
+
+resolved_landmarks AS (
+    SELECT
+        variable_type,
+        variable_id,
+        bbls,
+        point_geom,
+        lot_geom,
+        COALESCE(lot_geom, point_geom) AS raw_geom
+    FROM grouped_landmarks
 ),
 
 buffered_landmarks AS (
@@ -50,9 +65,11 @@ buffered_landmarks AS (
         variable_type,
         variable_id,
         bbls,
-        ST_MULTI(geom) AS raw_geom,
-        ST_BUFFER(geom, 90) AS buffer
-    FROM grouped_landmarks
+        point_geom,
+        lot_geom,
+        raw_geom,
+        ST_BUFFER(raw_geom, 90) AS buffer
+    FROM resolved_landmarks
 )
 
 SELECT * FROM buffered_landmarks

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__nysdec_state_facility_permits.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__nysdec_state_facility_permits.sql
@@ -30,7 +30,7 @@ final AS (
     SELECT
         variable_type,
         variable_id,
-        raw_geom,
+        ST_MULTI(raw_geom) AS raw_geom,
         ST_BUFFER(raw_geom, 1000) AS buffer
     FROM state_facility_permits_with_pluto
 )

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__nysdec_title_v_facility_permits.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__nysdec_title_v_facility_permits.sql
@@ -28,7 +28,7 @@ final AS (
     SELECT
         variable_type,
         variable_id,
-        raw_geom,
+        ST_MULTI(raw_geom) AS raw_geom,
         ST_BUFFER(raw_geom, 1000) AS buffer
     FROM title_v_facility_permits_with_pluto
 )

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__nysshpo_historic_buildings.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__nysshpo_historic_buildings.sql
@@ -23,6 +23,6 @@ points_with_maybe_pluto_geom AS (
 SELECT
     variable_type,
     variable_id,
-    raw_geom,
+    ST_MULTI(raw_geom) AS raw_geom,
     ST_BUFFER(raw_geom, 90) AS buffer
 FROM points_with_maybe_pluto_geom

--- a/products/green_fast_track/models/intermediate/buffers/int_buffers__pops.sql
+++ b/products/green_fast_track/models/intermediate/buffers/int_buffers__pops.sql
@@ -34,7 +34,7 @@ final AS (
     SELECT
         variable_type,
         variable_id,
-        raw_geom,
+        ST_MULTI(raw_geom) AS raw_geom,
         ST_BUFFER(raw_geom, 200) AS buffer
     FROM pops_with_pluto
 )

--- a/products/green_fast_track/models/product/sources/historic/sources__nyc_historic_buildings_points.sql
+++ b/products/green_fast_track/models/product/sources/historic/sources__nyc_historic_buildings_points.sql
@@ -2,4 +2,5 @@ SELECT
     variable_type,
     variable_id,
     raw_geom
-FROM {{ ref('stg__lpc_landmarks') }}
+FROM {{ ref('int_buffers__lpc_landmarks') }}
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPoint'


### PR DESCRIPTION
resolves #815 

successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/8913860231). all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-gft-source-geometry)

I found which models to change by searching for all models in `/product/sources` that select records `WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPolygon'` and changing the model they select from.

See [last commit message](https://github.com/NYCPlanning/data-engineering/pull/823/commits) for explanation of the substantial changes to `int_buffers__lpc_landmarks`. GIS is ok with (and actually likes) not seeing source points when lots where they were joined to lots.

## screenshots
### before
<img width="1080" alt="Screenshot 2024-05-01 at 12 39 44 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/7fdc1157-fa3c-426c-859c-96c6a7de29da">


### after
<img width="1080" alt="Screenshot 2024-05-01 at 12 40 10 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/00e9acba-ffa9-4a96-a919-3ad84adcbd38">

