### PR TITLE
Stop Filling out Product Metadata summary in export

### DIFF
--- a/dcpy/connectors/socrata/metadata.py
+++ b/dcpy/connectors/socrata/metadata.py
@@ -75,7 +75,7 @@ def make_dcp_metadata(socrata_md: pub.Socrata.Responses.Metadata) -> models.Meta
             else socrata_md["name"]
         ),
         display_name=socrata_md["name"],
-        summary=socrata_md["description"],
+        summary="",
         description=socrata_md["description"],
         tags=socrata_md.get("tags", []),
         each_row_is_a=socrata_md["metadata"].get("rowLabel")

--- a/dcpy/models/product/dataset/metadata.py
+++ b/dcpy/models/product/dataset/metadata.py
@@ -145,7 +145,7 @@ class Package(BaseModel, extra="forbid"):
 class Metadata(BaseModel, extra="forbid"):
     name: str
     display_name: str
-    summary: str
+    summary: str  # TODO: potentially remove this field
     description: str
     tags: list[str]
     each_row_is_a: str


### PR DESCRIPTION
I can't recall quite why I'd originally added this field, but it's now just an annoyance. Maybe there's room for a distinction between a "summary" (presumably a phrase or short sentence) then a lengthier "description" (paragraphs)