### PR TITLE
DO Directory Restructure : implement new `publishing`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
             --product ${{ inputs.product }} \
             --build ${{ inputs.draft_build }} \
             --acl ${{ inputs.product_acl }} \
-            --is_patch ${{ inputs.is_patch }} \
+            ${{ github.event.inputs.is_patch == 'true' && '--is_patch' || '' }} \
             ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
 
       - name: create tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ on:
         type: boolean
         default: true
         required: true
+      overwrite_if_exists:
+        description: "Overwrite contents if version exists?"
+        type: boolean
+        default: false
+        required: true
       product_acl:
         description: "Set access control list for output in DO"
         type: choice
@@ -85,6 +90,7 @@ jobs:
             --product ${{ inputs.product }} \
             --build ${{ inputs.draft_build }} \
             --acl ${{ inputs.product_acl }} \
+            --overwrite_if_exists ${{ inputs.overwrite_if_exists }} \
             ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
 
       - name: create tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,8 @@ on:
         type: boolean
         default: true
         required: true
-      overwrite_if_exists:
-        description: "Overwrite contents if version exists?"
+      is_patch:
+        description: "Create a patched version?"
         type: boolean
         default: false
         required: true
@@ -90,7 +90,7 @@ jobs:
             --product ${{ inputs.product }} \
             --build ${{ inputs.draft_build }} \
             --acl ${{ inputs.product_acl }} \
