### PR TITLE
PLUTO QA enhancements, expand `dcpy` repeat build functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,6 @@ on:
         description: "Version of dataset being built (overrides version defined in recipe)"
         type: string
         required: false
-      repeat:
-        description: "Repeat existing build?"
-        type: boolean
-        default: false
       dev_image: 
         description: "Use dev image specific to this branch (if exists)"
         type: boolean
@@ -75,20 +71,24 @@ on:
         type: string
         default: false
         required: false
-      repeat:
-        type: string
-        default: false
       build_name:
         type: string
         required: false
+
+
+env:
+  tag: ${{ (inputs.dev_image == 'true' || inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
+  build_name: ${{ inputs.build_name || github.head_ref || github.ref_name }}
+  version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
 
 jobs:
   health_check:
     name: Health Check
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ (inputs.dev_image == 'true' || inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
-      build_name: ${{ inputs.build_name || github.head_ref || github.ref_name }}
+      plan_command: recipe --recipe-path ./${{ inputs.recipe_file }}.yml ${{ env.version }}
+      tag: ${{ env.tag }}
+      build_name: ${{ env.build_name }}
     steps:
       - name: Check inputs
         run: |
@@ -104,8 +104,7 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
       logging_level: ${{ inputs.logging_level }}
       build_note: ${{ inputs.build_note }}
   cbbr:
@@ -114,10 +113,12 @@ jobs:
     uses: ./.github/workflows/cbbr_build.yml
     secrets: inherit
     with:
-      logging_level: ${{ inputs.logging_level }}
-      build_note: ${{ inputs.build_note }}
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
+      recipe_file: ${{ inputs.recipe_file }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      logging_level: ${{ inputs.logging_level }}
+      build_note: ${{ inputs.build_note }}
   checkbook:
     needs: health_check
     if: inputs.dataset_name == 'checkbook' || inputs.dataset_name  == 'all'
@@ -135,8 +136,7 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
   cpdb:
     needs: health_check
     if: inputs.dataset_name == 'cpdb' || inputs.dataset_name  == 'all'
@@ -146,8 +146,7 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
   devdb:
     needs: health_check
     if: inputs.dataset_name == 'devdb' || inputs.dataset_name  == 'all'
@@ -157,8 +156,7 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
   facilities:
     needs: health_check
     if: inputs.dataset_name == 'facilities' || inputs.dataset_name  == 'all'
@@ -168,8 +166,7 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
   factfinder:
     needs: health_check
     if: inputs.dataset_name == 'factfinder'
@@ -188,8 +185,7 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       recipe_file: ${{ inputs.recipe_file }}
       build_name: ${{ needs.health_check.outputs.build_name }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
   knownprojects:
     needs: health_check
     if: inputs.dataset_name == 'knownprojects' || inputs.dataset_name  == 'all'
@@ -207,8 +203,7 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
   ztl:
     needs: health_check
     if: inputs.dataset_name == 'ztl' || inputs.dataset_name  == 'all'
@@ -218,5 +213,4 @@ jobs:
       image_tag: ${{ needs.health_check.outputs.tag }}
       build_name: ${{ needs.health_check.outputs.build_name }}
       recipe_file: ${{ inputs.recipe_file }}
-      version: ${{ inputs.version }}
-      repeat: ${{ inputs.repeat }}
+      plan_command: ${{ needs.health_check.outputs.plan_command }}

--- a/.github/workflows/cbbr_build.yml
+++ b/.github/workflows/cbbr_build.yml
@@ -9,12 +9,18 @@ on:
       build_note:
         type: string
         required: false
+      recipe_file:
+        type: string
+        required: true
       image_tag:
         type: string
         required: false
       build_name: 
         type: string
         required: true
+      plan_command:
+        type: string
+        default: recipe
 
 jobs:
   build:
@@ -54,12 +60,15 @@ jobs:
         working-directory: ./
         run: ./bash/build_env_setup.sh
 
-      - name: Dataloading
-        run: python -m dcpy.lifecycle.builds.load recipe
+      - name: Plan build
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 
       - name: Set recipe env vars
         working-directory: ./
         run: source ./bash/export_recipe_env.sh products/cbbr/${{ inputs.recipe_file }}.lock.yml 
+
+      - name: Dataloading
+        run: python -m dcpy.lifecycle.builds.load load
 
       - name: Create Build Tables and Normalize CBBR Values
         working-directory: ./products/cbbr/cbbr_build

--- a/.github/workflows/colp_build.yml
+++ b/.github/workflows/colp_build.yml
@@ -11,11 +11,9 @@ on:
       recipe_file:
         type: string
         required: true
-      version:
+      plan_command:
         type: string
-        required: false
-      repeat:
-        type: string
+        default: recipe
 
 jobs:
   build:
@@ -65,15 +63,15 @@ jobs:
       working-directory: ./
       run: ./bash/build_env_setup.sh
 
-    - name: Dataloading ...
-      env:
-        version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-        repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-      run: python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+    - name: Plan build
+      run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 
     - name: Set recipe env vars
       working-directory: ./
       run: source ./bash/export_recipe_env.sh products/colp/${{ inputs.recipe_file }}.lock.yml 
+
+    - name: Dataloading
+      run: python -m dcpy.lifecycle.builds.load load
 
     - name: Build COLP ...
       run: ./colp.sh build

--- a/.github/workflows/cpdb_build.yml
+++ b/.github/workflows/cpdb_build.yml
@@ -12,11 +12,9 @@ on:
       recipe_file:
         type: string
         required: true
-      version:
+      plan_command:
         type: string
-        required: false
-      repeat:
-        type: string
+        default: recipe
         
 jobs:
   build:
@@ -53,8 +51,11 @@ jobs:
         working-directory: ./
         run: ./bash/build_env_setup.sh
 
+      - name: Plan build
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
+
+      - name: Dataloading
+        run: python -m dcpy.lifecycle.builds.load load
+
       - name: Build
-        env:
-          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-        run: ./cpdb.sh build ${{ inputs.recipe_file }} $version $repeat
+        run: ./cpdb.sh build

--- a/.github/workflows/developments_build.yml
+++ b/.github/workflows/developments_build.yml
@@ -12,11 +12,9 @@ on:
       recipe_file:
         type: string
         required: true
-      version:
+      plan_command:
         type: string
-        required: false
-      repeat:
-        type: string
+        default: recipe
 
 jobs:
   build:
@@ -54,15 +52,11 @@ jobs:
         working-directory: ./
         run: ./bash/build_env_setup.sh
 
-      - name: 1. dataloading
-        env:
-          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-        run: python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+      - name: Plan build
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 
-      - name: Set recipe env vars
-        working-directory: ./
-        run: source ./bash/export_recipe_env.sh products/developments/${{ inputs.recipe_file }}.lock.yml 
+      - name: Dataloading
+        run: python -m dcpy.lifecycle.builds.load load
 
       - name: Clear cache
         run: rm -rf .library

--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -12,11 +12,9 @@ on:
       recipe_file:
         type: string
         required: true
-      version:
+      plan_command:
         type: string
-        required: false
-      repeat:
-        type: string
+        default: recipe
 
 jobs:
   build:
@@ -56,11 +54,15 @@ jobs:
       - name: Set product environment variables
         run: cat version.env >> "$GITHUB_ENV"
 
+      - name: Plan build
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
+
+      - name: Set recipe env vars
+        working-directory: ./
+        run: source ./bash/export_recipe_env.sh products/facilities/${{ inputs.recipe_file }}.lock.yml 
+
       - name: Dataloading
-        env:
-          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-        run: python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+        run: python -m dcpy.lifecycle.builds.load load
 
       - name: Initialize
         run: python -m facdb.cli init

--- a/.github/workflows/green_fast_track_build.yml
+++ b/.github/workflows/green_fast_track_build.yml
@@ -11,11 +11,9 @@ on:
       recipe_file:
         type: string
         required: true
-      version:
+      plan_command:
         type: string
-        required: false
-      repeat:
-        type: string
+        default: recipe
 
 jobs:
   build:
@@ -54,11 +52,11 @@ jobs:
           ./bash/docker_container_setup.sh
           ./bash/build_env_setup.sh
 
-      - name: Load
-        env:
-          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-        run: python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+      - name: Plan build
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
+
+      - name: Dataloading
+        run: python -m dcpy.lifecycle.builds.load load
 
       - name: Build
         run: ./bash/build.sh

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -18,8 +18,9 @@ on:
       version:
         type: string
         required: false
-      repeat:
+      plan_command:
         type: string
+        default: recipe
 
 jobs:
   build:
@@ -58,16 +59,17 @@ jobs:
         working-directory: ./
         run: ./bash/build_env_setup.sh
 
-      - name: Load data
+      - name: Plan build
         working-directory: products/pluto
-        env:
-          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-        run: python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 
       - name: Set recipe env vars
         working-directory: ./
         run: source ./bash/export_recipe_env.sh products/pluto/${{ inputs.recipe_file }}.lock.yml 
+
+      - name: Dataloading
+        working-directory: products/pluto
+        run: python -m dcpy.lifecycle.builds.load load
 
       - name: Load Local Data
         run: ./01_load_local_csvs.sh

--- a/.github/workflows/repeat_build.yml
+++ b/.github/workflows/repeat_build.yml
@@ -3,3 +3,193 @@ run-name: "🏗️ Repeat a Product Build: ${{ inputs.product }}/${{ inputs.prod
 
 on:
   workflow_dispatch:
+    inputs:
+      product:
+        description: "Which product to repeat build"
+        type: choice
+        required: true
+        options:
+          - template
+          - cbbr
+          #- checkbook
+          - colp
+          - cpdb
+          - devdb
+          - facilities
+          #- factfinder
+          - green_fast_track
+          #- knownprojects
+          - pluto
+          - ztl
+      product_type:
+        description: "What type of product/build to repeat"
+        type: choice
+        options:
+          - publish
+          - draft
+        required: true
+      version_or_build:
+        description: "Key of product instance (publish version or draft build name)"
+        type: string
+        required: true
+      dev_image: 
+        description: "Use dev image specific to this branch (if exists)"
+        type: boolean
+        required: true
+        default: false
+      logging_level:
+        description: "Logging level"
+        type: choice
+        required: true
+        default: INFO
+        options:
+          - WARNING
+          - INFO
+          - DEBUG
+      build_name:
+        description: "Build name (defaults to branch name)"
+        type: string
+        required: false
+      build_note:
+        description: "An optional note about this build"
+        type: string
+        required: false
+
+env:
+  tag: ${{ (inputs.dev_image == 'true' || inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
+  build_name: ${{ inputs.build_name || github.head_ref || github.ref_name }}
+
+jobs:
+  health_check:
+    name: Health Check
+    runs-on: ubuntu-latest
+    outputs:
+      plan_command: repeat ${{ inputs.product }} --product-type ${{ inputs.product_type }} --version-or-build ${{ inputs.version_or_build }}
+      tag: ${{ env.tag }}
+      build_name: ${{ env.build_name }}
+    steps:
+      - name: Check inputs
+        run: |
+          echo "running with image tag ${{ env.tag }}"
+          echo "Workflow inputs are:"
+          echo "${{ toJSON(github.event.inputs) }}"
+  template:
+    needs: health_check
+    if: inputs.product == 'template'
+    uses: ./.github/workflows/template_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+      logging_level: ${{ inputs.logging_level }}
+      build_note: ${{ inputs.build_note }}
+  cbbr:
+    needs: health_check
+    if: inputs.product == 'cbbr' || inputs.product  == 'all'
+    uses: ./.github/workflows/cbbr_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+      logging_level: ${{ inputs.logging_level }}
+      build_note: ${{ inputs.build_note }}
+  #checkbook:
+  #  needs: health_check
+  #  if: inputs.product == 'checkbook' || inputs.product  == 'all'
+  #  uses: ./.github/workflows/checkbook_build.yml
+  #  secrets: inherit
+  #  with:
+  #    image_tag: ${{ needs.health_check.outputs.tag }}
+  #    build_name: ${{ needs.health_check.outputs.build_name }}
+  colp:
+    needs: health_check
+    if: inputs.product == 'colp' || inputs.product  == 'all'
+    uses: ./.github/workflows/colp_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+  cpdb:
+    needs: health_check
+    if: inputs.product == 'cpdb' || inputs.product  == 'all'
+    uses: ./.github/workflows/cpdb_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+  devdb:
+    needs: health_check
+    if: inputs.product == 'devdb' || inputs.product  == 'all'
+    uses: ./.github/workflows/developments_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+  facilities:
+    needs: health_check
+    if: inputs.product == 'facilities' || inputs.product  == 'all'
+    uses: ./.github/workflows/facilities_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+  #factfinder:
+  #  needs: health_check
+  #  if: inputs.product == 'factfinder'
+  #  uses: ./.github/workflows/factfinder_build.yml
+  #  secrets: inherit
+  #  with:
+  #    plan_command: ${{ needs.health_check.outputs.plan_command }}
+  #    recipe_file: recipe
+  #    image_tag: ${{ needs.health_check.outputs.tag }}
+  #    build_name: ${{ needs.health_check.outputs.build_name }}
+  green_fast_track:
+    needs: health_check
+    if: inputs.product == 'green_fast_track' || inputs.product  == 'all'
+    uses: ./.github/workflows/green_fast_track_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+  #knownprojects:
+  #  needs: health_check
+  #  if: inputs.product == 'knownprojects' || inputs.product  == 'all'
+  #  uses: ./.github/workflows/knownprojects_build.yml
+  #  secrets: inherit
+  #  with:
+  #    image_tag: ${{ needs.health_check.outputs.tag }}
+  #    build_name: ${{ needs.health_check.outputs.build_name }}
+  pluto:
+    needs: health_check
+    if: inputs.product == 'pluto' || inputs.product  == 'all'
+    uses: ./.github/workflows/pluto_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}
+  ztl:
+    needs: health_check
+    if: inputs.product == 'ztl' || inputs.product  == 'all'
+    uses: ./.github/workflows/zoningtaxlots_build.yml
+    secrets: inherit
+    with:
+      plan_command: ${{ needs.health_check.outputs.plan_command }}
+      recipe_file: recipe
+      image_tag: ${{ needs.health_check.outputs.tag }}
+      build_name: ${{ needs.health_check.outputs.build_name }}

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -21,8 +21,9 @@ on:
       version:
         type: string
         required: false
-      repeat:
+      plan_command:
         type: string
+        default: recipe
 
 env:
   TOY_SECRET_GITHUB: ${{ secrets.TOY_SECRET }}
@@ -76,15 +77,15 @@ jobs:
         working-directory: ./
         run: ./bash/build_env_setup.sh
 
-      - name: Load
-        env:
-          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-        run: python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+      - name: Plan build
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 
       - name: Set recipe env vars
         working-directory: ./
         run: source ./bash/export_recipe_env.sh products/template/${{ inputs.recipe_file }}.lock.yml 
+
+      - name: Dataloading
+        run: python -m dcpy.lifecycle.builds.load load
 
       - name: Transform
         run: |

--- a/.github/workflows/zoningtaxlots_build.yml
+++ b/.github/workflows/zoningtaxlots_build.yml
@@ -15,8 +15,9 @@ on:
       version:
         type: string
         required: false
-      repeat:
+      plan_command:
         type: string
+        default: recipe
 
 jobs:
   build:
@@ -54,15 +55,15 @@ jobs:
         working-directory: ./
         run: ./bash/build_env_setup.sh
 
-      - name: 1. dataloading ...
-        env:
-          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
-          repeat: ${{ github.event.inputs.repeat == 'true' && '--repeat' || '' }}
-        run: python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ./${{ inputs.recipe_file }}.yml $version $repeat
+      - name: Plan build
+        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 
       - name: Set recipe env vars
         working-directory: ./
         run: source ./bash/export_recipe_env.sh products/zoningtaxlots/${{ inputs.recipe_file }}.lock.yml 
+
+      - name: Dataloading
+        run: python -m dcpy.lifecycle.builds.load load
 
       - name: 2. build ...
         run: ./ztl.sh build

--- a/apps/qa/src/pages/pluto/components/aggregate_report.py
+++ b/apps/qa/src/pages/pluto/components/aggregate_report.py
@@ -5,11 +5,12 @@ from src.shared.constants import COLOR_SCHEME
 
 
 class AggregateReport:
-    def __init__(self, data, v1, v2, v3, condo, mapped):
+    def __init__(self, data, v, v_prev, v_comp, v_comp_prev, condo, mapped):
         self.df = data
-        self.v1 = v1
-        self.v2 = v2
-        self.v3 = v3
+        self.v = v
+        self.v_prev = v_prev
+        self.v_comp = v_comp
+        self.v_comp_prev = v_comp_prev
         self.condo = condo
         self.mapped = mapped
 
@@ -27,21 +28,25 @@ class AggregateReport:
         return self.df.loc[
             (self.df.condo == self.condo)
             & (self.df.mapped == self.mapped)
-            & (self.df.v.isin([self.v1, self.v2, self.v3])),
+            & (self.df.v.isin([self.v, self.v_prev, self.v_comp, self.v_comp_prev])),
             :,
         ]
 
     @property
-    def v1_records(self):
-        return self.records_by_version(self.v1)
+    def v_records(self):
+        return self.records_by_version(self.v)
 
     @property
-    def v2_records(self):
-        return self.records_by_version(self.v2)
+    def v_prev_records(self):
+        return self.records_by_version(self.v_prev)
 
     @property
-    def v3_records(self):
-        return self.records_by_version(self.v3)
+    def v_comp_records(self):
+        return self.records_by_version(self.v_comp)
+
+    @property
+    def v_comp_prev_records(self):
+        return self.records_by_version(self.v_comp_prev)
 
     def records_by_version(self, version):
         return self.aggregate_df.loc[self.aggregate_df.v == version, :].to_dict(
@@ -88,8 +93,10 @@ class AggregateReport:
     def display_graph(self):
         fig = go.Figure()
 
-        fig.add_trace(self.generate_trace(self.v1_records, self.v2_records))
-        fig.add_trace(self.generate_trace(self.v2_records, self.v3_records))
+        fig.add_trace(self.generate_trace(self.v_records, self.v_prev_records))
+        fig.add_trace(
+            self.generate_trace(self.v_comp_records, self.v_comp_prev_records)
+        )
 
         fig.add_hline(y=0, line_color="grey", opacity=0.5)
         fig.update_layout(

--- a/apps/qa/src/pages/pluto/components/aggregate_report.py
+++ b/apps/qa/src/pages/pluto/components/aggregate_report.py
@@ -15,13 +15,13 @@ class AggregateReport:
         self.mapped = mapped
 
     def __call__(self):
-        st.header("Aggregate Graph")
+        st.header("Aggregate Changes")
+
+        st.info(self.info_description)
 
         self.display_graph()
 
         st.write(self.aggregate_df.sort_values(by="v", ascending=False))
-
-        st.info(self.info_description)
 
     @property
     def aggregate_df(self):
@@ -100,7 +100,7 @@ class AggregateReport:
 
         fig.add_hline(y=0, line_color="grey", opacity=0.5)
         fig.update_layout(
-            title="Aggregate graph",
+            title="Percent change in sum of columns for all PLUTO lots",
             template="plotly_white",
             yaxis={"title": "Percent Change"},
             colorway=COLOR_SCHEME,
@@ -111,7 +111,7 @@ class AggregateReport:
     @property
     def info_description(self):
         return """
-            In addition to looking at the number of lots with a changed value, it’s important to look at the magnitude of the change. 
+            In addition to looking at the number of lots with a changed value, it’s important to look at the magnitude of the change, summed across the entire dataset.
             For example, the mismatch graph for finance may show that over 90% of lots get an updated assessment when the tentative roll is released. 
             The aggregate graph may show that the aggregated sum increased by 5%. 
             Totals for assessland, assesstot, and exempttot should only change after the tentative and final rolls. 

--- a/apps/qa/src/pages/pluto/components/expected_value_differences_report.py
+++ b/apps/qa/src/pages/pluto/components/expected_value_differences_report.py
@@ -33,10 +33,10 @@ FIELDS_OF_INTEREST = {
 
 
 class ExpectedValueDifferencesReport:
-    def __init__(self, data, v1, v2):
+    def __init__(self, data, v, v_prev):
         self.df = data
-        self.v1 = v1
-        self.v2 = v2
+        self.v = v
+        self.v_prev = v_prev
 
     def __call__(self):
         st.header("Expected Value Comparison")
@@ -71,8 +71,8 @@ class ExpectedValueDifferencesReport:
             value_differences = pd.DataFrame.from_dict(
                 dict(
                     [
-                        (f"in {self.v1} but not {self.v2}", [in1not2]),
-                        (f"in {self.v2} but not {self.v1}", [in2not1]),
+                        (f"in {self.v} but not {self.v_prev}", [in1not2]),
+                        (f"in {self.v_prev} but not {self.v}", [in2not1]),
                     ]
                 ),
                 orient="index",
@@ -93,15 +93,15 @@ class ExpectedValueDifferencesReport:
 
     @property
     def expected_records(self) -> dict:
-        return self.df[self.df["v"].isin([self.v1, self.v2])].to_dict("records")
+        return self.df[self.df["v"].isin([self.v, self.v_prev])].to_dict("records")
 
     @property
-    def v1_expected_records(self) -> dict:
-        return self.expected_records_by_version(self.v1)
+    def v_expected_records(self) -> dict:
+        return self.expected_records_by_version(self.v)
 
     @property
-    def v2_expected_records(self) -> dict:
-        return self.expected_records_by_version(self.v2)
+    def v_prev_expected_records(self) -> dict:
+        return self.expected_records_by_version(self.v_prev)
 
     def expected_records_by_version(self, version) -> dict:
         return [i["expected"] for i in self.expected_records if i["v"] == version][0]
@@ -121,14 +121,14 @@ class ExpectedValueDifferencesReport:
     def value_differences_across_versions(
         self, comparison_name: str
     ) -> tuple[list, list]:
-        v1_values = self.values_by_fields(
-            self.v1_expected_records,
+        v_values = self.values_by_fields(
+            self.v_expected_records,
             FIELDS_OF_INTEREST[comparison_name],
         )
-        v2_values = self.values_by_fields(
-            self.v2_expected_records,
+        v_prev_values = self.values_by_fields(
+            self.v_prev_expected_records,
             FIELDS_OF_INTEREST[comparison_name],
         )
-        in1not2 = self.value_differences(v1_values, v2_values)
-        in2not1 = self.value_differences(v2_values, v1_values)
+        in1not2 = self.value_differences(v_values, v_prev_values)
+        in2not1 = self.value_differences(v_prev_values, v_values)
         return (in1not2, in2not1)

--- a/apps/qa/src/pages/pluto/components/mismatch_report.py
+++ b/apps/qa/src/pages/pluto/components/mismatch_report.py
@@ -22,6 +22,11 @@ class MismatchReport:
         v1v2 = self.filter_by_version_pair(df, self.version_pairs[0])
         v2v3 = self.filter_by_version_pair(df, self.version_pairs[1])
 
+        st.header("Mismatched Records")
+        st.info(
+            "Each mismatch graph and table shows the number of records (identified by bbl) with a changed value in a given field."
+        )
+
         for group in self.groups:
             self.display_graph(v1v2, v2v3, group)
 
@@ -31,7 +36,7 @@ class MismatchReport:
             """
             This table reports the number of records with differences in a field value between versions. 
             This table is useful for digging into any anomalies identified using the graphs above.
-        """
+            """
         )
 
     def display_graph(self, v1v2, v2v3, group):
@@ -41,7 +46,10 @@ class MismatchReport:
         fig.add_trace(self.generate_version_trace(v2v3, group["columns"]))
 
         fig.update_layout(
-            title=group["title"], template="plotly_white", colorway=COLOR_SCHEME
+            title=group["title"],
+            template="plotly_white",
+            colorway=COLOR_SCHEME,
+            yaxis={"title": "# Changed Records"},
         )
 
         st.plotly_chart(fig)

--- a/apps/qa/src/pages/pluto/components/mismatch_report.py
+++ b/apps/qa/src/pages/pluto/components/mismatch_report.py
@@ -4,14 +4,15 @@ from src.shared.constants import COLOR_SCHEME
 
 
 class MismatchReport:
-    def __init__(self, data, v1, v2, v3, condo, mapped):
+    def __init__(self, data, v, v_prev, v_comp, v_comp_prev, condo, mapped):
         self.df_mismatch = data
-        self.v1 = v1
-        self.v2 = v2
-        self.v3 = v3
+        self.v = v
+        self.v_prev = v_prev
+        self.v_comp = v_comp
+        self.v_comp_prev = v_comp_prev
         self.version_pairs = [
-            f"{v1} - {v2}",
-            f"{v2} - {v3}",
+            f"{v} - {v_prev}",
+            f"{v_comp} - {v_comp_prev}",
         ]
         self.condo = condo
         self.mapped = mapped

--- a/apps/qa/src/pages/pluto/components/outlier_report.py
+++ b/apps/qa/src/pages/pluto/components/outlier_report.py
@@ -4,17 +4,17 @@ from st_aggrid import AgGrid
 
 
 class OutlierReport:
-    def __init__(self, data, v1, v2, condo, mapped):
+    def __init__(self, data, v, v_prev, condo, mapped):
         self.df = data
-        self.v1 = v1
-        self.v2 = v2
+        self.v = v
+        self.v_prev = v_prev
         self.condo = condo
         self.mapped = mapped
 
     def __call__(self):
         st.header("Outlier Analysis")
 
-        if self.v1 not in self.versions:
+        if self.v not in self.versions:
             st.info("There is no outlier report available for selected version.")
             return
 
@@ -40,7 +40,7 @@ class OutlierReport:
                 AgGrid(df)
 
     def fetch_dataframe(self, field):
-        records = [i["values"] for i in self.v1_outlier_records if i["field"] == field][
+        records = [i["values"] for i in self.v_outlier_records if i["field"] == field][
             0
         ]
 
@@ -64,17 +64,17 @@ class OutlierReport:
         return self.df.loc[
             (self.df.condo == self.condo)
             & (self.df.mapped == self.mapped)
-            & (self.df.v == self.v1),
+            & (self.df.v == self.v),
             :,
         ].to_dict("records")
 
     @property
-    def v1_outlier_records(self):
-        return [i["outlier"] for i in self.outlier_records if i["v"] == self.v1][0]
+    def v_outlier_records(self):
+        return [i["outlier"] for i in self.outlier_records if i["v"] == self.v][0]
 
     @property
     def version_pair(self):
-        return f"{self.v1}-{self.v2}"
+        return f"{self.v}-{self.v_prev}"
 
     @property
     def markdown_dict(self):

--- a/apps/qa/src/pages/pluto/components/version_comparison_report.py
+++ b/apps/qa/src/pages/pluto/components/version_comparison_report.py
@@ -1,0 +1,102 @@
+import streamlit as st
+
+from src.shared.components import build_outputs
+from .mismatch_report import MismatchReport
+from .null_graph import NullReport
+from .source_data_versions_report import (
+    SourceDataVersionsReport,
+)
+from .expected_value_differences_report import (
+    ExpectedValueDifferencesReport,
+)
+from .outlier_report import OutlierReport
+from .aggregate_report import AggregateReport
+from .bbl_diffs_report import BblDiffsReport
+
+
+def version_comparison_report(product_key, data):
+    versions = sorted(data["df_aggregate"]["v"].unique(), reverse=True)
+
+    v1 = st.sidebar.selectbox(
+        "Choose a version of PLUTO",
+        versions,
+    )
+    v2 = st.sidebar.selectbox(
+        "Choose a Previous version of PLUTO",
+        versions,
+        versions.index(v1) + 1,
+        disabled=True,
+    )
+    v3 = st.sidebar.selectbox(
+        "Choose a Previous Previous of PLUTO",
+        versions,
+        versions.index(v1) + 2,
+        disabled=True,
+    )
+
+    condo = st.sidebar.checkbox("condo only")
+    mapped = st.sidebar.checkbox("mapped only")
+
+    build_outputs.data_directory_link(product_key)
+
+    st.markdown(
+        f"""
+        **{v1}** is the Current version
+
+        **{v2}** is the Previous version
+
+        **{v3}** is the Previous Previous version
+    """
+    )
+    st.markdown(
+        f"""
+        This series of reports compares two pairs of PLUTO versions using two colors in graphs:
+        - blue: the Selected and the Previous versions ({v1})
+        - gold: the previous two versions ({v2})
+
+        The graphs report the number of records that have a different value in a given field but share the same BBL between versions.
+
+        In this series of graphs the x-axis is the field name and the y-axis is the total number of records. \
+
+        The graphs are useful to see if there are any dramatic changes in the values of fields between versions.
+
+        For example, you can read these graphs as "there are 300,000 records with the same BBL between {v1} to {v2}, but the exempttot value changed."
+
+        Hover over the graph to see the percent of records that have a change.
+
+        There is an option to filter these graphs to just show condo lots. \
+        Condos make up a small percentage of all lots, but they contain a large percentage of the residential housing. \
+        A second filter enables you look at all lots or just mapped lots. \
+        Unmapped lots are those with a record in PTS, but no corresponding record in DTM. \
+        This happens because DOF updates are not in sync.
+
+    """
+    )
+
+    MismatchReport(
+        data=data["df_mismatch"],
+        v1=v1,
+        v2=v2,
+        v3=v3,
+        condo=condo,
+        mapped=mapped,
+    )()
+
+    AggregateReport(
+        data=data["df_aggregate"],
+        v1=v1,
+        v2=v2,
+        v3=v3,
+        condo=condo,
+        mapped=mapped,
+    )()
+
+    NullReport(data=data["df_null"], v1=v1, v2=v2, v3=v3, condo=condo, mapped=mapped)()
+
+    SourceDataVersionsReport(version_text=data["version_text"])()
+
+    ExpectedValueDifferencesReport(data=data["df_expected"], v1=v1, v2=v2)()
+
+    OutlierReport(data=data["df_outlier"], v1=v1, v2=v2, condo=condo, mapped=mapped)()
+
+    BblDiffsReport(data=data.get("df_bbl_diffs", None))()

--- a/apps/qa/src/pages/pluto/pluto.py
+++ b/apps/qa/src/pages/pluto/pluto.py
@@ -21,7 +21,16 @@ def pluto():
         data = get_data(product_key)
 
         if report_type == "Compare with Previous Version":
-            version_comparison_report(product_key, data)
+            comp_type = st.sidebar.selectbox(
+                "Comparison Type",
+                ["Previous", "Last of same version type"],
+                help="""
+                    "Previous" will compare 24v2 - 24v1.1 diffs with 24v1.1 - 24v1 diffs \n
+                    "Last of same version type" will compare instead to last major or minor i.e. 24v2 - 24v1.1 to 24v1 - 24v3.1
+                """,
+            )
+
+            version_comparison_report(product_key, data, comp_type)
 
         elif report_type == "Review Manual Changes":
             ChangesReport(data)()

--- a/apps/qa/tests/test_pluto.py
+++ b/apps/qa/tests/test_pluto.py
@@ -14,17 +14,17 @@ def example_ExpectedValueDifferencesReport():
     data = get_data(publishing.PublishKey(PRODUCT, TEST_VERSION_1))
     return ExpectedValueDifferencesReport(
         data=data["df_expected"],
-        v1=TEST_VERSION_1,
-        v2=TEST_VERSION_2,
+        v=TEST_VERSION_1,
+        v_prev=TEST_VERSION_2,
     )
 
 
-def test_v1_expected_records(
+def test_expected_records(
     example_ExpectedValueDifferencesReport: ExpectedValueDifferencesReport,
 ):
-    v1_expected_records = example_ExpectedValueDifferencesReport.v1_expected_records
-    assert isinstance(v1_expected_records, list)
-    assert len(v1_expected_records) == 15
+    expected_records = example_ExpectedValueDifferencesReport.v_expected_records
+    assert isinstance(expected_records, list)
+    assert len(expected_records) == 15
 
 
 def test_values_by_field(
@@ -44,9 +44,9 @@ def test_values_by_field(
         "C2-5",
         "C1-3",
     ]
-    v1_expected_records = example_ExpectedValueDifferencesReport.v1_expected_records
+    expected_records = example_ExpectedValueDifferencesReport.v_expected_records
     values_by_field_actual = example_ExpectedValueDifferencesReport.values_by_field(
-        v1_expected_records,
+        expected_records,
         field,
     )
     assert values_by_field_actual == values_by_field_expected
@@ -80,9 +80,9 @@ def test_values_by_fields(
         "C1-5",
         "C1-1",
     ]
-    v1_expected_records = example_ExpectedValueDifferencesReport.v1_expected_records
+    expected_records = example_ExpectedValueDifferencesReport.v_expected_records
     actual_values = example_ExpectedValueDifferencesReport.values_by_fields(
-        v1_expected_records,
+        expected_records,
         fields,
     )
     assert actual_values == expected_values

--- a/bash/export_recipe_env.sh
+++ b/bash/export_recipe_env.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 # This file must be used with "source" to export to active shell env
 
 function export_ {
@@ -9,6 +8,11 @@ function export_ {
         echo "$1" >> $GITHUB_ENV
     fi
 }
+
+if [[ ! -f "$1" ]] ; then
+    echo "File \"$1\" does not exist"
+    exit 1
+fi
 
 for s in $(cat $1 | yq -o json | jq -r ".vars|to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" ); do
     export_ $s

--- a/products/cpdb/cpdb.sh
+++ b/products/cpdb/cpdb.sh
@@ -57,7 +57,6 @@ function share {
 }
 
 case $1 in 
-    dataloading ) python3 -m dcpy.lifecycle.builds.load recipe --recipe_path ./${2:-"recipe"}.yml ;;
     preprocessing ) ./bash/01_preprocessing.sh ;;
     attribute ) ./bash/02_build.sh ;;
     adminbounds ) ./bash/03_adminbounds.sh ;;
@@ -68,10 +67,6 @@ case $1 in
     share ) share $@ ;;
     sql) sql $@;;
     build)
-        recipe=$2
-        shift 2
-        python3 -m dcpy.lifecycle.builds.load recipe --recipe-path ${recipe}.yml $@
-        export VERSION=$(yq .version recipe.lock.yml)
         ./bash/01_preprocessing.sh
         ./bash/02_build.sh
         ./bash/03_adminbounds.sh

--- a/products/pluto/pluto_build/06_export.sh
+++ b/products/pluto/pluto_build/06_export.sh
@@ -2,10 +2,6 @@
 source ./bash/config.sh
 set_error_traps
 
-echo "Vacuuming build DB"
-# NOTE in the future may need to drop big tables (dof_dtm, pluto_input_cama_dof, pluto_input_geocodes)
-run_sql_command "VACUUM (FULL, ANALYZE, VERBOSE)"
-
 mkdir -p output
 
 cd output

--- a/products/pluto/pluto_build/bash/config.sh
+++ b/products/pluto/pluto_build/bash/config.sh
@@ -5,7 +5,6 @@ ROOT_DIR="${FILE_DIR}/../../.."
 
 source $ROOT_DIR/bash/utils.sh
 
-set_env $ROOT_DIR/.env
 set_error_traps
 
 function import_qaqc {

--- a/products/pluto/pluto_build/sql/remove_unitlots.sql
+++ b/products/pluto/pluto_build/sql/remove_unitlots.sql
@@ -18,6 +18,7 @@ INSERT INTO pluto_removed_records (
 DELETE FROM pluto
 WHERE
     lot::numeric >= 1000
+    AND lot NOT LIKE '75%'
     AND unitstotal::numeric > 1
     AND geom IS NULL;
 


### PR DESCRIPTION
Does NOT actually close #657, 

Closes #538

Part of #831 

Ended being a bunch of little stuff in here, so will go commit by commit

### QAQC Enhancements (#538) See issue for screenshots
1. Move logic to a component. Mainly wanted as part of commit 2 but this makes diffs in commit 2 easier to see
2. Add selectbox that lets you choose whether the other "diff" being shown is the previous, or previous of the same build type (major vs minor). The current build is a good example. We built 24v2. The prev is 24v1.1, so our "current" diff is "24v2 - 24v1.1". The former default, "previous previous" diff would be "24v1.1 - 24v1". But if we want to compare this to the last "major" diff instead, we can now do that, where the comparison diff will be "24v1 - 23v3.1" instead.
    There are cases where these would be the same - if we didn't have a minor last build and current was "24v2 - 24v1", either option would be "24v1 - 23v3.1". Same if we have 24v2.2 - both will be "24v2.1 - 24v2"
    This works for minors as well. 24v1.1 (with diff "24v1.1 - 24v1") can either look at diff "24v1 - 23v3.1" or "23v3.1 - 23v3"
    This commit includes a lot of renaming - instead of just "v1" "v2" and "v3" thought it's best to describe. So "version"/"v", "previous", "comparison", and "comparison_previous" seemed intuitive to me. "previous" always describing the directly preceding build, and "comparison" describing the build whose diff we want to compare to.
3. Adding new fields to outlier reports so that GIS can filter them out of the tables. So adding an additional column to the QA outputs as well as a checkbox in the app to filter rows. This checkbox is grayed out (with a useful tooltip) if the build doesn't have the new columns
4. add a few comments and axes labels as requested

### Non-correction or QA changes
5. don't vacuum in pluto build. This took a little while, and was added to attempt to reclaim space in constrained github runner temp postgres instances. Our db seems to have aggressive autovacuuming set up, so this seems unneeded
6. we've moved away from using .envs in this manner - I personally would rather run `set_env` manually before a build. Maybe worth broader discussion
7. Fix a bug introduced in #801 (or rather not entirely fixed - the fix was needed in 3 lines, I only added it on 2)
8. Rework "repeat" build functionality. I wanted to be able to repeat a draft, rather than only published versions, since once GIS begins QAing a dataset, it seems like we should be locking versions of all input datasets as to not introduce potentially new errors. This was tough with the way I initially implemented this. I decoupled normal recipe-planning and this repeat logic since they require fairly different inputs, and we can't have dynamic inputs to github actions
