### PR TITLE
Socrata: Push blob datasets

### DIFF
--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -267,6 +267,29 @@ class Revision:
             )
         )
 
+    def _fetch_socrata_revision_data(self):
+        _socratapy_client = SocrataPy(
+            Authorization(SOCRATA_DOMAIN, SOCRATA_USER, SOCRATA_PASSWORD)
+        )
+        view = _socratapy_client.views.lookup(self.four_four)
+        return view.revisions.lookup(self.revision_num)
+
+    def push_blob(self, path: Path, *, dest_filename: str | None = None):
+        rev = self._fetch_socrata_revision_data()
+        with open(path, "rb") as blob:
+            logger.info(
+                f"Pushing blob at {path} to {self.four_four} - rev: {self.revision_num}"
+            )
+            push_resp = (
+                rev.create_upload(dest_filename or path.name, {"parse_source": False})
+                .blob(blob)
+                .wait_for_finish()
+            )
+        error_details: dict | None = push_resp.attributes["failure_details"]
+        if error_details:
+            logger.error(f"BLOB upload failed with {error_details}")
+            raise Exception(str(error_details))
+
     def push_csv(
         self, path: Path, *, dest_filename: str | None = None
     ) -> Socrata.Responses.RevisionDataSource:
@@ -291,7 +314,6 @@ class Revision:
     def push_shp(
         self, path: Path, *, dest_filename: str | None = None
     ) -> Socrata.Responses.RevisionDataSource:
-        # This is the only use of socrata-py. The data syncing utilities are nice.
         _socratapy_client = SocrataPy(
             Authorization(SOCRATA_DOMAIN, SOCRATA_USER, SOCRATA_PASSWORD)
         )
@@ -397,23 +419,26 @@ def push_dataset(
     )
 
     data_source = None
-    if md_dataset.type == "csv":
+    if dest.is_blob_dataset:
+        rev.push_blob(file_path)
+    elif md_dataset.type == "csv":
         data_source = rev.push_csv(file_path)
     elif md_dataset.type == "shapefile":
         data_source = rev.push_shp(file_path)
     else:
         raise Exception(f"Pushing unsupported file type: {md_dataset.type}")
 
-    try:
-        data_source.update_column_metadata(dest, metadata)
-    except Exception as e:
-        # Upating column Metadata is tricky, and there's still some work to be done
-        logger.error(
-            f"""Error Updating Column Metadata! However,
-            the Dataset File was uploaded and the revision can still be applied manually, here: {rev.page_url}
-            Error: {e}"""
-        )
-        return
+    if not dest.is_blob_dataset and data_source:  # appease the type-checker
+        try:
+            data_source.update_column_metadata(dest, metadata)
+        except Exception as e:
+            # Upating column Metadata is tricky, and there's still some work to be done
+            logger.error(
+                f"""Error Updating Column Metadata! However,
+                the Dataset File was uploaded and the revision can still be applied manually, here: {rev.page_url}
+                Error: {e}"""
+            )
+            return
 
     if not publish:
         logger.info(

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import requests
 from socrata.authorization import Authorization
 from socrata import Socrata as SocrataPy
+from socrata.revisions import Revision as SocrataPyRevision
 import time
 from typing import TypedDict, Literal, NotRequired
 
@@ -267,7 +268,9 @@ class Revision:
             )
         )
 
-    def _fetch_socrata_revision_data(self):
+    def _fetch_socratapy_revision(self) -> SocrataPyRevision:
+        """Fetches the SocrataPy object wrapper around the revision object.
+        This is useful for uploading to open revisions."""
         _socratapy_client = SocrataPy(
             Authorization(SOCRATA_DOMAIN, SOCRATA_USER, SOCRATA_PASSWORD)
         )
@@ -275,7 +278,7 @@ class Revision:
         return view.revisions.lookup(self.revision_num)
 
     def push_blob(self, path: Path, *, dest_filename: str | None = None):
