### PR TITLE
Pluto zoning tweaks

### DIFF
--- a/products/pluto/pluto_build/02_build.sh
+++ b/products/pluto/pluto_build/02_build.sh
@@ -74,8 +74,6 @@ run_sql_file sql/zoning_specialdistrict.sql
 run_sql_file sql/zoning_limitedheight.sql
 run_sql_file sql/zoning_zonemap.sql
 run_sql_file sql/zoning_parks.sql
-run_sql_file sql/zoning_correctdups.sql
-run_sql_file sql/zoning_correctgaps.sql
 run_sql_file sql/zoning_splitzone.sql
 run_sql_command "VACUUM ANALYZE pluto;"
 

--- a/products/pluto/pluto_build/sql/zoning_correctdups.sql
+++ b/products/pluto/pluto_build/sql/zoning_correctdups.sql
@@ -1,5 +1,0 @@
--- remove duplicate zoning values
--- this can be deleted if overlay logic is updated to align with zonedist, spdist
-UPDATE pluto
-SET overlay2 = NULL
-WHERE overlay1 = overlay2;

--- a/products/pluto/pluto_build/sql/zoning_correctgaps.sql
+++ b/products/pluto/pluto_build/sql/zoning_correctgaps.sql
@@ -1,8 +1,0 @@
--- fill in gaps of zoning information
--- this can be deleted if overlay logic is updated to align with zonedist, spdist
-
-UPDATE pluto
-SET
-    overlay1 = overlay2,
-    overlay2 = NULL
-WHERE overlay1 IS NULL;

--- a/products/pluto/pluto_build/sql/zoning_specialdistrict.sql
+++ b/products/pluto/pluto_build/sql/zoning_specialdistrict.sql
@@ -54,7 +54,7 @@ SELECT
     bbl,
     sdlbl,
     segbblgeom,
-    ROW_NUMBER() OVER (PARTITION BY id ORDER BY segbblgeom ASC, sdlbl DESC) AS row_number
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY segbblgeom DESC, sdlbl ASC) AS row_number
 FROM specialpurposeperorder_init
 WHERE
     perbblgeom >= 10


### PR DESCRIPTION
A couple things were discovered in #972 for ztl that are the same for pluto
1. Bug in special districts - sorting wrong order. This changes about 60 lots - outside of the lots that have their ordering manually set for the specific combo of special districts, there are luckily very few that are in multiple
2. Use grouping logic in commercial overlay just like we do for zoning districts. This ends up only affecting a few rows as well

Running build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9942202430) to compare to nightly_qa. Differences are
- 40 sp dist flips (expected). I need to confirm with GIS about these (and ordering in ztl)
- 12 commercial dist changes (expected) - due to grouping by commercial overlay (so if there are two smaller C-2 overlays, that's captured)
- 1 splitzone change (due to a commercial overlay change)
- 25 lottype changes - unexpected. See #1012 