### PR TITLE
fix socrata column set-comp bug

### DIFF
--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -139,7 +139,7 @@ class Socrata:
                 """
                 )
 
-                assert self.column_names == set(
+                assert set(self.column_names) == set(
                     expected_api_names
                 ), f"""The field names in the uploaded data do not match our metadata.
                 - Present in our metadata, but not dataset page: {set(expected_api_names) - set(self.column_names)}


### PR DESCRIPTION
@damonmcc FYI, was failing where columns were identical, e.g. [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9601408283/job/26479913355)

```
INFO:dcpy:Updating Columns at https://data.cityofnewyork.us/api/publishing/v1/source/216260781/schema/213461781
INFO:dcpy:                    Columns from dataset page: ['bbl', 'borocode', 'ceqr_num', 'descriptio', 'enumber', 'taxblock', 'taxlot', 'the_geom', 'ulurp_num', 'zoning_map']
INFO:dcpy:                    Columns from our metadata: ['bbl', 'borocode', 'ceqr_num', 'descriptio', 'enumber', 'taxblock', 'taxlot', 'the_geom', 'ulurp_num', 'zoning_map']
INFO:dcpy:                
ERROR:dcpy:Error Updating Column Metadata! However,
ERROR:dcpy:            the Dataset File was uploaded and the revision can still be applied manually, here: https://data.cityofnewyork.us/d/jep3-h9py/revisions/13
ERROR:dcpy:            Error: The field names in the uploaded data do not match our metadata.
ERROR:dcpy:                - Present in our metadata, but not dataset page: set()
ERROR:dcpy:                - Present in dataset page, but not our metadata: set()
ERROR:dcpy:                
```