-            --overwrite_if_exists ${{ inputs.overwrite_if_exists }} \
+            --is_patch ${{ inputs.is_patch }} \
             ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
 
       - name: create tag

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -214,7 +214,6 @@ def publish(
     By default, keeps draft output folder"""
     if version is None:
         version = get_version(draft_key)
-        assert version is not None
 
     version_already_published = version in get_published_versions(
         product=draft_key.product

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -216,7 +216,9 @@ def publish(
     )
     # Bump version if input version already exists and overwrite isn't allowed
     if version_already_published and not overwrite_if_exists:
-        version = versions.bump(previous_version=version, bump_type="patch", bump_by=1)
+        version = versions.bump(
+            previous_version=version, bump_type=versions.VersionSubType.patch, bump_by=1
+        )
 
     source = draft_key.path + "/"
     target = f"{draft_key.product}/publish/{version}/"

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -38,22 +38,19 @@ def get_build_metadata(product_key: ProductKey) -> BuildMetadata:
     return BuildMetadata(**yaml.safe_load(file_content))
 
 
-def get_version(product_key: ProductKey) -> str | None:
-    """
-    Given product key, gets version. None is returned when metadata file
-    for given product_key doesn't exist.
-    """
-    try:
-        return get_build_metadata(product_key).version
-    except ClientError:
-        return None
+def get_version(product_key: ProductKey) -> str:
+    """Given product key, gets version."""
+    return get_build_metadata(product_key).version
 
 
 def get_latest_version(product: str) -> str | None:
     """Given product name, gets latest version
     Assumes existence of build_metadata.json in output folder
     """
-    return get_version(PublishKey(product, "latest"))
+    try:
+        return get_version(PublishKey(product, "latest"))
+    except ClientError:
+        return None
 
 
 def get_published_versions(product: str) -> list[str]:

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -42,7 +42,7 @@ def get_version(product_key: ProductKey) -> str:
 
 def get_latest_version(product: str) -> str:
     """Given product name, gets latest version
-    Assumes existence of version.txt in output folder
+    Assumes existence of build_metadata.json in output folder
     """
     return get_version(PublishKey(product, "latest"))
 
@@ -211,6 +211,8 @@ def publish(
     target = f"{draft_key.product}/publish/{version}/"
     s3.copy_folder(BUCKET, source, target, acl, max_files=max_files)
     if latest:
+        # TODO: if the version is is older than existing latest, pass. provide logging message
+        # TODO: do we want raise an error or a logging message suffices?
         s3.copy_folder(
             BUCKET,
             source,

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -214,13 +214,8 @@ def publish(
     version_already_published = version in get_published_versions(
         product=draft_key.product
     )
-    # Exit if input version already exists and overwrite isn't allowed
+    # Bump version if input version already exists and overwrite isn't allowed
     if version_already_published and not overwrite_if_exists:
-        raise FileExistsError(
-            f"Version {version} already exists in s3. If you wish to overwrite folder contents, select 'overwrite'."
-        )
-    # Bump version if input version already exists in s3
-    elif version_already_published:
         version = versions.bump(previous_version=version, bump_type="patch", bump_by=1)
 
     source = draft_key.path + "/"

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -218,7 +218,7 @@ def publish(
     if version_already_published and not overwrite_if_exists:
         version = versions.bump(
             previous_version=version, bump_type=versions.VersionSubType.patch, bump_by=1
-        )
+        ).label
 
     source = draft_key.path + "/"
     target = f"{draft_key.product}/publish/{version}/"

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -525,6 +525,12 @@ def _cli_wrapper_publish(
     latest: bool = typer.Option(
         False, "-l", "--latest", help="Publish to latest folder as well?"
     ),
+    is_patch: bool = typer.Option(
+        False,
+        "-ip",
+        "--is_patch",
+        help="Create a patched version if version already exists?",
+    ),
 ):
     acl_literal = s3.string_as_acl(acl)
     logger.info(
@@ -535,6 +541,7 @@ def _cli_wrapper_publish(
         acl=acl_literal,
         version=version,
         latest=latest,
+        is_patch=is_patch,
     )
 
 

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -496,6 +496,12 @@ def _cli_wrapper_publish(
     latest: bool = typer.Option(
         False, "-l", "--latest", help="Publish to latest folder as well?"
     ),
+    overwrite_if_exists: bool = typer.Option(
+        False,
+        "-o",
+        "--overwrite_if_exists",
+        help="Overwrite contents if version exists?",
+    ),
 ):
     acl_literal = s3.string_as_acl(acl)
     logger.info(
@@ -506,6 +512,7 @@ def _cli_wrapper_publish(
         acl=acl_literal,
         version=version,
         latest=latest,
+        overwrite_if_exists=overwrite_if_exists,
     )
 
 

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -216,6 +216,7 @@ def publish(
     By default, keeps draft output folder"""
     if version is None:
         version = get_version(draft_key)
+        assert version is not None
 
     version_already_published = version in get_published_versions(
         product=draft_key.product

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -41,13 +41,17 @@ def plan_recipe(recipe_path: Path, version: str | None = None) -> Recipe:
             case versions.SimpleVersionStrategy.first_of_month:
                 recipe.version = versions.generate_first_of_month().label
             case versions.SimpleVersionStrategy.bump_latest_release:
+                previous_version = publishing.get_latest_version(recipe.product)
+                assert previous_version is not None
                 recipe.version = versions.bump(
-                    previous_version=publishing.get_latest_version(recipe.product),
+                    previous_version=previous_version,
                     bump_type=recipe.version_type,
                 ).label
             case versions.BumpLatestRelease() as bump:
+                previous_version = publishing.get_latest_version(recipe.product)
+                assert previous_version is not None
                 recipe.version = versions.bump(
-                    previous_version=publishing.get_latest_version(recipe.product),
+                    previous_version=previous_version,
                     bump_type=recipe.version_type,
                     bump_by=bump.bump_latest_release,
                 ).label

--- a/dcpy/test/conftest.py
+++ b/dcpy/test/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import shutil
 import yaml
 
-from dcpy.utils import s3
+from dcpy.utils import s3, versions
 from dcpy.models.lifecycle.builds import BuildMetadata
 from dcpy.connectors.edm import recipes, publishing, packaging
 from dcpy.lifecycle.builds import plan
@@ -54,7 +54,7 @@ def mock_data_constants():
         )
 
     test_product_name = "test-product"
-    test_version = "v001"
+    test_version = versions.MajorMinor(year=24, major=2).label
     constants = {
         "TEST_PRODUCT_NAME": test_product_name,
         "TEST_PACKAGE_DATASET": "test_package_dataset",

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -155,8 +155,7 @@ def test_publish_excludes_latest_when_flag_false(
         draft_key=draft_key, acl=TEST_ACL, version=TEST_VERSION, latest=False
     )
     # assert that latest folder was not populated
-    with pytest.raises(ClientError) as e_info:
-        publishing.get_latest_version(TEST_PRODUCT_NAME)
+    publishing.get_latest_version(TEST_PRODUCT_NAME) == None
     # assert a file is published to "latest"
     publishing.publish(
         draft_key=draft_key,

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -89,7 +89,7 @@ def test_publish_overwrite_and_patch(
         previous_version=TEST_VERSION,
         bump_type=versions.VersionSubType.patch,
         bump_by=1,
-    )
+    ).label
     assert set(publishing.get_published_versions(product=draft_key.product)) == set(
         [TEST_VERSION, bumped_version]
     )

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -101,14 +101,13 @@ class TestVersions(TestCase):
             ["23v2", "22v3.4", True],
             ["23Q1", "23Q2", False],
             ["2023-01-01", "2023-08-01", False],
+            ["23Q2", "2023-01-01", True],
         ]:
             self.assertEqual(bool_expected, versions.is_newer(version_1, version_2))
 
     def test_is_newer_invalid_versions(self):
         with self.assertRaises(TypeError):
             versions.is_newer("23v2", "23Q2")
-        with self.assertRaises(TypeError):
-            versions.is_newer("23Q1", "2023-01-01")
         with self.assertRaises(ValueError):
             versions.is_newer("", "2023-08-01")
 
@@ -123,5 +122,13 @@ class TestVersions(TestCase):
             [None, 7, "23Q2", "25Q1"],
             [None, 7, "2023-01", "2023-08"],
             [None, 1, "2023-12", "2024-01"],
+            ["patch", 1, "23v2", "23v2.0.1"],
+            ["patch", 1, "23v2.1", "23v2.1.1"],
+            ["patch", 1, "2023-01", "2023-01.1"],
+            ["patch", 1, "2023-01.2", "2023-01.3"],
+            ["patch", 2, "23Q2.1", "23Q2.3"],
+            ["major", None, "23v2.0.1", "23v3"],
+            ["minor", None, "23v2.2.1", "23v2.3"],
+            [None, 2, "23Q4.1", "24Q2"],
         ]:
             self.assertEqual(v_expected, versions.bump(v, bumped_part, bump_by).label)

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -106,7 +106,7 @@ class TestVersions(TestCase):
             self.assertEqual(bool_expected, versions.is_newer(version_1, version_2))
 
     def test_is_newer_invalid_versions(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             versions.is_newer("23v2", "23Q2")
         with self.assertRaises(ValueError):
             versions.is_newer("", "2023-08-01")

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -96,6 +96,22 @@ class TestVersions(TestCase):
                 "2024-01-01",
             ].sort()
 
