### PR TITLE
Create repeat_build.yml

### DIFF
--- a/.github/workflows/repeat_build.yml
+++ b/.github/workflows/repeat_build.yml
@@ -1,0 +1,5 @@
+name: 🏗️ Repeat a Product Build
+run-name: "🏗️ Repeat a Product Build: ${{ inputs.product }}/${{ inputs.product_type }}/${{ inputs.version_or_build }}"
+
+on:
+  workflow_dispatch:


### PR DESCRIPTION
I'm extending the repeating a build functionality, and because of the different inputs than regular building, think it's cleaner to have it as a separate workflow

Stub so I can use this on my branch