### PR TITLE
add bash script to run sqlfluff dbt for multiple projects

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -56,11 +56,8 @@ jobs:
           sqlfluff lint products/pluto/pluto_build/sql/
           sqlfluff lint products/zoningtaxlots/sql/
 
-          # this should probably be its own util/script
-          export BUILD_ENGINE_DB=db-green-fast-track
-          dbt deps --profiles-dir products/green_fast_track --project-dir products/green_fast_track
-          dbt build --select config.materialized:seed --indirect-selection=cautious --full-refresh --profiles-dir products/green_fast_track --project-dir products/green_fast_track
-          sqlfluff lint products/green_fast_track/models --templater=dbt
+          # dbt requires slightly special logic
+          ./bash/sqlfluff_dbt.sh lint green_fast_track
 
   mypy:
     runs-on: ubuntu-22.04

--- a/bash/sqlfluff_dbt.sh
+++ b/bash/sqlfluff_dbt.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+command=$1
+project=$2
+dir="products/${project}"
+folder=${3:-models}
+
+if [ -z $project ]
+then
+    echo "supply both sqlfluff command (lint/fix) and project folder"
+    exit 1
+fi
+
+if [ -eq "$project" "zoningtaxlots" ]
+then
+    export BUILD_ENGINE_DB="db-ztl"
+else
+    export BUILD_ENGINE_DB="db-$(echo "$project" | tr '_' '-')"
+fi
+
+echo "
+[tool.sqlfluff.templater.dbt]
+dialect = \"postgres\"
+project_dir = \"${dir}\"
+profiles_dir = \"${dir}\"" >> pyproject.toml
+
+dbt deps --profiles-dir $dir --project-dir $dir
+dbt build --select config.materialized:seed --indirect-selection=cautious --full-refresh --profiles-dir $dir --project-dir $dir
+sqlfluff $command $dir/$folder --templater=dbt
+
+echo "$(head -n -5 pyproject.toml)" > pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,6 @@ CAPTURE_DATE_PREV = "2023-07-01"
 internal_columns = '"Job_Number","Job_Type"'
 external_columns = '"Job_Number","Job_Type"'
 
-[tool.sqlfluff.templater.dbt]
-project_dir = "products/green_fast_track"
-profiles_dir = "products/green_fast_track"
-dialect = "postgres"
-
 [tool.sqlfluff.templater.jinja.context]
 source_column="bct2020"
 output_column="bct2020"


### PR DESCRIPTION
@HengJiang0206 has run up in issues in #936 that it's awkward to run sqlfluff with dbt templater for a different project. This PR creates a script to make it a relatively simple call to run dbt in one step.

This removes the sqlfluff dbt templater section from pyproject.toml and instead only adds it in when we want to run it. This is an annoying hack since these configs can't just be passed to sqlfluff (maybe I need add this to my fork...)

I originally was going to do something like yq to edit the toml, but yq doesn't support things like arrays in toml yet and installing another tool seemed like more hassle than it was worth, so I just append to and then drop the end of the pyproject.toml with basic bash function calls