### PR TITLE
replace `\x1a` with `'` in facdb source data

### DIFF
--- a/products/facilities/facdb/sql/dohmh_daycare.sql
+++ b/products/facilities/facdb/sql/dohmh_daycare.sql
@@ -28,11 +28,13 @@ _dohmh_daycare_tmp AS(
     SELECT
         uid,
         source,
-        (CASE
-            WHEN center_name LIKE '%SBCC%' THEN initcap(legal_name)
-            WHEN center_name LIKE '%SCHOOL BASED CHILD CARE%' THEN initcap(legal_name)
-            ELSE initcap(center_name)
-        END) as facname,
+        REGEXP_REPLACE(
+            (CASE
+                WHEN center_name LIKE '%SBCC%' THEN initcap(legal_name)
+                WHEN center_name LIKE '%SCHOOL BASED CHILD CARE%' THEN initcap(legal_name)
+                ELSE initcap(center_name)
+            END), '\x1a', ''''
+        ) as facname,
         building as addressnum,
         street as streetname,
         building||' '||street as address,


### PR DESCRIPTION
resolves #500 

successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9864520948) (temporarily used changes from #992 because FacDB is broken on main)

### query showing no records with the bad character:

<img width="296" alt="Screenshot 2024-07-09 at 5 48 44 PM" src="https://github.com/NYCPlanning/data-engineering/assets/7444289/16ca792d-179f-4aad-a0da-e3cf4d1f61ce">
