### PR TITLE
Minor tweaks for ztl

### DIFF
--- a/dcpy/lifecycle/builds/load.py
+++ b/dcpy/lifecycle/builds/load.py
@@ -197,15 +197,29 @@ def _import_dataset(
         help="Dataset type",
     ),
     database_schema: str = typer.Option(
+        None,
         "-s",
         "--schema",
         help="Database Schema",
     ),
+    database: str = typer.Option(
+        None,
+        "-d",
+        "--database",
+    ),
+    import_as: str = typer.Option(
+        None, "--import-as", help="Renames the imported table"
+    ),
 ):
     database_schema = database_schema or os.environ["BUILD_SCHEMA"]
     import_dataset(
-        InputDataset(name=dataset_name, version=version, file_type=dataset_type),
-        postgres.PostgresClient(schema=database_schema),
+        InputDataset(
+            name=dataset_name,
+            version=version,
+            file_type=dataset_type,
+            import_as=import_as,
+        ),
+        postgres.PostgresClient(schema=database_schema, database=database),
     )
 
 

--- a/products/zoningtaxlots/bash/config.sh
+++ b/products/zoningtaxlots/bash/config.sh
@@ -9,9 +9,7 @@ set_env $ROOT_DIR/.env version.env
 set_error_traps
 
 # Set Date and Versions
-DATE=$(date "+%Y-%m-01")
-VERSION=$DATE
-VERSION_PREV=$(date --date="$(date "+%Y-%m-01") - 1 month" "+%Y-%m-01")
+VERSION_PREV=$(date --date=""$VERSION" - 1 month" "+%Y-%m-01")
 # Set SQL Version Table Names
-VERSION_SQL_TABLE=$(date "+%Y%m01")
-VERSION_PREV_SQL_TABLE=$(date --date="$(date "+%Y%m01") - 1 month" "+%Y%m01")
+VERSION_SQL_TABLE=$(date --date="$VERSION" "+%Y%m01")
+VERSION_PREV_SQL_TABLE=$(date --date=""$VERSION" - 1 month" "+%Y%m01")


### PR DESCRIPTION
A couple things came up looking into #906 

1. The little cli I wrote around loading a single dataset could use some more arguments, and had one of its options misformatted (first arg is default, NOT the flags)
2. ztl bash version env vars are unrelated to the version env var exported by dcpy logic. This fixes that

[Passing build](https://github.com/NYCPlanning/data-engineering/actions/runs/9503100040)