### PR TITLE
Fix `dcpy` util function `s3.get_subfolders()`

### DIFF
--- a/dcpy/test/utils/test_s3.py
+++ b/dcpy/test/utils/test_s3.py
@@ -63,3 +63,27 @@ def test_get_filenames(create_buckets, prefix, expected_num_objects):
         s3.client().put_object(Bucket=TEST_BUCKET, Key=obj)
     actual_objects = s3.get_filenames(bucket=TEST_BUCKET, prefix=prefix)
     assert len(actual_objects) == expected_num_objects
+
+
+@pytest.mark.parametrize(
+    "prefix, index, expected_num_folders",
+    [
+        ("", 1, 2),
+        ("", 2, 1),
+        (TEST_DIR_NAME_1, 1, 1),
+        (TEST_DIR_NAME_1, 2, 0),
+        (TEST_DIR_NAME_2, 1, 0),
+    ],
+)
+def test_get_subfolders(create_buckets, prefix, index, expected_num_folders):
+    """Tests total number of folders with given prefix and depth (index)."""
+    objects_to_add = [
+        TEST_DIR_NAME_1 + "/" + TEST_FILE_NAME,
+        TEST_DIR_NAME_1 + "/" + TEST_DIR_NAME_2 + "/",
+        TEST_DIR_NAME_2 + "/",
+    ]
+    for obj in objects_to_add:
+        s3.client().put_object(Bucket=TEST_BUCKET, Key=obj)
+    actual_objects = s3.get_subfolders(bucket=TEST_BUCKET, prefix=prefix, index=index)
+
+    assert len(actual_objects) == expected_num_folders

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -398,7 +398,7 @@ def get_subfolders(bucket: str, prefix: str, index=1) -> list[str]:
         print(f"get_subfolders(bucket={bucket}, prefix={prefix}, index={index}) failed")
         raise exc
 
-    return list(subfolders)
+    return sorted(list(subfolders))
 
 
 def get_file_as_stream(bucket: str, path: str) -> BytesIO:


### PR DESCRIPTION
### What
While working on DO directory restructure stuff, I tried to use existing `s3.get_subfolders()` function but realized it doesn't work correctly when input param `index` isn't the default value (default value is set to be the top level of directory). For example, let's say we have the following objects in s3:

* `folder1/folder2/file.txt`
* `folder3/`

**The expected behavior of the function is this:**

```bash
>>> s3.get_subfolders(bucket='my_bucket', prefix='', index=1)
>>> ['folder1', 'folder3']
>>>
>>> s3.get_subfolders(bucket='my_bucket', prefix='', index=2)
>>> ['folder1/folder2']
```

**The current behavior:**
```bash
>>> s3.get_subfolders(bucket='my_bucket', prefix='', index=1)
>>> ['folder1', 'folder3']
>>>
>>> s3.get_subfolders(bucket='my_bucket', prefix='', index=2)
>>> []
```

### Why
The reason why the current code doesn't work is because supplying the `Delimiter` param below automatically returns directories ONLY from the top level: 
```python
paginator = client().get_paginator("list_objects_v2")
paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/")
```  

We probably didn't notice the code issue before because all references use this function with the default index value. 