### PR TITLE
Add Socrata distribution README

### DIFF
--- a/.github/workflows/socrata_publish_dataset.yml
+++ b/.github/workflows/socrata_publish_dataset.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       PRODUCT_NAME:
-        description: "Name of the dataset"
+        description: "Name of the product"
         type: string
         required: true
       DATASET:
@@ -21,12 +21,12 @@ on:
         type: string
         required: true
       PUBLISH:
-        description: "Publish the revision? Or leave open"
+        description: "Publish the revision? (if not, will leave the revision open)"
         type: boolean
         default: false
         required: true
       IGNORE_VALIDATION_ERRORS:
-        description: "Ignore Validation Errors? Will still perform validation, but ignore errors, allowing a push"
+        description: "Ignore Validation Errors? (Will still perform validation, but will just log the outputs to the console"
         type: boolean
         default: false
         required: true

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -221,6 +221,12 @@ class Revision:
     def revision_endpoint(self):
         return f"{_revisions_root}/{self.four_four}/{self.revision_num}"
 
+    @property
+    def page_url(self):
+        return (
+            f"https://{SOCRATA_DOMAIN}/d/{self.four_four}/revisions/{self.revision_num}"
+        )
+
     def apply(self):
         """Apply the revision to the dataset, closing the revision."""
         return _socrata_request(f"{self.revision_endpoint}/apply", "put")
