### PR TITLE
Set dtm source crs back to state plane

### DIFF
--- a/dcpy/library/templates/dof_dtm.yml
+++ b/dcpy/library/templates/dof_dtm.yml
@@ -10,7 +10,7 @@ dataset:
       - "X_POSSIBLE_NAMES=lon"
       - "Y_POSSIBLE_NAMES=lat"
     geometry:
-      SRS: EPSG:3857
+      SRS: EPSG:2263
       type: MULTIPOLYGON
 
   destination:


### PR DESCRIPTION
Revert change in #852 per in person communication with GIS that they would be reprojecting upstream of us back to state plane