### PR TITLE
ESRI PDF Parser

### DIFF
--- a/dcpy/connectors/_cli.py
+++ b/dcpy/connectors/_cli.py
@@ -5,7 +5,7 @@ from .socrata import metadata
 from .esri import arcgis_feature_service
 
 edm_app = typer.Typer()
-edm_app.add_typer(package_app, name="package")
+edm_app.add_typer(package_app, name="packaging")
 
 socrata_app = typer.Typer()
 socrata_app.add_typer(metadata.app, name="metadata")

--- a/dcpy/lifecycle/_cli.py
+++ b/dcpy/lifecycle/_cli.py
@@ -1,11 +1,12 @@
 import typer
 
 from dcpy.lifecycle.ingest import run
-from dcpy.lifecycle.package import validate
+from dcpy.lifecycle.package._cli import app as package_app
 from dcpy.lifecycle.distribute import socrata
 
+
 app = typer.Typer()
-app.add_typer(validate.app, name="package")
+app.add_typer(package_app, name="package")
 app.add_typer(socrata.distribute_app, name="distribute")
 # while there's only one ingest command, add it directly
 app.command(name="ingest")(run._cli_wrapper_run)

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -99,7 +99,7 @@ python -m dcpy.cli connectors esri metadata export https://services5.arcgis.com/
 #### ESRI PDF parser
 
 The last resort for grabbing column metadata. This is by far the most fragile of the methods.
-1. Open the ESRI pdf
+1. Open the ESRI pdf in the **Mac Preview app** (Important - copying from other apps doesn't work)
 2. Copy paste the document contents into a text file
 3. Run:
 

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -75,3 +75,34 @@ INFO:dcpy:            here https://data.cityofnewyork.us/d/b7pm-uzu7/revisions/3
 Follow the provided link. Here you can review the modified data and metadata. Hit `Update` in the top right to apply the revision. 
 ![template_db_socrata](https://github.com/NYCPlanning/data-engineering/assets/11164730/b0c24251-00e3-4be1-99a6-6cf015240cc6)
 
+
+## Generating Metadata
+
+So you need to generate a `metadata.yml` file. There are a few options that will each get you part of the way:
+
+#### Socrata Connector
+``` sh
+python -m dcpy.cli connectors socrata metadata export {four-four here}
+```
+
+The limitations here are when you're working from an old datasource. It will correctly pull certain dataset-level fields (e.g. Description), but unfortonutely no column metadata. (yet)
+
+#### ESRI FeatureServer Connector
+``` sh
+python -m dcpy.cli connectors esri metadata export {feature-server here}
+
+-- e.g.
+
+python -m dcpy.cli connectors esri metadata export https://services5.arcgis.com/GfwWNkhOj9bNBqoJ/arcgis/rest/services/NYC_Borough_Boundary/FeatureServer/0
+```
+
+#### ESRI PDF parser
+
+The last resort for grabbing column metadata. This is by far the most fragile of the methods.
+1. Open the ESRI pdf
+2. Copy paste the document contents into a text file
+3. Run:
+
+``` sh
+python -m dcpy.cli lifecycle package esri parse_pdf_text {path to your text file}
+```

--- a/dcpy/lifecycle/package/_cli.py
+++ b/dcpy/lifecycle/package/_cli.py
@@ -1,0 +1,8 @@
+import typer
+
+from .validate import _validate
+from .esri import app as esri_app
+
+app = typer.Typer()
+app.command(name="validate")(_validate)
+app.add_typer(esri_app, name="esri")

--- a/dcpy/lifecycle/package/esri.py
+++ b/dcpy/lifecycle/package/esri.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import re
+import typer
+import yaml
+
+import dcpy.models.product.dataset.metadata as models
+from dcpy.utils.logging import logger
+
+
+def _parse_raw_column(field_raw) -> models.Column:
+    """
+    Parse a column value from ESRI metadata pdfs
+    example value: 'Field AssemDist,Alias ASSEMDIST,Data type String,Width 2,,,Field description\nState Assembly District Number'
+    """
+    parsed_field_info = {
+        "description": "CHANGE_ME",
+        "name": "CHANGE_ME",
+        "display_name": "CHANGE_ME",
+        "data_type": "CHANGE_ME",
+    }
+
+    field_token = "Field "
+    alias_token = "Alias "
+    type_token = "Data type"
+    desc_token = "Field description\n"
+    iters = 0
+    while True:
+        next_comma = field_raw.find(",")
+        next_chunk = field_raw[0:next_comma]
+
+        PROBABLY_AN_INFINITE_LOOP_COUNTER = 100
+        if next_comma == -1 or iters > PROBABLY_AN_INFINITE_LOOP_COUNTER:
+            if next_chunk.startswith(desc_token):
+                # Description always comes last in the metadata
+                parsed_field_info["description"] = field_raw[len(desc_token) :]
+            break
+
+        if next_chunk.startswith(field_token) and not next_chunk.startswith(
+            field_token + "description"
+        ):
+            parsed_field_info["name"] = next_chunk[len(field_token) :]
+        elif next_chunk.startswith(alias_token):
+            parsed_field_info["display_name"] = next_chunk[len(alias_token) :]
+        elif next_chunk.startswith(type_token):
+            parsed_field_info["data_type"] = next_chunk[len(type_token) :]
+
+        field_raw = field_raw[next_comma + 1 :]
+        iters = iters + 1
+
+    return models.Column(**parsed_field_info)  # type: ignore
+
+
+app = typer.Typer()
+
+
+@app.command("parse_pdf_text")
+def parse_pdf_text(
+    esri_pdf_path: Path,
+    output_path: Path = typer.Option(
+        None,
+        "--output-path",
+        "-o",
+        help="Path to export the metadata to",
+    ),
+):
+    text = open(esri_pdf_path, "r").read()
+    text = (
+        text.replace("\n_\n", "_")
+        .replace("\n►\n*\n", ",")
+        .replace("\n*\n", ",")
+        .replace("Scale 0\n", ",")
+        .replace("Precision 0,", ",")
+    )
+    fields_split_messy = re.split("\nHide Field .* ▲\n", text)[1:]
+    fields = []
+    for f in fields_split_messy:
+        try:
+            fields.append(_parse_raw_column(f).model_dump(exclude_none=True))
+        except Exception as e:
+            logger.error(str(e))
+
+    output_path = output_path or Path(f"columns.yml")
+    with open(output_path, "w") as outfile:
+        yaml.dump(fields, outfile, sort_keys=False)

--- a/dcpy/lifecycle/package/validate.py
+++ b/dcpy/lifecycle/package/validate.py
@@ -297,7 +297,7 @@ def validate_package(
 app = typer.Typer(add_completion=False)
 
 
-@app.command("validate")
+@app.command()
 def _validate(
     package_path: Path,
     metadata_path: Path = typer.Option(


### PR DESCRIPTION
Add a very janky parser to make column metadata from the contents of an ESRI pdf. Also updates the documentation to list the ways one could generate metadata. 

I wouldn't waste too much time reviewing the logic of the pdf-text parser. If this is something we continue on with, we might want to actually use a pdf-parser, or just grab the data from an FGDB or somehow from ESRI. (There's got be a better way!)

@damonmcc 👆in reference to your question about how to export md.