### PR TITLE
FacDB 24v1: address issues from QAQC (round 2)

### DIFF
--- a/dcpy/library/templates/dot_pedplazas.yml
+++ b/dcpy/library/templates/dot_pedplazas.yml
@@ -9,7 +9,7 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:2263
+      SRS: EPSG:4326
       type: POLYGON
 
   destination:

--- a/dcpy/library/templates/nysdec_lands.yml
+++ b/dcpy/library/templates/nysdec_lands.yml
@@ -2,11 +2,10 @@ dataset:
   name: nysdec_lands
   acl: public-read
   source:
-    url:
-      path: .library/upload/NYS_DEC_Lands.csv
-    options:
-      - "AUTODETECT_TYPE=NO"
-      - "EMPTY_STRING_AS_NULL=YES"
+    arcgis_feature_server:
+      server: nys_clearinghouse
+      name: NYS_DEC_Lands
+      layer: 0
     geometry:
       SRS: EPSG:26918
       type: MULTIPOLYGON


### PR DESCRIPTION
Related to #461.

GIS found 2 new issues as a part of their 2nd QAQC (original issues from 1st QAQC review were already addressed): 

## 1. `nysdec_lands`
In both 24v1 draft builds, the qaqc report was showing zero `nysdec_lands` facilities when compared to 88 facilities in 23v2 version. After inspecting the source data, it seems that the csv obtained from the source website had all records with null geometries resulting in zero `nysdec_lands` records in facdb table: 
![image](https://github.com/NYCPlanning/data-engineering/assets/144725249/730f0837-40be-4045-b320-cf856ad7619d)

**Solution**: instead of downloading a csv from the website, update `nysdec_lands` recipe to pull data from arcgis server. New data now shows geometries:
    <img width="935" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/a7c08e63-deea-4d20-878b-e9a64e91bf76">

Successful pull of updated recipe [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9099856767/job/25013381524).

## 2. `dot_pedplazas`
The facdb table didn't have a single `dot_pedplazas` facility. In previous builds, we received a `dot_pedplazas` file from the DOT. I updated the `dot_pedpazas` recipe to pull data from Socrata but didn't update the source projection, incorrectly mapping `dot_pedplazas` facilities in a different state. 

**Solution**: I updated the projection and now the count has been restored:
<img width="1015" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/144725249/6a39df4e-2ee2-49ac-a6e6-587fa1606616">

#### Successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9101845730/job/25020039844).

#### Note, I plan to remove last commit clipping recipe versions prior to merging to main.