+    def test_is_newer_valid_versions(self):
+        for version_1, version_2, bool_expected in [
+            ["23v2", "22v3.4", True],
+            ["23Q1", "23Q2", False],
+            ["2023-01-01", "2023-08-01", False],
+        ]:
+            self.assertEqual(bool_expected, versions.is_newer(version_1, version_2))
+
+    def test_is_newer_invalid_versions(self):
+        with self.assertRaises(TypeError):
+            versions.is_newer("23v2", "23Q2")
+        with self.assertRaises(TypeError):
+            versions.is_newer("23Q1", "2023-01-01")
+        with self.assertRaises(ValueError):
+            versions.is_newer("", "2023-08-01")
+
     def test_bumping_versions(self):
         for bumped_part, bump_by, v, v_expected in [
             ["major", None, "23v2", "23v3"],

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -242,11 +242,7 @@ def is_newer(version_1: str, version_2: str) -> bool:
         versions_sorted = sort([version_1_obj, version_2_obj])
     except TypeError:
         raise TypeError(
-            f"Can't compare mixed types of dataset versions: {type(version_1_obj), type(version_2_obj)}"
-        )
-    except Exception:
-        raise ValueError(
-            f"Tried to parse version: but one or both did not match the expected formats: {version_1, version_2}"
+            f"Can't compare mixed types of dataset versions: {version_1_obj, version_2_obj}"
         )
 
     return versions_sorted[-1] == version_1_obj

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -35,6 +35,8 @@ class RegexSpmMatch:
 
 @total_ordering
 class Version:
+    patch: int = 0
+
     @property
     @abstractmethod
     def label(self) -> str:
@@ -190,6 +192,27 @@ def sort(versions: list[Version]) -> list[Version]:
             f"Can't sort mixed types of dataset versions: {[v.__name__ for v in version_types]}"
         )
     return sorted(versions)
