### PR TITLE
Fix nightly qa workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,10 +72,11 @@ on:
         type: string
         required: true
       dev_image:
-        type: boolean
+        type: string
         default: false
+        required: false
       repeat:
-        type: boolean
+        type: string
         default: false
       build_name:
         type: string
@@ -86,12 +87,12 @@ jobs:
     name: Health Check
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
+      tag: ${{ (inputs.dev_image == 'true' || inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
       build_name: ${{ inputs.build_name || github.head_ref || github.ref_name }}
     steps:
       - name: Check inputs
         run: |
-          echo "running with image tag ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}"
+          echo "running with image tag ${{ (inputs.dev_image == 'true'|| inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}"
           echo "Workflow inputs are:"
           echo "${{ toJSON(github.event.inputs) }}"
   template:

--- a/.github/workflows/colp_build.yml
+++ b/.github/workflows/colp_build.yml
@@ -15,8 +15,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/cpdb_build.yml
+++ b/.github/workflows/cpdb_build.yml
@@ -16,8 +16,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
         
 jobs:
   build:

--- a/.github/workflows/developments_build.yml
+++ b/.github/workflows/developments_build.yml
@@ -16,8 +16,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -16,8 +16,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/green_fast_track_build.yml
+++ b/.github/workflows/green_fast_track_build.yml
@@ -15,8 +15,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/nightly_qa.yml
+++ b/.github/workflows/nightly_qa.yml
@@ -10,7 +10,6 @@ on:
       dev_image: 
         description: Use dev image specific to this branch (if exists)
         type: boolean
-        required: true
         default: false
   schedule:
     - cron: "0 5 * * *"
@@ -20,7 +19,7 @@ jobs:
     uses: ./.github/workflows/test_helper.yml
     secrets: inherit
     with:
-      image_tag: ${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
+      image_tag: ${{ (inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
   
   build:
     uses: ./.github/workflows/build.yml
@@ -29,7 +28,7 @@ jobs:
       dataset_name: all
       build_note: nightly qa
       recipe_file: recipe
-      dev_image: ${{ inputs.dev_image }}
+      dev_image: ${{ inputs.dev_image || 'false' }}
       build_name: ${{ inputs.build_name || 'nightly_qa' }}
 
   create_issue_on_failure:

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -19,8 +19,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -22,8 +22,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
 
 env:
   TOY_SECRET_GITHUB: ${{ secrets.TOY_SECRET }}

--- a/.github/workflows/zoningtaxlots_build.yml
+++ b/.github/workflows/zoningtaxlots_build.yml
@@ -16,8 +16,7 @@ on:
         type: string
         required: false
       repeat:
-        type: boolean
-        default: false
+        type: string
 
 jobs:
   build:


### PR DESCRIPTION
cleanup from #829. Fixing [failed workflow](https://github.com/NYCPlanning/data-engineering/actions/runs/8979959749) due to invalid template on non-workflow dispatch trigger

Also, turns out I needed to clean up how boolean inputs to `workflow_call` were being handles - turns out they aren't handled very well. Kept getting "misformatted yml" when I tried to specify `input: false` becuase "false" there is a string not a bool... even if I use `${{ input.value == 'true'}}`. So for workflow calls made them strings, and logic will work around that.

Despite all these canceled/failed actions, seems that all is working.

[Nightly QA via push trigger (build via workflow call](https://github.com/NYCPlanning/data-engineering/actions/runs/8986624237) - canceled, but it worked as expected

[Running with workflow dispatch to make sure it attempts to use dev images when specified](https://github.com/NYCPlanning/data-engineering/actions/runs/8986627814) are properly used (fails because dev image doesn't exist for this branch)

[Build with workflow dispatch - don't use dev image](https://github.com/NYCPlanning/data-engineering/actions/runs/8986711315/job/24683508803). Canceled because images are successfully grabbed

[Build with workflow dispatch - use dev image](https://github.com/NYCPlanning/data-engineering/actions/runs/8986761872) fails because they don't exist