### PR TITLE
protect `nightly_qa` build artifacts from `clean_artifacts`

### DIFF
--- a/dcpy/lifecycle/builds/clean_artifacts.py
+++ b/dcpy/lifecycle/builds/clean_artifacts.py
@@ -9,11 +9,14 @@ from dcpy.lifecycle.builds import metadata
 
 from . import BUILD_REPO, BUILD_DBS
 
+PROTECTED_BUILD_NAMES = ["nightly_qa"]
+
 
 def get_active_build_names(as_schema=False) -> list[str]:
     branches = github.get_branches(repo=BUILD_REPO)  # all remote branches
     branch_build_names = sorted(
-        [
+        PROTECTED_BUILD_NAMES
+        + [
             metadata.build_name(name=branch) if as_schema else branch
             for branch in branches
         ]


### PR DESCRIPTION
our [action](https://github.com/NYCPlanning/data-engineering/actions/workflows/stale_builds.yml) runs automatically every week and can be run manually (would like to run today)

but because we don't have a branch named `nightly_qa`, that schema is always deleted. the `nightly_qa` build artifacts are very helpful as a "baseline" for comparing to dev branch builds so shouldn't be deleted

## tests

log [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9292326246/job/25572980322#step:5:735) of  action run keeping `nightly_qa` and `nightly_qa__tests` (with a since-deleted commit that prevented actual schema deletion)