-        rev = self._fetch_socrata_revision_data()
+        rev = self._fetch_socratapy_revision()
         with open(path, "rb") as blob:
             logger.info(
                 f"Pushing blob at {path} to {self.four_four} - rev: {self.revision_num}"
@@ -293,11 +296,7 @@ class Revision:
     def push_csv(
         self, path: Path, *, dest_filename: str | None = None
     ) -> Socrata.Responses.RevisionDataSource:
-        _socratapy_client = SocrataPy(
-            Authorization(SOCRATA_DOMAIN, SOCRATA_USER, SOCRATA_PASSWORD)
-        )
-        view = _socratapy_client.views.lookup(self.four_four)
-        rev = view.revisions.lookup(self.revision_num)
+        rev = self._fetch_socratapy_revision()
         with open(path, "rb") as csv:
             logger.info(
                 f"Pushing csv at {path} to {self.four_four} - rev: {self.revision_num}"
@@ -314,11 +313,7 @@ class Revision:
     def push_shp(
         self, path: Path, *, dest_filename: str | None = None
     ) -> Socrata.Responses.RevisionDataSource:
-        _socratapy_client = SocrataPy(
-            Authorization(SOCRATA_DOMAIN, SOCRATA_USER, SOCRATA_PASSWORD)
-        )
-        view = _socratapy_client.views.lookup(self.four_four)
-        rev = view.revisions.lookup(self.revision_num)
+        rev = self._fetch_socratapy_revision()
         with open(path, "rb") as shp_zip:
             logger.info(
                 f"Pushing shapefiles at {path} to {self.four_four} - rev: {self.revision_num}"

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -414,7 +414,7 @@ def push_dataset(
     )
 
     data_source = None
-    if dest.is_blob_dataset:
+    if dest.is_unparsed_dataset:
         rev.push_blob(file_path)
     elif md_dataset.type == "csv":
         data_source = rev.push_csv(file_path)
@@ -423,7 +423,7 @@ def push_dataset(
     else:
         raise Exception(f"Pushing unsupported file type: {md_dataset.type}")
 
-    if not dest.is_blob_dataset and data_source:  # appease the type-checker
+    if not dest.is_unparsed_dataset and data_source:  # appease the type-checker
         try:
             data_source.update_column_metadata(dest, metadata)
         except Exception as e:

--- a/dcpy/models/product/dataset/metadata.py
+++ b/dcpy/models/product/dataset/metadata.py
@@ -69,6 +69,7 @@ class SocrataDestination(BaseModel, extra="forbid"):
     omit_columns: list[str] = []
     column_details: dict[str, SocrataColumn] = {}
     overrides: DatasetOverrides = DatasetOverrides()
+    is_blob_dataset: bool = False
 
     def get_metadata(self, md: Metadata) -> SocrataMetada:
         dataset_file_overrides = md.package.get_dataset(self.datasets[0]).overrides

--- a/dcpy/models/product/dataset/metadata.py
+++ b/dcpy/models/product/dataset/metadata.py
@@ -69,7 +69,7 @@ class SocrataDestination(BaseModel, extra="forbid"):
     omit_columns: list[str] = []
     column_details: dict[str, SocrataColumn] = {}
     overrides: DatasetOverrides = DatasetOverrides()
-    is_blob_dataset: bool = False
+    is_unparsed_dataset: bool = False
 
     def get_metadata(self, md: Metadata) -> SocrataMetada:
         dataset_file_overrides = md.package.get_dataset(self.datasets[0]).overrides


### PR DESCRIPTION
Certain Socrata Pages have unparsed blobs (e.g. zipfiles) instead of tabular data like shapefiles or csvs. This adds the ability to push those. Successful run for LION Street Name Dictionary [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9652691459/job/26623373045)

Since it's socrata-specific behavior (as opposed to a dataset_file attribute), I added a flag called `is_blob_dataset` to the SocrataDestination in the Metadata.