### PR TITLE
A Few Metadata Tweaks

### DIFF
--- a/dcpy/connectors/_cli.py
+++ b/dcpy/connectors/_cli.py
@@ -2,6 +2,7 @@ import typer
 
 from .edm.packaging import package_app as package_app
 from .socrata import metadata
+from .esri import arcgis_feature_service
 
 edm_app = typer.Typer()
 edm_app.add_typer(package_app, name="package")
@@ -12,3 +13,4 @@ socrata_app.add_typer(metadata.app, name="metadata")
 app = typer.Typer()
 app.add_typer(edm_app, name="edm")
 app.add_typer(socrata_app, name="socrata")
+app.add_typer(arcgis_feature_service.app, name="esri")

--- a/dcpy/connectors/edm/packaging.py
+++ b/dcpy/connectors/edm/packaging.py
@@ -9,7 +9,7 @@ from dcpy.connectors.edm import publishing
 from dcpy.connectors.edm import product_metadata
 
 BUCKET = "edm-publishing"
-BUCKET_FOLDER = "product_datasets"
+DATASETS_FOLDER = "product_datasets"
 BUCKET_ACL: s3.ACL = "public-read"
 PACKAGE_FOLDER = "package"
 
@@ -31,7 +31,7 @@ class PackageKey(publishing.ProductKey):
 
     @property
     def path(self) -> str:
-        return f"{BUCKET_FOLDER}/{self.relative_path}"
+        return f"{DATASETS_FOLDER}/{self.relative_path}"
 
 
 @dataclass
@@ -49,7 +49,7 @@ class DatasetPackageKey(publishing.ProductKey):
 
     @property
     def path(self) -> str:
-        return f"{BUCKET_FOLDER}/{self.relative_path}"
+        return f"{DATASETS_FOLDER}/{self.relative_path}"
 
 
 def upload(local_folder_path: Path, package_key: DatasetPackageKey) -> None:
@@ -66,7 +66,7 @@ def upload(local_folder_path: Path, package_key: DatasetPackageKey) -> None:
 
 def get_packaged_versions(product: str) -> list[str]:
     return sorted(
-        s3.get_subfolders(BUCKET, f"{BUCKET_FOLDER}/{product}/{PACKAGE_FOLDER}"),
+        s3.get_subfolders(BUCKET, f"{DATASETS_FOLDER}/{product}/{PACKAGE_FOLDER}"),
         reverse=True,
     )
 
@@ -139,7 +139,7 @@ def _generate_package_scaffold(
 ):
     client = s3.client()
     bucket = "edm-publishing"
