### PR TITLE
Add ability to template destination filenames

### DIFF
--- a/dcpy/lifecycle/distribute/socrata.py
+++ b/dcpy/lifecycle/distribute/socrata.py
@@ -20,6 +20,7 @@ distribute_app.add_typer(socrata_app, name="socrata")
 def _dist_from_local(
     package_path: Path = typer.Argument(),
     dataset_destination_id: str = typer.Argument(),
+    version: str = typer.Argument(),
     metadata_path: Path = typer.Option(
         None,
         "-m",
@@ -64,7 +65,9 @@ def _dist_from_local(
                 validation.pretty_print_errors()
                 raise Exception(error_msg)
 
-    soc_pub.push_dataset(md, dataset_destination_id, package_path, publish=publish)
+    soc_pub.push_dataset(
+        md, dataset_destination_id, package_path, version=version, publish=publish
+    )
 
 
 @socrata_app.command("from_s3")
@@ -115,6 +118,7 @@ def _dist_from_s3(
     _dist_from_local(
         package_path=package_path,
         dataset_destination_id=dataset_destination_id,
+        version=version,
         metadata_path=metadata_path,
         publish=publish,
         ignore_validation_errors=ignore_validation_errors,

--- a/dcpy/models/product/dataset/metadata.py
+++ b/dcpy/models/product/dataset/metadata.py
@@ -40,6 +40,17 @@ class DatasetOverrides(BaseModel, extra="forbid"):
     display_name: str | None = None
     description: str | None = None
     tags: list[str] = []
+    destination_file_name: str | None = None
+
+    _VERSION_TEMPLATE_TOKEN = "{{ version }}"
+
+    def get_dataset_destination_name(self, version) -> str:
+        """Get filename for the destination dataset. Should only be invoked for unparsed datasets."""
+        return (
+            self.destination_file_name.replace(self._VERSION_TEMPLATE_TOKEN, version)
+            if self.destination_file_name is not None
+            else ""
+        )
 
 
 class BytesDestination(BaseModel, extra="forbid"):

--- a/dcpy/test/lifecycle/package/resources/colp_single_feature_package/metadata.yml
+++ b/dcpy/test/lifecycle/package/resources/colp_single_feature_package/metadata.yml
@@ -286,3 +286,16 @@ destinations:
     omit_columns: [dcpedited, uid]
     overrides:
       display_name: "display_name overridden at the destination level"
+
+  - id: socrata_unparsed
+    type: socrata
+    four_four: "fn4k-abcd"
+    is_unparsed_dataset: true
+    datasets:
+      - primary_shapefile
+    attachments:
+      -  "colp_readme.pdf"
+    omit_columns: []
+    overrides:
+      display_name: "display_name overridden at the destination level"
+      destination_file_name: shapefile_blob_{{ version }}

--- a/dcpy/test/lifecycle/package/test_packages_validation.py
+++ b/dcpy/test/lifecycle/package/test_packages_validation.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import yaml
+import pytest
 
 from dcpy.lifecycle.package import validate
 import dcpy.models.product.dataset.metadata as md
@@ -63,3 +64,14 @@ def test_destination_overrides():
     Description is overridden ONLY at the dataset_file level"""
 
     assert soc_md.tags == RAW_MD["tags"], "Tags should be unchanged"
+
+
+def test_unparsed_dataset_name_templating():
+    VERSION = "24b"
+    dest = COLP_MD.get_destination("socrata_unparsed")
+    assert type(dest) == md.SocrataDestination
+
+    assert (
+        dest.overrides.get_dataset_destination_name(version=VERSION)
+        == f"shapefile_blob_{VERSION}"
+    )


### PR DESCRIPTION
Add ability to set destination filename override. Successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9670094962)

There's an argument that we should perhaps just jinja template the entire metadata.yml file, rather than targeting individual fields. But we can cross that bridge when we start implementing re-usable metadata components (e.g. the column definition for BBLs)