### PR TITLE
Add new historical footprints GR test to app

### DIFF
--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -22,56 +22,15 @@ jobs:
     strategy:
       matrix:
         dataset:
-          - council_members
-          - dca_operatingbusinesses
-          - dcla_culturalinstitutions
-          - dcp_edeseignation_csv
-          - dep_cats_permits
-          - dfta_contracts
-          - doe_busroutesgarages
-          - doe_eszones
-          - doe_hszones
-          - doe_mszones
-          - dohmh_daycare
-          - doit_evictions
-          - doitt_buildingcentroids
           - doitt_buildingfootprints
           - doitt_buildingfootprints_historical
-          - dot_pedplazas
-          - dot_projects_intersections
-          - dot_projects_streets
-          - dpr_forever_wild
           - dpr_greenthumb
           - dpr_park_access_zone
           - dpr_parksproperties
-          - dpr_schoolyard_to_playgrounds
-          - dsny_donatenycdirectory
-          - dsny_electronicsdrop
-          - dsny_fooddrop
           - dsny_frequencies
           - dsny_garages
-          - dsny_leafdrop
-          - dsny_specialwastedrop
-          - dsny_textiledrop
-          - dycd_afterschoolprograms
-          - dycd_service_sites
-          - fdny_firecompanies
-          - fdny_firehouses
-          - hhc_hospitals
-          - hpd_hny_units_by_building
-          - hra_jobcenters
-          - hra_medicaid
-          - hra_snapcenters
-          - lpc_historic_district_areas
           - lpc_historic_districts
           - lpc_landmarks
-          - lpc_scenic_landmarks
-          - nycha_communitycenters
-          - nycha_policeservice
-          - nypd_policeprecincts
-          - qpl_libraries
-          - sbs_workforce1
-          - sca_enrollment_capacity
           
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -22,13 +22,57 @@ jobs:
     strategy:
       matrix:
         dataset:
+          - council_members
+          - dca_operatingbusinesses
+          - dcla_culturalinstitutions
+          - dcp_edeseignation_csv
+          - dep_cats_permits
+          - dfta_contracts
+          - doe_busroutesgarages
+          - doe_eszones
+          - doe_hszones
+          - doe_mszones
+          - dohmh_daycare
+          - doit_evictions
+          - doitt_buildingcentroids
           - doitt_buildingfootprints
+          - doitt_buildingfootprints_historical
+          - dot_pedplazas
+          - dot_projects_intersections
+          - dot_projects_streets
+          - dpr_forever_wild
+          - dpr_greenthumb
+          - dpr_park_access_zone
+          - dpr_parksproperties
+          - dpr_schoolyard_to_playgrounds
+          - dsny_donatenycdirectory
+          - dsny_electronicsdrop
+          - dsny_fooddrop
+          - dsny_frequencies
+          - dsny_garages
+          - dsny_leafdrop
+          - dsny_specialwastedrop
+          - dsny_textiledrop
+          - dycd_afterschoolprograms
+          - dycd_service_sites
+          - fdny_firecompanies
+          - fdny_firehouses
+          - hhc_hospitals
+          - hpd_hny_units_by_building
+          - hra_jobcenters
+          - hra_medicaid
+          - hra_snapcenters
+          - lpc_historic_district_areas
           - lpc_historic_districts
           - lpc_landmarks
-          - dpr_greenthumb
-          - dpr_parksproperties
-          - dsny_frequencies
-          - dpr_park_access_zone
+          - lpc_scenic_landmarks
+          - nycha_communitycenters
+          - nycha_policeservice
+          - nypd_policeprecincts
+          - qpl_libraries
+          - sbs_workforce1
+          - sca_enrollment_capacity
+          
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/qa/src/pages/gru/constants.py
+++ b/apps/qa/src/pages/gru/constants.py
@@ -20,6 +20,12 @@ qa_checks = pd.DataFrame(
             ["rejects_footprintbin_padbin"],
             ["doitt_buildingfootprints"],
         ),
+        (
+            "Historical Footprint BINs vs PAD",
+            "historical-footprints-vs-pad",
+            ["all_results_historicalfootprintbin_padbin"],
+            ["doitt_buildingfootprints_historical"],
+        ),
         ("TBINs vs. C/Os", "housing", ["tbins_certf_occp"], ["dcp_developments"]),
         (
             "PAD BINs vs Footprint BINs",


### PR DESCRIPTION
Closes #812 
Follow up to https://github.com/NYCPlanning/db-gru-qaqc/pull/267 - Output (from new check in linked PR) has already been confirmed as what's needed (for now at least) by VB. This gets the new check in the dashboard

Check added to dashboard (both screenshots running app locally)

![image](https://github.com/NYCPlanning/data-engineering/assets/9454672/b6f8b93f-fae8-4342-a19e-5c7a0d969847)

And successfully triggered

<img width="947" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/f703019a-14fd-4b75-879d-c3be893b5815">