@@ -372,13 +378,16 @@ def push_shp(
         # Upating column Metadata is tricky, and there's still some work to be done
         logger.error(
             f"""Error Updating Column Metadata! However,
-        the Dataset File was uploaded and the revision can still be applied manually. Error: {e}"""
+            the Dataset File was uploaded and the revision can still be applied manually, here: {rev.page_url}
+            Error: {e}"""
         )
         return
 
     if not publish:
         logger.info(
-            f"Finished syncing product to Socrata, but did not publish. Find revision {rev.revision_num}, and apply manually"
+            f"""Finished syncing product to Socrata, but did not publish. Find revision {rev.revision_num}, and apply manually
+            here {rev.page_url}
+            """
         )
     else:
         logger.info("Publishing")
@@ -394,7 +403,8 @@ def push_shp(
             elapsed_secs += 5
             if elapsed_secs > SOCRATA_REVISION_APPLY_TIMEOUT_SECS:
                 raise Exception(
-                    f"waited {SOCRATA_REVISION_APPLY_TIMEOUT_SECS} seconds for the Socrata \
-                revision to apply, but it didn't. Note: it may just be a very long running job. Please investigate manually."
+                    f"""waited {SOCRATA_REVISION_APPLY_TIMEOUT_SECS} seconds for the Socrata \
+                    revision to apply, but it didn't. Note: it may just be a very long running job.
+                    Please investigate manually here: {rev.page_url}"""
                 )
         logger.info("Job Finished Successfully")

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -70,6 +70,6 @@ INFO:dcpy:Finished syncing product to Socrata, but did not publish. Find revisio
 INFO:dcpy:            here https://data.cityofnewyork.us/d/b7pm-uzu7/revisions/32
 ```
 
-[ TODO: Image Here ]
 Follow the provided link. Here you can review the modified data and metadata. Hit `Update` in the top right to apply the revision. 
+![template_db_socrata](https://github.com/NYCPlanning/data-engineering/assets/11164730/b0c24251-00e3-4be1-99a6-6cf015240cc6)
 

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -1,10 +1,12 @@
 # Distribute
 
 ## Terms
-- `Product`: a suite of datasets. E.g. LION, which contains multiple `datasets`, such as "2010 Census Blocks" or "Community Districts (water areas Included)"
-- `Dataset` : roughly analogous to what you'd find on a Socrata page. Effectively it's metadata, attachments, and dataset files. 
-- `Dataset File`: actual file for a dataset, e.g. a csv, or a shapefile. Note: there may be slight variations between `dataset files` for the same `dataset`. e.g. columns in the shapefile for PLUTO will have slightly different columns than the csv. 
+- `Dataset`: Abstractly, a single table of data and metadata about it.
+- `Product`: A suite of datasets. E.g. LION, which contains multiple `datasets`, such as "2010 Census Blocks" or "Community Districts (water areas Included)"
+- `Dataset File`: Actual file export for a dataset, e.g. a csv, or a shapefile. Note: there may be slight variations between `dataset files` for the same `dataset`. e.g. columns in the shapefile for PLUTO will have slightly different columns than the csv. 
 - `Attachment`: README's, data dictionaries, etc.
+- `Dataset Package`: Instance of a `Dataset`, meaning metadata, attachments, and dataset files. 
+- `Product Package`: Versioned collection of Dataset Packages. 
 
 ## How to distribute to Socrata
 Socrata datasets consist of, effectively, one table. In the past, a single Socrata dataset could contain multiple shapefile layers, but that's no longer the case. So for us:
@@ -51,10 +53,10 @@ Note: this is a low-risk operation when you don't tick the box to publish the da
 ## The Socrata Publish Flow
 In our publishing connector, the flow for distributing is as follows: 
 
-- create a new revision for the dataset, and discard other open revisions. 
-- upload attachments, and update dataset-level metadata. (e.g. the dataset description or tags) 
-- Upload the dataset itself. Currently only shapefiles are supported. 
-- _Attempt_ to update column metadata for the uploaded dataset. This step is placed last because it's the most finicky at the moment, as it entails reconciling our uploaded columns, Socrata's existing columns, and our metadata. However, should this step fail, you can still go manually apply the revision in the Socrata GUI. 
+1. create a new revision for the dataset, and discard other open revisions. 
+2. upload attachments, and update dataset-level metadata. (e.g. the dataset description or tags) 
+3. Upload the dataset itself. Currently only shapefiles are supported. 
+4. _Attempt_ to update column metadata for the uploaded dataset. This step is placed last because it's the most finicky at the moment, as it entails reconciling our uploaded columns, Socrata's existing columns, and our metadata. However, should this step fail, you can still go manually apply the revision in the Socrata GUI. 
 
 ## Applying Revisions in Socrata
 

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -55,3 +55,21 @@ In our publishing connector, the flow for distributing is as follows:
 - upload attachments, and update dataset-level metadata. (e.g. the dataset description or tags) 
 - Upload the dataset itself. Currently only shapefiles are supported. 
 - _Attempt_ to update column metadata for the uploaded dataset. This step is placed last because it's the most finicky at the moment, as it entails reconciling our uploaded columns, Socrata's existing columns, and our metadata. However, should this step fail, you can still go manually apply the revision in the Socrata GUI. 
+
+## Applying Revisions in Socrata
+
+In the case of errors, or if the the `--publish` flag isn't supplied, you'll have to manually apply on the Socrata website. Below is an example push without a publish:
+
+```
+INFO:dcpy:Pushing shapefiles at .package/product_datasets/template_db/package/20231227/template_db/dataset_files/templatedb_points.shp.zip to b7pm-uzu7 - rev: 32
+INFO:dcpy:Updating Columns at https://data.cityofnewyork.us/api/publishing/v1/source/202450926/schema/199848287
+INFO:dcpy:                    Columns in uploaded data: {'place_name', 'bbl', 'place_type', 'wkb_geometry', 'borough'}
+INFO:dcpy:                    Columns from our metadata: ['place_name', 'bbl', 'place_type', 'borough', 'wkb_geometry']
+INFO:dcpy:
+INFO:dcpy:Finished syncing product to Socrata, but did not publish. Find revision 32, and apply manually
+INFO:dcpy:            here https://data.cityofnewyork.us/d/b7pm-uzu7/revisions/32
+```
+
+[ TODO: Image Here ]
+Follow the provided link. Here you can review the modified data and metadata. Hit `Update` in the top right to apply the revision. 
+

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -1,0 +1,57 @@
+# Distribute
+
+## Terms
+- `Product`: a suite of datasets. E.g. LION, which contains multiple `datasets`, such as "2010 Census Blocks" or "Community Districts (water areas Included)"
+- `Dataset` : roughly analogous to what you'd find on a Socrata page. Effectively it's metadata, attachments, and dataset files. 
+- `Dataset File`: actual file for a dataset, e.g. a csv, or a shapefile. Note: there may be slight variations between `dataset files` for the same `dataset`. e.g. columns in the shapefile for PLUTO will have slightly different columns than the csv. 
+- `Attachment`: README's, data dictionaries, etc.
+
+## How to distribute to Socrata
+Socrata datasets consist of, effectively, one table. In the past, a single Socrata dataset could contain multiple shapefile layers, but that's no longer the case. So for us:
+
+One `Dataset Package` -> one Socrata page.
+
+So the first step is to assemble the `Dataset Package`.
+
+#### Dataset Package Structure
+The package must be structured like so:
+- `/attachments/`: folder containing all attachments (except metadata.yml)
+- `/dataset_files/`: folder containing data files for the dataset, e.g. the shapefile, the csv, etc.
+- `metadata.yml`: describes all columns, destinations, expected attachments, and expected dataset files. It also drives all the package-level validation.
+
+#### Pushing from S3 via CLI:
+
+To push from S3, the Dataset Package must exist in `edm-publishing` in the `product_datasets` folder, under it's relevant product folder. The directory structure is:
+```
+edm-publishing / product_dataset / {product_name} / package / {version} / {dataset_name} / [package files here]
+```
+Note: In many cases the product has only one dataset, e.g. Facilities. In that case, the convention is to just use the same product_name and dataset_name. E.g 
+```
+edm-publishing / product_dataset / facilities / package / 24v2 / facilities / [package files here]
+```
+To actually push:
+```
+python -m dcpy.cli lifecycle distribute socrata from_s3 [args]
+```
+The --help flag will list required args.
+
+Note that unless you explicitly specify `--publish`, only a draft will be created on Socrata, and you'll need to manually apply it via the socrata GUI. The output of the command will tell you the revision number, which you can find via search on Socrata. There you can review data changes, metadata changes, etc, before actually publishing. 
+
+##### Quick Tip
+If package validation fails, you can validate locally by running the validation commands locally:
+```
+python -m dcpy.cli lifecycle package validate [your package path here]
+```
+
+#### Pushing from S3 via Github Action:
+[Relevant Action](https://github.com/NYCPlanning/data-engineering/actions/workflows/socrata_publish_dataset.yml). The same options as above apply. You'll need to supply the product name, the dataset name, and the version.
+
+Note: this is a low-risk operation when you don't tick the box to publish the dataset. 
+
+## The Socrata Publish Flow
+In our publishing connector, the flow for distributing is as follows: 
+
+- create a new revision for the dataset, and discard other open revisions. 
+- upload attachments, and update dataset-level metadata. (e.g. the dataset description or tags) 
+- Upload the dataset itself. Currently only shapefiles are supported. 
+- _Attempt_ to update column metadata for the uploaded dataset. This step is placed last because it's the most finicky at the moment, as it entails reconciling our uploaded columns, Socrata's existing columns, and our metadata. However, should this step fail, you can still go manually apply the revision in the Socrata GUI. 


### PR DESCRIPTION
A quick README for distributing to Socrata. @fvankrieken @sf-dcp @damonmcc let me know what information would be useful in order to get started automating socrata distributions.

Also, if you have any suggestions for formatting, etc. I like the idea of having README's at relevant levels in dcpy, then perhaps we can link them together from a top-level README