### PR TITLE
add linguist gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.sql linguist-detectable=true
+# for sql files that show up as "PLpgSQL"
+*.sql linguist-language=SQL
+**/data/** linguist-vendored
+*.ipynb linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.sql linguist-language=SQL
 **/data/** linguist-vendored
 *.ipynb linguist-vendored
+**/docs/** linguist-documentation


### PR DESCRIPTION
Silly little PR

See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md for documentation on these "gitattributes"

This bugs me
<img width="335" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/b88f430c-8d44-4b43-8e4f-8dccb033c2e5">

Especially because when you click on "Jupyter Notebooks", nothing shows up - see [here](https://github.com/search?q=repo%3ANYCPlanning%2Fdata-engineering++language%3A%22Jupyter+Notebook%22&type=code)

We do actually have a single notebook - https://github.com/NYCPlanning/data-engineering/blob/main/products/template/python/map_data.ipynb. We could maybe just get rid of this, but I'd still rather not see ipynbs dominate the language dist for one small file.

I've also added sql as a language which is not included by default, though this ignores the couple GIGANTIC files in `data` folders. We should probably get these into library/recipes (cpdb has a monster one. Not entirely sure at first glance why its needed. It's called "sprints"). 

Now, we see a much more reasonable distribution
<img width="369" alt="image" src="https://github.com/NYCPlanning/data-engineering/assets/9454672/cf0b5579-1bdc-4d59-95e3-bbaaff67e1a2">

We could specify HTML as "generated" since we don't actually write any as well