### PR TITLE
Update COLP README

### DIFF
--- a/.github/ISSUE_TEMPLATE/product_update_colp.md
+++ b/.github/ISSUE_TEMPLATE/product_update_colp.md
@@ -1,0 +1,26 @@
+---
+name: Product Update: COLP
+about: Product Update: COLP
+title: "{{ env.VERSION }} COLP Update"
+labels: 'data update'
+---
+
+# COLP Source Data Updates
+
+Like most of our data products, source data must be updated in data library before COLP is run/built.
+
+All source data listed is to be uploaded as .sql files.
+
+### Bytes of the Big Apple Source Data
+Make sure versions of each dataset are the most recent published version in DigitalOcean.
+
+- [ ] dcp_pluto - https://www.nyc.gov/site/planning/data-maps/open-data.page#pluto (Version that was last built and published, typically updated 4x a year)
+- [ ] dcp_colp - https://www.nyc.gov/site/planning/data-maps/open-data.page#city_facilities (Version that was last built and published)
+- [ ] dcp_boroboundaries_wi - https://www.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page (New release with every geosupport but should not change from version to version)
+
+### Manual Uploads
+- [ ] dcas_ipis - DCAS emails us a csv and this is ingested manually
+
+### Recieved via GIS Team uploaded to DO
+
+- [ ] dof_air_rights_lots

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Data Engineering Team ![CI](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml/badge.svg)
 
-This is the primary repository for the Data Engineering team at the NYC Department of City Planning (DCP).
+This is the primary repository for the Data Engineering team at the NYC Department of City Planning (DCP). It is used to build data products for internal and external use. Each product has it's own folder in `products/` where their respective code and READMEs can be found.
 
