### PR TITLE
fix GFT Shadows Historic Resources

### DIFF
--- a/products/green_fast_track/analyses/pluto_zoning_district_groups.sql
+++ b/products/green_fast_track/analyses/pluto_zoning_district_groups.sql
@@ -15,7 +15,7 @@ group_by_rollup AS (
         zonedist4,
         count(*) AS zoning_combo_count
     FROM pluto
-    GROUP BY rollup(zonedist1, zonedist2, zonedist3, zonedist4) -- noqa: PRS
+    GROUP BY ROLLUP(zonedist1, zonedist2, zonedist3, zonedist4) -- noqa: PRS, CP03
 )
 
 SELECT

--- a/products/green_fast_track/analyses/pluto_zoning_district_groups.sql
+++ b/products/green_fast_track/analyses/pluto_zoning_district_groups.sql
@@ -15,7 +15,7 @@ group_by_rollup AS (
         zonedist4,
         count(*) AS zoning_combo_count
     FROM pluto
-    GROUP BY ROLLUP (zonedist1, zonedist2, zonedist3, zonedist4) -- noqa: PRS
+    GROUP BY rollup(zonedist1, zonedist2, zonedist3, zonedist4) -- noqa: PRS
 )
 
 SELECT

--- a/products/green_fast_track/analyses/source_geometry_counts.sql
+++ b/products/green_fast_track/analyses/source_geometry_counts.sql
@@ -1,0 +1,42 @@
+WITH all_spatial AS (SELECT * FROM {{ ref("int_spatial__all") }}),
+
+record_details AS (
+    SELECT
+        source_relation,
+        flag_id_field_name,
+        variable_type,
+        raw_geom IS NOT null AS has_raw_geom,
+        lot_geom IS NOT null AS has_lot_geom,
+        buffer_geom IS NOT null AS has_buffer_geom
+    FROM all_spatial
+),
+
+counts AS (
+    SELECT
+        flag_id_field_name,
+        variable_type,
+        count(*) AS variable_type_count,
+        sum(CASE WHEN has_raw_geom THEN 1 ELSE 0 END)
+        AS records_with_raw_geom,
+        sum(CASE WHEN has_lot_geom THEN 1 ELSE 0 END)
+        AS records_with_lot_geom,
+        sum(CASE WHEN has_buffer_geom THEN 1 ELSE 0 END)
+        AS records_with_buffer_geom
+    FROM record_details
+    GROUP BY flag_id_field_name, variable_type
+    ORDER BY flag_id_field_name ASC, variable_type ASC
+),
+
+final AS (
+    SELECT
+        flag_id_field_name,
+        variable_type,
+        variable_type_count,
+        records_with_raw_geom,
+        records_with_lot_geom,
+        records_with_buffer_geom,
+        records_with_raw_geom - records_with_lot_geom AS records_without_lots
+    FROM counts
+)
+
+SELECT * FROM final;

--- a/products/green_fast_track/analyses/source_geometry_types.sql
+++ b/products/green_fast_track/analyses/source_geometry_types.sql
@@ -5,15 +5,15 @@ record_details AS (
         source_relation,
         flag_id_field_name,
         variable_type,
-        geometrytype(variable_geom) AS geometry_type
+        geometrytype(raw_geom) AS raw_geom_type
     FROM all_spatial
 )
 
 SELECT
     flag_id_field_name,
     variable_type,
-    geometry_type,
-    count(*) AS geometry_type_count
+    raw_geom_type,
+    count(*) AS raw_geom_type_count
 FROM record_details
-GROUP BY flag_id_field_name, variable_type, geometry_type
-ORDER BY flag_id_field_name, variable_type ASC, geometry_type ASC;
+GROUP BY flag_id_field_name, variable_type, raw_geom_type
+ORDER BY flag_id_field_name ASC, variable_type ASC, raw_geom_type ASC;

--- a/products/green_fast_track/analyses/source_geometry_types.sql
+++ b/products/green_fast_track/analyses/source_geometry_types.sql
@@ -5,7 +5,8 @@ record_details AS (
         source_relation,
         flag_id_field_name,
         variable_type,
-        geometrytype(raw_geom) AS raw_geom_type
+        geometrytype(raw_geom) AS raw_geom_type,
+        geometrytype(variable_geom) AS variable_geom_type
     FROM all_spatial
 )
 