-    base_path = f"product_datasets/{product_name}/package/{version}/{dataset}"
+    base_path = f"{DATASETS_FOLDER}/{product_name}/package/{version}/{dataset}"
 
     logger.info("Making empty `attachments` folder")
     client.put_object(

--- a/dcpy/connectors/edm/product_metadata.py
+++ b/dcpy/connectors/edm/product_metadata.py
@@ -1,0 +1,23 @@
+import requests
+import yaml
+
+from dcpy.utils.logging import logger
+import dcpy.models.product.dataset.metadata as md
+
+METADATA_REPO_RAW_URL = (
+    "https://raw.githubusercontent.com/NYCPlanning/product-metadata/main/products"
+)
+
+
+def _github_url(product: str, *, dataset: str | None = None) -> str:
+    return f"{METADATA_REPO_RAW_URL}/{product}/{dataset or product}/metadata.yml"
+
+
+def fetch_raw(product: str, *, dataset: str | None = None) -> str:
+    url = _github_url(product, dataset=dataset)
+    logger.info(f"Pulling metadata at {url}")
+    return requests.get(url).text
+
+
+def fetch(product: str, *, dataset: str | None = None) -> md.Metadata:
+    return md.Metadata(**yaml.safe_load(fetch_raw(product, dataset=dataset)))

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -77,6 +77,9 @@ def get_dataset(dataset: FeatureServer, crs: int) -> dict:
 
 
 def make_dcp_metadata(layer_url: str) -> models.Metadata:
+    if layer_url.endswith("FeatureServer/0"):
+        layer_url = layer_url + "?f=pjson"
+
     resp = requests.get(layer_url).json()
     esri_to_dcp = {"esriFieldTypeString": "text", "esriFieldTypeDouble": "double"}
 

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -101,7 +101,7 @@ def make_dcp_metadata(layer_url: str) -> models.Metadata:
 
     return models.Metadata(
         name=resp.get("name"),
-        display_name="FILL ME IN",
+        display_name=models.FILL_ME_IN_PLACEHOLDER,
         package=models.Package(
             dataset_files=[
                 models.DatasetFile(

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -81,7 +81,11 @@ def make_dcp_metadata(layer_url: str) -> models.Metadata:
         layer_url = layer_url + "?f=pjson"
 
     resp = requests.get(layer_url).json()
-    esri_to_dcp = {"esriFieldTypeString": "text", "esriFieldTypeDouble": "double"}
+    esri_to_dcp = {
+        "esriFieldTypeString": "text",
+        "esriFieldTypeDouble": "double",
+        "esriFieldTypeSmallInteger": "integer",
+    }
 
     raw_cols = resp.get("fields")
     our_cols = [

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -1,5 +1,7 @@
 from datetime import datetime
+from pathlib import Path
 import requests
+import typer
 from typing import cast
 from rich.progress import (
     BarColumn,
@@ -8,8 +10,11 @@ from rich.progress import (
     TextColumn,
     TimeRemainingColumn,
 )
+import yaml
 
 from dcpy.models.connectors.esri import FeatureServer
+import dcpy.models.product.dataset.metadata as models
+from dcpy.utils.logging import logger
 
 
 def get_metadata(dataset: FeatureServer) -> dict:
@@ -69,3 +74,76 @@ def get_dataset(dataset: FeatureServer, crs: int) -> dict:
             features += [_downcase_properties_keys(feat) for feat in chunk["features"]]
 
     return {"type": "FeatureCollection", "crs": crs, "features": features}
+
+
+def make_dcp_metadata(layer_url: str) -> models.Metadata:
+    resp = requests.get(layer_url).json()
+    esri_to_dcp = {"esriFieldTypeString": "text", "esriFieldTypeDouble": "double"}
+
+    raw_cols = resp.get("fields")
+    our_cols = [
+        models.Column(
+            name=c.get("name"),
+            display_name=c.get("alias"),
+            description="",
+            data_type=esri_to_dcp[c.get("type")],
+        )
+        for c in raw_cols
+        if c["name"] != "OBJECTID"
+    ]
+
+    return models.Metadata(
+        name=resp.get("name"),
+        display_name="FILL ME IN",
+        package=models.Package(
+            dataset_files=[
+                models.DatasetFile(
+                    name="primary_shapefile",
+                    filename="shapefile.zip",
+                    type="shapefile",
+                    overrides=models.DatasetOverrides(),
+                )
+            ],
+            attachments=[],
+        ),
+        destinations=[
+            models.SocrataDestination(
+                id="socrata_prod",
+                four_four="",
+                datasets=["primary_shapefile"],
+                omit_columns=[],
+            )
+        ],
+        summary="",
+        description=resp.get("description"),
+        tags=[],
+        each_row_is_a="",
+        columns=our_cols,
+    )
+
+
+metadata_app = typer.Typer(add_completion=False)
+
+app = typer.Typer(add_completion=False)
+app.add_typer(metadata_app, name="metadata")
+
+
+@metadata_app.command("export")
+def _export_metadata(
+    layer_url: str,
+    output_path: Path = typer.Option(
+        None,
+        "--output-path",
+        "-o",
+        help="Path to export the metadata to",
+    ),
+):
+    logger.info(f"fetching metadata for {layer_url}")
+    md = make_dcp_metadata(layer_url)
+    md_json = md.model_dump(exclude_none=True)
+
+    output_path = output_path or Path(f"{md.name}.yml")
+
+    logger.info(f"exporting metadata to {output_path}")
+    with open(output_path, "w") as outfile:
+        yaml.dump(md_json, outfile, sort_keys=False)

--- a/dcpy/connectors/socrata/metadata.py
+++ b/dcpy/connectors/socrata/metadata.py
@@ -18,7 +18,7 @@ soc_types_to_dcp_types = {
 
 def make_dcp_col(c: pub.Socrata.Responses.Column):
     samples = c.get("cachedContents", {}).get("top", [])
-    sample = "<FILL_ME_IN>"
+    sample = models.FILL_ME_IN_PLACEHOLDER
     dcp_type = None
 
     if samples:
@@ -30,7 +30,7 @@ def make_dcp_col(c: pub.Socrata.Responses.Column):
         elif type(sample) == int:
             dcp_type = "integer"
         else:
-            dcp_type = "<FILL_ME_IN>!"
+            dcp_type = models.FILL_ME_IN_PLACEHOLDER
     else:
         dcp_type = soc_types_to_dcp_types[c["renderTypeName"]]
 
@@ -51,7 +51,7 @@ def make_dcp_col(c: pub.Socrata.Responses.Column):
         and len(samples) == int(c["cachedContents"].get("cardinality"))  # type: ignore
     ):
         dcp_col["values"] = [
-            [s["item"], "<FILL_IN_THE_VALUE_DESCRIPTION!>"] for s in samples
+            [s["item"], models.FILL_ME_IN_PLACEHOLDER] for s in samples
         ]  # type: ignore
     return models.Column(**dcp_col)  # type: ignore
 
@@ -78,7 +78,8 @@ def make_dcp_metadata(socrata_md: pub.Socrata.Responses.Metadata) -> models.Meta
         summary=socrata_md["description"],
         description=socrata_md["description"],
         tags=socrata_md["tags"],
-        each_row_is_a=socrata_md["metadata"].get("rowLabel") or "<FILL_ME_IN>",
+        each_row_is_a=socrata_md["metadata"].get("rowLabel")
+        or models.FILL_ME_IN_PLACEHOLDER,
         columns=columns,
         destinations=[
             models.SocrataDestination(

--- a/dcpy/connectors/socrata/metadata.py
+++ b/dcpy/connectors/socrata/metadata.py
@@ -77,7 +77,7 @@ def make_dcp_metadata(socrata_md: pub.Socrata.Responses.Metadata) -> models.Meta
         display_name=socrata_md["name"],
         summary=socrata_md["description"],
         description=socrata_md["description"],
-        tags=socrata_md["tags"],
+        tags=socrata_md.get("tags", []),
         each_row_is_a=socrata_md["metadata"].get("rowLabel")
         or models.FILL_ME_IN_PLACEHOLDER,
         columns=columns,

--- a/dcpy/models/product/dataset/metadata.py
+++ b/dcpy/models/product/dataset/metadata.py
@@ -4,6 +4,10 @@ from pydantic import BaseModel, conlist
 from typing import Any, Literal
 import yaml
 
+# Putting this here so we can have a constant value in all connectors
+# and throw an exception when we attempt to deserialize files that contain it.
+FILL_ME_IN_PLACEHOLDER = "<FILL ME IN!>"
+
 
 class BytesDestination(BaseModel, extra="forbid"):
     type: Literal["bytes"]


### PR DESCRIPTION
Various Quality of Life tweaks for metadata related work. Adds:
- "Connector" to our product-metadata repo
- CLI exporter for ESRI metadata from a feature server, e.g.
```
python -m dcpy.cli connectors esri metadata export https://services5.arcgis.com/GfwWNkhOj9bNBqoJ/arcgis/rest/services/NYC_Public_Use_Microdata_Areas_PUMAs_2010/FeatureServer/0
```

- Scaffold generator for packages
```
python -m dcpy.cli connectors edm package scaffold lion 24b 2020_community_district_tabulation_areas
```
will generate empty folders, and copy over the product-dataset metadata from the product-metadata repo. 

