### PR TITLE
GFT: Filter CATS permits that start with `PA` or `PB` permit id

### DIFF
--- a/products/green_fast_track/models/intermediate/spatial/air_quality/int_spatial__cats_permits.sql
+++ b/products/green_fast_track/models/intermediate/spatial/air_quality/int_spatial__cats_permits.sql
@@ -5,7 +5,7 @@ WITH cats_permits AS (
         permit_geom
     FROM
         {{ ref('stg__dep_cats_permits') }}
-    WHERE upper(status) IN ('EXPIRED', 'CURRENT') and variable_id SIMILAR TO 'PA%|PB%'
+    WHERE UPPER(status) IN ('EXPIRED', 'CURRENT') AND variable_id SIMILAR TO 'PA%|PB%'
 ),
 
 pluto AS (

--- a/products/green_fast_track/models/intermediate/spatial/air_quality/int_spatial__cats_permits.sql
+++ b/products/green_fast_track/models/intermediate/spatial/air_quality/int_spatial__cats_permits.sql
@@ -5,6 +5,7 @@ WITH cats_permits AS (
         permit_geom
     FROM
         {{ ref('stg__dep_cats_permits') }}
+    WHERE upper(status) IN ('EXPIRED', 'CURRENT') and variable_id SIMILAR TO 'PA%|PB%'
 ),
 
 pluto AS (

--- a/products/green_fast_track/models/staging/stg__dep_cats_permits.sql
+++ b/products/green_fast_track/models/staging/stg__dep_cats_permits.sql
@@ -9,7 +9,6 @@ final AS (
         status,
         st_transform(geom::geometry, 2263) AS permit_geom
     FROM source
-    WHERE upper(status) IN ('EXPIRED', 'CURRENT')
 )
 
 SELECT * FROM final


### PR DESCRIPTION
Fixes #872.

I also moved filtering by status from staging to intermediate model as it makes more sense to have it there. 

Build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9308602666/job/25622348258)