@@ -13,7 +14,8 @@ SELECT
     flag_id_field_name,
     variable_type,
     raw_geom_type,
-    count(*) AS raw_geom_type_count
+    variable_geom_type,
+    count(*) AS combo_of_geom_types_count
 FROM record_details
-GROUP BY flag_id_field_name, variable_type, raw_geom_type
-ORDER BY flag_id_field_name ASC, variable_type ASC, raw_geom_type ASC;
+GROUP BY flag_id_field_name, variable_type, raw_geom_type, variable_geom_type
+ORDER BY flag_id_field_name ASC, variable_type ASC, raw_geom_type ASC, variable_geom_type ASC;

--- a/products/green_fast_track/models/intermediate/spatial/shadows/int_spatial__shadow_hist_resources.sql
+++ b/products/green_fast_track/models/intermediate/spatial/shadows/int_spatial__shadow_hist_resources.sql
@@ -1,23 +1,9 @@
-WITH all_shadow_resources AS (
-{{ dbt_utils.union_relations(
-    relations=[
-        ref('int_spatial__historic_resources'),
-        ref('stg__lpc_scenic_landmarks'),
-    ],
-    source_column_name="source_relation",
-    include=["variable_type", "variable_id", "raw_geom", "lot_geom"],
-    column_override={"raw_geom": "geometry", "lot_geom": "geometry"}
-) }}
-)
--- Note: without `column_override`, dbt throws an error trying to cast.
--- e.g.: `cast("raw_geom" as USER-DEFINED) as "raw...`
-
 SELECT
     source_relation,
     'shadow_hist_resources' AS flag_id_field_name,
     variable_type,
     variable_id,
-    ST_MULTI(raw_geom) AS raw_geom,
-    ST_MULTI(lot_geom) AS lot_geom,
+    raw_geom,
+    lot_geom,
     ST_MULTI(ST_BUFFER(COALESCE(lot_geom, raw_geom), 200)) AS buffer_geom
-FROM all_shadow_resources
+FROM {{ ref('int_spatial__historic_resources') }}

--- a/products/green_fast_track/models/product/source/_source_models.yml
+++ b/products/green_fast_track/models/product/source/_source_models.yml
@@ -57,5 +57,4 @@ models:
 
   - name: source__shadow_hist_resources_points
   - name: source__shadow_hist_resources_lots
-  - name: source__shadow_hist_resources_polys
   - name: source__shadow_hist_resources_buffer

--- a/products/green_fast_track/models/product/source/shadow/source__shadow_hist_resources_polys.sql
+++ b/products/green_fast_track/models/product/source/shadow/source__shadow_hist_resources_polys.sql
@@ -1,6 +1,0 @@
-SELECT
-    variable_type,
-    variable_id,
-    raw_geom
-FROM {{ ref("int_spatial__shadow_hist_resources") }}
-WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPolygon'

--- a/products/green_fast_track/seeds/variables.csv
+++ b/products/green_fast_track/seeds/variables.csv
@@ -52,4 +52,3 @@ shadow_nat_resources,Significant Natural Communities,natural_heritage_communitie
 shadow_nat_resources,National Wetlands,usfws_wetlands,usfws_nyc_wetlands,FALSE,200,
 shadow_hist_resources,NYC Historic Buildings,nyc_historic_buildings,lpc_landmarks,TRUE,200,
 shadow_hist_resources,State Historic Buildings,nys_historic_buildings,nysshpo_historic_buildings_points,TRUE,200,
-shadow_hist_resources,Scenic Landmarks,scenic_landmarks,lpc_scenic_landmarks,FALSE,200,


### PR DESCRIPTION
per GIS comment [here](https://github.com/NYCPlanning/data-engineering/issues/816#issuecomment-2140920024)

> I reviewed the `variables.csv` and here are my additional comments besides **removing Scenic Landmarks from Historic Shadows**

Screenshot showing new source raw geometry types contributing to Shadow Natural Resources below (all points due to removal of Scenic Landmarks)

![Screenshot 2024-05-31 at 9 20 57 AM](https://github.com/NYCPlanning/data-engineering/assets/7444289/b72fcad0-7a49-418f-adb5-115e3577b524)

