### PR TITLE
Experiment: Create tags when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,6 @@ on:
         description: "Build folder in drafts to publish"
         type: string
         required: true
-      publishing_version:
-        description: "Data product release version"
-        type: string
-        required: true
       latest:
         description: "Publish to 'latest' folder?"
         type: boolean
@@ -70,13 +66,34 @@ jobs:
         working-directory: ./
         run: ./bash/docker_container_setup.sh
 
-      - name: publish
-        env:
-          latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
+      - name: Download Metadata
+        run: |
+          python3 -m dcpy.connectors.edm.publishing download_file \
+            --filepath build_metadata.json \
+            --product ${{ inputs.product }} \
+            --draft \
+            --version ${{inputs.draft_build}}
+
+      - name: Set version and build sha
+        run: |
+          echo "version=$(cat build_metadata.json | jq -r .version)" >> $GITHUB_ENV
+          echo "commit=$(cat build_metadata.json | jq -r .commit)" >> $GITHUB_ENV
+
+      - name: Publish
         run: |
           python3 -m dcpy.connectors.edm.publishing publish \
             --product ${{ inputs.product }} \
             --build ${{ inputs.draft_build }} \
-            --version ${{ inputs.publishing_version }} \
             --acl ${{ inputs.product_acl }} \
-            $latest
+            ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
+
+      - name: create tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ inputs.product }}__${{ env.version }}',
+              sha: '${{ env.commit }}'
+            })

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -495,7 +495,7 @@ def _cli_wrapper_download_file(
     ),
 ):
     if draft:
-        key = DraftKey(product=product, build=version)
+        key: ProductKey = DraftKey(product=product, build=version)
     else:
         key = PublishKey(product=product, version=version)
     download_file(key, filepath, output_dir)

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -481,6 +481,11 @@ def _cli_wrapper_download_file(
         "--product",
         help="Name of data product (publishing folder in s3)",
     ),
+    draft: bool = typer.Option(
+        False,
+        "-d",
+        "--draft",
+    ),
     version: str = typer.Option(None, "-v", "--version", help="Product version"),
     filepath: str = typer.Option(
         None, "-f", "--filepath", help="Filepath within s3 output folder"
@@ -489,7 +494,11 @@ def _cli_wrapper_download_file(
         None, "-o", "--output-dir", help="Folder to download file to"
     ),
 ):
-    download_file(PublishKey(product, version), filepath, output_dir)
+    if draft:
+        key = DraftKey(product=product, build=version)
+    else:
+        key = PublishKey(product=product, version=version)
+    download_file(key, filepath, output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thinking about ingest rollout has gotten me thinking about stability of code and ability to recreate older builds. Personally, I'd like us to be able to change the projection of our source datasets to be consistently in state plane, or not worry too much if we want to clean up column names in a source dataset at some point. However, those would likely both require code changes in, say ztl build code. These changes would produce the desired results with new data, but if we tried to rerun an old build with our current repo, we'd obviously not be able to due to breaking changes.

We do track the commit which produced a dataset, but often these commits don't exist in the repo anymore. Github seems to [retain them](https://github.com/NYCPlanning/data-engineering/commit/7330f0700a8190ae904132da2a5872bcdccb88a2) for some amount of time, see that example of the commit that built FacDB 24v1. But it'd be a pain to try to run code from that commit - we can't just check it out, since it's not a part of any tree.

So, it'd make a lot of sense to create tags when we publish, cementing the code that built a specific published version. This is a first draft, really mean this to be a conversation starter more than anything else. For now, went with convention of tag names being "{product}__{version}" - most special characters aren't allowed.

[Here's the action that published a tag](https://github.com/NYCPlanning/data-engineering/actions/runs/9685375521/job/26725313608)
[Here's the tag](https://github.com/NYCPlanning/data-engineering/releases/tag/db-template__0.0.2)