+
+
+def is_newer(version_1: str, version_2: str) -> bool:
+    """
+    Compares `version_1` to `version_2`. Returns True if `version_1` is newer than `version_2`.
+    Both versions are expected to be of same Version subtype.
+    """
+    try:
+        version_1_obj = parse(version_1)
+        version_2_obj = parse(version_2)
+        versions_sorted = sort([version_1_obj, version_2_obj])
+    except TypeError as e:
+        raise e(
+            f"Can't compare mixed types of dataset versions: {type(version_1_obj), type(version_2_obj)}"
+        )
+    except Exception:
+        raise ValueError(
+            f"Tried to parse version: but one or both did not match the expected formats: {version_1, version_2}"
+        )
+
+    return versions_sorted[-1] == version_1_obj
 
 
 def bump(

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -178,6 +178,20 @@ def parse(v: str) -> Version:
             )
 
 
+def sort(versions: list[Version]) -> list[Version]:
+    """
+    Sorts version in ascending order: from oldest to newest.
+    """
+    version_types = set([type(v) for v in versions])
+    # can't compare different types
+    if len(version_types) != 1:
+        # only handle date-like versions
+        raise TypeError(
+            f"Can't sort mixed types of dataset versions: {[v.__name__ for v in version_types]}"
+        )
+    return sorted(versions)
+
+
 def bump(
     previous_version: str | Version,
     bump_type: VersionSubType | None = None,

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -236,16 +236,9 @@ def is_newer(version_1: str, version_2: str) -> bool:
     Compares `version_1` to `version_2`. Returns True if `version_1` is newer than `version_2`.
     Both versions are expected to be of same Version subtype.
     """
-    try:
-        version_1_obj = parse(version_1)
-        version_2_obj = parse(version_2)
-        versions_sorted = sort([version_1_obj, version_2_obj])
-    except TypeError:
-        raise TypeError(
-            f"Can't compare mixed types of dataset versions: {version_1_obj, version_2_obj}"
-        )
-
-    return versions_sorted[-1] == version_1_obj
+    version_1_obj = parse(version_1)
+    version_2_obj = parse(version_2)
+    return version_1_obj > version_2_obj
 
 
 def bump(

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -240,8 +240,8 @@ def is_newer(version_1: str, version_2: str) -> bool:
         version_1_obj = parse(version_1)
         version_2_obj = parse(version_2)
         versions_sorted = sort([version_1_obj, version_2_obj])
-    except TypeError as e:
-        raise e(
+    except TypeError:
+        raise TypeError(
             f"Can't compare mixed types of dataset versions: {type(version_1_obj), type(version_2_obj)}"
         )
     except Exception:

--- a/products/template/recipe.yml
+++ b/products/template/recipe.yml
@@ -1,6 +1,6 @@
 name: Template DB
 product: template
-version: 0.0.2
+version: 24Q3
 inputs:
   datasets:
     - name: nypl_libraries


### PR DESCRIPTION
Related to #825 and #960.

## What
1. Add `overwrite` option in GH publishing action. Why?
    * During a publishing action, suppose something fails **before** publishing to `latest` but **after** publishing to `<version>` folder. In this case, `latest` doesn't have up to date version. If we were to re-publish same data, then we would be creating a new, patched `<version>` folder. 
    **Solution:** add a button in GHA to overwrite folder contents if the version already exists. If overwriting is not selected, bump the version by patch type. 

2. Modify logic promoting to `latest` folder: if the draft has an older version when compared to the data in `latest`, throw an error and don't promote the draft.

3. Modify current versioning to allow patches in `publish`. Below are 3 scenarios when promoting to `publish` and the new logic implemented in this PR:
    * The version doesn't exist in `publish` folder - promote to `publish` with the input version. No changes to current behavior.         
    * The version already exists in `publish` and `overwrite` is selected - overwrite existing version folder with the new contents.
    * The version already exists in `publish` and `overwrite` is NOT selected - save data contents to a new, patched version folder.  

I recommend reviewing commit by commit. 

## New version examples
* `24v3` -> `24v3.0.1` 
* `24v3.2` -> `24v3.2.1`
* `24Q1` -> `24Q1.1`
* `2024-03-01` -> `2024-03-01.1`

## 🚨 Feedback needed
* For non-patched `MajorMinor` versions, do we prefer `24v3` or `24v3.0`? 
* Overall version patch format consisting of  `<version>.<patch num>`? 
* Thoughts on new logic for promoting to `latest`