-It is used to build data products for internal and external use. Each product has it's own folder in `products/` where their respective code and READMEs can be found.
+Additionally, Data Engineering maintains the [Product Metadata](https://github.com/NYCPlanning/product-metadata) repository, which contains specifications for City Planning datasets, including those maintained by Data Engineering as well as other teams.
 
 The [Data Engineering wiki page](https://github.com/NYCPlanning/data-engineering/wiki) in this repo is the single source of truth for all of our documentation.

--- a/products/colp/README.md
+++ b/products/colp/README.md
@@ -1,10 +1,10 @@
-# City Owned and Leased Properties Database
+## City Owned and Leased Properties Database
 
 Various city authorities own or lease a large inventory of properties. This repo contains code to create a database of all city owned and leased properties, as required under Section 204 of the City Charter. The database contains information about each property's use, owning/leasing agency, location, and tenent agreements. This repo is a refactoring of the dataset found on [Bytes of the Big Apple](https://www1.nyc.gov/site/planning/about/publications/colp.page), and is currently in development.
 
 The input data for COLP is the Integrated Property Information System (IPIS), a real estate database maintained by the Department of Citywide Administrative Services (DCAS).
 
-## Outputs
+## Important Files
 | File | Description |
 | ---- | ----------- |
 | [output.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/output.zip) | Zipped directory containing all files below |
@@ -24,9 +24,15 @@ The input data for COLP is the Integrated Property Information System (IPIS), a 
 | [ipis_cd_errors.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_cd_errors.csv) | QAQC table of mismatch between IPIS community district and PLUTO |
 | [version.txt](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/version.txt) | Build date |
 
-## Additional Resources
-Look-up tables for agency abbreviations and use types are availaible in CSV form under [`/resources`](https://github.com/NYCPlanning/data-engineering/tree/main/products/colp/resources)
+### Links
+[COLP on Open Data](https://data.cityofnewyork.us/d/fn4k-qyk2)
+[COLP on Bytes](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-colp.page)
+[`/resources`](https://github.com/NYCPlanning/data-engineering/tree/main/products/colp/resources) - Look-up tables for agency abbreviations and use types 
 
+
+For more in-depth information on COLP, check out its [wiki page](https://github.com/NYCPlanning/data-engineering/wiki/Product:-COLP)
+
+# MOVE EVERYTHING BELOW
 ### Bytes of the Big Apple Source Data 
 Make sure versions of each dataset are the most recent published version in DigitalOcean.
 

--- a/products/colp/README.md
+++ b/products/colp/README.md
@@ -1,4 +1,4 @@
-# City Owned and Leased Properties Database ![CI](https://github.com/NYCPlanning/db-colp/workflows/CI/badge.svg)
+# City Owned and Leased Properties Database
 
 Various city authorities own or lease a large inventory of properties. This repo contains code to create a database of all city owned and leased properties, as required under Section 204 of the City Charter. The database contains information about each property's use, owning/leasing agency, location, and tenent agreements. This repo is a refactoring of the dataset found on [Bytes of the Big Apple](https://www1.nyc.gov/site/planning/about/publications/colp.page), and is currently in development.
 
@@ -26,17 +26,6 @@ The input data for COLP is the Integrated Property Information System (IPIS), a 
 
 ## Additional Resources
 Look-up tables for agency abbreviations and use types are availaible in CSV form under [`/resources`](https://github.com/NYCPlanning/data-engineering/tree/main/products/colp/resources)
-
-## Building COLP
-There are currently two methods to create colp:
-1. via a `push` event, make sure you include `[build]` in your commit message to trigger a build. This workflow can be triggered on all branches.
-2. via a `workflow_dispatch` event. Head to the `actions` tab of the repo and click **Run Workflow** under the **Build** section. 
-
-# COLP Source Data Updates
-
-Like most of our data products, source data must be updated in data library before COLP is run/built. 
-
-All source data listed is to be uploaded as .sql files.
 
 ### Bytes of the Big Apple Source Data 
 Make sure versions of each dataset are the most recent published version in DigitalOcean.

--- a/products/colp/README.md
+++ b/products/colp/README.md
@@ -4,30 +4,9 @@ Various city authorities own or lease a large inventory of properties. This repo
 
 The input data for COLP is the Integrated Property Information System (IPIS), a real estate database maintained by the Department of Citywide Administrative Services (DCAS).
 
-## Important Files
-| File | Description |
-| ---- | ----------- |
-| [output.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/output.zip) | Zipped directory containing all files below |
-| [colp.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/colp.shp.zip) | Shapefile version COLP database, only including records with coordinates |
-| [colp.gdb.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/colp.gdb.zip) | GeoDatabase version COLP database, only including records with coordinates |
-| [colp.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/colp.csv) | CSV version COLP database, only including records with coordinates |
-| [ipis_modified_hnums.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_modified_hnums.csv) | QAQC table of records with modified house numbers |
-| [ipis_modified_names.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_modified_names.csv) | QAQC table of records with modified parcel names |
-| [usetype_changes.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/usetype_changes.csv) | QAQC table of version-to-version changes in the number of records per use type |
-| [modifications_applied.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/modifications_applied.csv) | Table of manual modifications that were applied |
-| [modifications_not_applied.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/modifications_not_applied.csv) | Table of manual modifications that existed in the modifications table, but failed to get applied |
-| [ipis_unmapped.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_unmapped.csv) | QAQC table of unmappable input records |
-| [ipis_colp_geoerrors.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_colp_geoerrors.csv) | QAQC table of addresses that return errors (or warnings type 1-9, B, C, I, J) from 1B |
-| [ipis_sname_errors.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_sname_errors.csv) | QAQC table of addresses that return streetname errors (GRC is 11 or EE) from 1B |
-| [ipis_hnum_errors.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_hnum_errors.csv) | QAQC table of addresses that return out-of-range address errors (GRC is 41 or 42) from 1B |
-| [ipis_bbl_errors.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_bbl_errors.csv) | QAQC table of records where address isn't valid for input BBL |
-| [ipis_cd_errors.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/qaqc/ipis_cd_errors.csv) | QAQC table of mismatch between IPIS community district and PLUTO |
-| [version.txt](https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/main/latest/output/version.txt) | Build date |
-
 ### Links
 [COLP on Open Data](https://data.cityofnewyork.us/d/fn4k-qyk2)
 [COLP on Bytes](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-colp.page)
 [`/resources`](https://github.com/NYCPlanning/data-engineering/tree/main/products/colp/resources) - Look-up tables for agency abbreviations and use types 
-
 
 For more in-depth information on COLP, check out its [wiki page](https://github.com/NYCPlanning/data-engineering/wiki/Product:-COLP)

--- a/products/colp/README.md
+++ b/products/colp/README.md
@@ -31,18 +31,3 @@ The input data for COLP is the Integrated Property Information System (IPIS), a 
 
 
 For more in-depth information on COLP, check out its [wiki page](https://github.com/NYCPlanning/data-engineering/wiki/Product:-COLP)
-
-# MOVE EVERYTHING BELOW
-### Bytes of the Big Apple Source Data 
-Make sure versions of each dataset are the most recent published version in DigitalOcean.
-
-- [ ] dcp_pluto - https://www.nyc.gov/site/planning/data-maps/open-data.page#pluto (Version that was last built and published, typically updated 4x a year)
-- [ ] dcp_colp - https://www.nyc.gov/site/planning/data-maps/open-data.page#city_facilities (Version that was last built and published)
-- [ ] dcp_boroboundaries_wi - https://www.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page (New release with every geosupport but should not change from version to version)
-
-### Manual Uploads
-- [ ] dcas_ipis - DCAS emails us a csv and this is ingested manually 
-
-### Recieved via GIS Team uploaded to DO
-
-- [ ] dof_air_rights_lots 


### PR DESCRIPTION
Conforms COLP README to pared down format, and moves build steps to a new build issue. For the build issue itself, I found an old Issue, and copied the markdown to this new file.