### PR TITLE
ignore `TypeError` in `try_get_previous_version`

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -90,19 +90,6 @@ def get_previous_version(
             )
 
 
-def try_get_previous_version(
-    product: str, version: str | versions.Version
-) -> versions.Version | None:
-    try:
-        return get_previous_version(product, version)
-    except (
-        LookupError,
-        ValueError,
-    ) as e:  # versions not found, or don't parse correctly
-        logger.error(f"Error: {e}")
-        return None
-
-
 def get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
     """Given product name, gets source data versions of published version"""
     source_data_versions = read_csv(product_key, "source_data_versions.csv", dtype=str)

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -58,14 +58,20 @@ def plan_recipe(recipe_path: Path, version: str | None = None) -> Recipe:
     recipe.vars["VERSION"] = recipe.version
 
     # Determine previous version
-    previous_recipe = publishing.try_get_previous_version(
-        recipe.product, recipe.version
-    )
-    if previous_recipe is not None:
+    try:
+        previous_recipe = publishing.get_previous_version(
+            product=recipe.product, version=recipe.version
+        )
         logger.info(
             f"Previous version of {recipe.product}: {previous_recipe.label} ({previous_recipe})"
         )
         recipe.vars["VERSION_PREV"] = previous_recipe.label
+    except (
+        LookupError,
+        ValueError,
+        TypeError,
+    ) as e:  # versions not found, or don't parse correctly
+        logger.error(f"Error: {e}")
 
     # Add vars to environ so both can be accessed in environ
     logger.info(f"Export envars: {recipe.vars}")


### PR DESCRIPTION
related to https://github.com/NYCPlanning/data-engineering/issues/980

this is likely a temporary fix for an issue that's breaking FacDB builds ([build log example](https://github.com/NYCPlanning/data-engineering/actions/runs/9851298874/job/27197932440#step:8:16)): 

```bash
INFO:dcpy:Planning recipe from recipe.yml
INFO:dcpy:Published versions of db-facilities: ['latest', '24v1', '2023-08-09', '2023-08-02', '2023-04-10', '2023-04-07', '2023-03-23', '2022-07-01', '2022-04-25', '2022-04-21', '2022-04-20', '2022-04-19', '2022-04-15', '2021-10-20', '2021-08-02', '2021-07-09', '2021-07-08', '2021-07-06', '2021-07-02', '2021-06-30', '2021-06-24', '2021-06-22', '2021-06-17', '2021-06-14', '2021-06-11', '2021-06-09', '2021-06-08', '2021-06-07', '2021-06-04', '2021-06-02', '2021-05-14', '2021-05-13', '2021-05-12', '2021-03-02', '2021-03-01', '2020-12-18', '2020-12-04', '2020-12-03', '2020-11-30', '2020-07-15', '2020-07-10', '2020-07-08', '2020-06-24', '2020-05-28', '2020-05-01', '2020-04-13', '2020-04-10', '2020-04-09', '2020-04-08', '2020-04-02', '2020-03-30', '2020-03-25', '2020-03-24', '2020-02-26', '2020-02-21', '2020-02-19']
...
TypeError: Can't sort mixed types of dataset versions: ['FirstOfMonth', 'Date',  'MajorMinor']
```

successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9860916775)