### PR TITLE
export csvs of CPDB projects filtered by certain admin geographies

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -50,6 +50,7 @@ jobs:
           sqlfluff lint products/template/sql
           sqlfluff lint products/cbbr/cbbr_build/sql
           sqlfluff lint products/cpdb/sql/
+          sqlfluff lint products/cpdb/sql_templates/ --templater=jinja
           sqlfluff lint products/developments/sql/*.sql
           sqlfluff lint products/developments/sql/qaqc
           sqlfluff lint products/developments/sql/unit_change_summary --templater=jinja

--- a/products/cpdb/bash/04_analysis.sh
+++ b/products/cpdb/bash/04_analysis.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 source bash/config.sh
 
+# Tables of projects in geographies of interest
+python3 -m python.projects_in_geographies
+
 # Summary table by managing and sponsor agency
 echo 'Creating summary tables by managing and sponsor agency'
 run_sql_file sql/analysis/projects_dollars_mapped_categorized_managing.sql

--- a/products/cpdb/bash/05_export.sh
+++ b/products/cpdb/bash/05_export.sh
@@ -17,6 +17,8 @@ mkdir -p output && (
     csv_export checkbook_spending_by_year &
     csv_export geospatial_check &
     csv_export cpdb_projects_without_budget_data &
+    
+    cp ../projects_in_geographies.zip ./
 
     cp ../source_data_versions.csv ./
     cp ../build_metadata.json ./

--- a/products/cpdb/python/admin_geographies.py
+++ b/products/cpdb/python/admin_geographies.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from abc import abstractmethod
+
+
+@dataclass
+class AdminGeography:
+    geography_type: str
+    cpdb_geography_type: str
+    table_name: str
+    geography_id: str
+    geography_name: str
+
+
+@dataclass
+class AdminGeographies:
+    @abstractmethod
+    def generate_geography(self, geography_number: int) -> AdminGeography:
+        raise NotImplementedError("AdminGeographies is an abstract class")
+
+
+@dataclass
+class CityCouncilDistricts(AdminGeographies):
+    count: int
+    geography_type: str = "City Council District"
+    cpdb_geography_type: str = "council"
+
+    def generate_geography(self, geography_number: int) -> AdminGeography:
+        table_name = "city_council_district_" + str(geography_number)
+        geography_id = str(geography_number)
+        geography_name = "City Council District " + str(geography_number)
+
+        return AdminGeography(
+            self.geography_type,
+            self.cpdb_geography_type,
+            table_name,
+            geography_id,
+            geography_name,
+        )
+
+
+@dataclass
+class BoroughCommunityDistricts(AdminGeographies):
+    borough_name: str
+    borough_code: int
+    count: int
+    boundary_type: str = "Community District"
+    cpdb_geography_type: str = "commboard"
+
+    def generate_geography(self, geography_number: int) -> AdminGeography:
+        table_suffix = (
+            self.borough_name.replace(" ", "_") + "_cd" + str(geography_number)
+        ).lower()
+        table_name = "community_district_" + table_suffix
+
+        geography_id = str(self.borough_code) + str(geography_number).zfill(2)
+        geography_name = f"{self.borough_name} CD{geography_number}"
+        return AdminGeography(
+            self.boundary_type,
+            self.cpdb_geography_type,
+            table_name,
+            geography_id,
+            geography_name,
+        )
+
+
+ALL_CITY_COUNCIL_DISTRICTS = CityCouncilDistricts(count=51)
+
+ALL_COMMUNITY_DISTRICT_BOROUGHS = [
+    BoroughCommunityDistricts(borough_name="Manhattan", borough_code=1, count=12),
+    BoroughCommunityDistricts(borough_name="Bronx", borough_code=2, count=12),
+    BoroughCommunityDistricts(borough_name="Brooklyn", borough_code=3, count=18),
+    BoroughCommunityDistricts(borough_name="Queens", borough_code=4, count=14),
+    BoroughCommunityDistricts(borough_name="Staten Island", borough_code=5, count=3),
+]
+
+
+def generate_city_council_districts(
+    city_council_districts: CityCouncilDistricts,
+) -> list[AdminGeography]:
+    ccds = []
+    for city_council_district_number in range(1, city_council_districts.count + 1):
+        ccd = city_council_districts.generate_geography(city_council_district_number)
+        ccds.append(ccd)
+    return ccds
+
+
+def generate_community_districts(
+    community_district_boroughs: list[BoroughCommunityDistricts],
+) -> list[AdminGeography]:
+    cds = []
+    for borough in community_district_boroughs:
+        for community_district_number in range(1, borough.count + 1):
+            cd = borough.generate_geography(community_district_number)
+            cds.append(cd)
+    return cds
+
+
+def generate_all_admin_geographies() -> list[AdminGeography]:
+    return generate_city_council_districts(
+        ALL_CITY_COUNCIL_DISTRICTS
+    ) + generate_community_districts(ALL_COMMUNITY_DISTRICT_BOROUGHS)

--- a/products/cpdb/python/projects_in_geographies.py
+++ b/products/cpdb/python/projects_in_geographies.py
@@ -1,0 +1,74 @@
+import os
+import shutil
+from pathlib import Path
+from jinja2 import Template
+from sqlalchemy import create_engine, text
+import pandas as pd
+
+from python.admin_geographies import generate_all_admin_geographies
+
+OUTPUT_DIR = Path(__file__).parent.parent / "projects_in_geographies"
+
+SQL_TEMPLATE_PATH = (
+    Path(__file__).parent.parent / "sql_templates/projects_in_geographies.sql"
+)
+
+# SQL Template
+with open(SQL_TEMPLATE_PATH, "r") as f:
+    SQL_TEMPLATE_TEXT = f.read()
+
+
+def create_table(
+    geography_type: str,
+    table_name: str,
+    geography_id: str,
+    geography_name: str,
+) -> None:
+    print(f"creating table {table_name} ...")
+    # render templated sql
+    sql_rendered = Template(SQL_TEMPLATE_TEXT).render(
+        geography_type=geography_type,
+        table_name=table_name,
+        geography_id=geography_id,
+        geography_name=geography_name,
+    )
+    # execute SQL
+    engine = create_engine(os.environ["BUILD_ENGINE"])
+    with engine.begin() as conn:
+        conn.execute(text(sql_rendered))
+
+
+def export_table(geography_type: str, table_name: str) -> None:
+    print(f"pd.read_sql from table {table_name} ...")
+    engine = create_engine(os.environ["BUILD_ENGINE"])
+    with engine.begin() as conn:
+        df = pd.read_sql(text("select * from %(name)s" % {"name": table_name}), conn)
+
+    output_subfolder = OUTPUT_DIR / geography_type
+    if not output_subfolder.exists():
+        output_subfolder.mkdir(parents=True, exist_ok=True)
+
+    output_file_path = output_subfolder / f"{table_name}.csv"
+    print(f"sql_to_csv from {table_name} to {output_file_path} ...")
+    df.to_csv(output_file_path, index=False)
+
+
+if __name__ == "__main__":
+    # create all csv files
+    all_geographies = generate_all_admin_geographies()
+    for geography in all_geographies:
+        create_table(
+            geography.cpdb_geography_type,
+            geography.table_name,
+            geography.geography_id,
+            geography.geography_name,
+        )
+        export_table(geography.geography_type, geography.table_name)
+
+    # zip folder with all csv files
+    print(f"Zipping folder\n\t{OUTPUT_DIR}")
+    shutil.make_archive(
+        base_name=OUTPUT_DIR,
+        format="zip",
+        root_dir=OUTPUT_DIR,
+    )

--- a/products/cpdb/sql_templates/projects_in_geographies.sql
+++ b/products/cpdb/sql_templates/projects_in_geographies.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS {{ table_name }};
+WITH boundaries AS (
+    SELECT * FROM cpdb_adminbounds
+    WHERE
+        cpdb_adminbounds.admin_boundary_type = '{{ geography_type }}'
+        AND cpdb_adminbounds.admin_boundary_id = '{{ geography_id }}'
+),
+
+all_projects AS (
+    SELECT * FROM cpdb_projects_shp
+),
+
+final AS (
+    SELECT
+        '{{ geography_name }}' AS geography_name,
+        '{{ geography_id }}' AS geography_id,
+        all_projects.*
+    FROM all_projects
+    INNER JOIN boundaries ON all_projects.maprojid = boundaries.feature_id
+)
+SELECT * INTO {{ table_name }}
+FROM final
+ORDER BY maprojid ASC;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ years="['2010', '2011']"
 decade="2020"
 geom="CD"
 CAPTURE_DATE="2024-01-01"
+geography_type="anything"
+geography_name="anything"
+geography_id="anything"
+table_name="anything"
 
 [tool.sqlfluff.rules.layout.long_lines]
 ignore_comment_lines = true


### PR DESCRIPTION
resolves #779 

adds a new zip file to the CPDB build called `projects_in_geographies.zip`

it has a csv for all projects which intersect with each Community District and each City Council District. these csv files have all CPDB columns, including geometry

successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9004378604)

## approach
- inspired by other CPDB code: [`checkbook_spending_by_year.py`](https://github.com/NYCPlanning/data-engineering/blob/main/products/cpdb/python/checkbook_spending_by_year.py)
- add a python script to create tables and export them as csv files
- use a sql template to be populated and run by the python script
- zip the folder with all of the csv files

## notes

This new zip file increases the zipped build output from 16MBs to 75MBs 🙃.

We haven't decided how these new files will be distributed yet. Looks like the only attachment we include on [Open Data](https://data.cityofnewyork.us/City-Government/Capital-Projects-Database-CPDB-Projects-Polygons-/9jkp-n57r/about_data) is the data dictionary, but that seems like a good place to put this zip file in the future.

For now, I've been uploading the files to a new EDM Sharepoint folder called [Capital Project's Map](https://nyco365.sharepoint.com/:f:/r/sites/NYCPLANNING/itd/edm/Shared%20Documents/PROJECTS/DATA%20ENGINEERING/DATA%20PRODUCTS/CPDB/Capital%20Projects%20Map?csf=1&web=1&e=Tmu58s) so that everyone working on the project "Capital Projects Maps" can access them.