### PR TITLE
custom ordering for versions

### DIFF
--- a/.github/workflows/facilities_build.yml
+++ b/.github/workflows/facilities_build.yml
@@ -51,9 +51,6 @@ jobs:
         working-directory: ./
         run: ./bash/build_env_setup.sh
 
-      - name: Set product environment variables
-        run: cat version.env >> "$GITHUB_ENV"
-
       - name: Plan build
         run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -69,7 +69,7 @@ def get_previous_version(
     published_versions = [
         versions.parse(v) for v in published_version_strings if v != "latest"
     ]
-    published_versions = versions.sort(published_versions)
+    published_versions.sort()
     if len(published_versions) == 0:
         raise LookupError(f"No published versions found for {product}")
     if version_obj in published_versions:

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -36,7 +36,7 @@ class TestVersions(TestCase):
             versions.parse("20231212")
 
     def test_sort_valid_versions(self):
-        for version_list, sorted in [
+        for version_list, sorted_list in [
             [
                 [
                     "23v2",
@@ -56,12 +56,15 @@ class TestVersions(TestCase):
                     "23Q4",
                     "2023-10-02",
                     "2023-11-02",
+                    "25v3",
+                    "21v1",
                     "2023-11",
                     "2023-02-05",
                     "2024-01-01",
                     "23Q2",
                 ],
                 [
+                    "21v1",
                     "2023-02-05",
                     "23Q2",
                     "23Q4",
@@ -69,23 +72,29 @@ class TestVersions(TestCase):
                     "2023-11",
                     "2023-11-02",
                     "2024-01-01",
+                    "25v3",
                 ],
             ],
         ]:
-            parsed_and_sorted = versions.sort([versions.parse(v) for v in version_list])
+            parsed_and_sorted = sorted([versions.parse(v) for v in version_list])
             labels = [v.label for v in parsed_and_sorted]
-            self.assertEqual(sorted, labels)
+            self.assertEqual(sorted_list, labels)
 
     def test_sort_invalid_versions(self):
+        with self.assertRaises(ValueError):
+            [
+                versions.Date(
+                    date(2024, 1, 1), format=versions.DateVersionFormat.quarter
+                ),
+                versions.MajorMinor(year=24, major=2),
+            ].sort()
         with self.assertRaises(TypeError):
-            versions.sort(
-                [
-                    versions.Date(
-                        date(2024, 1, 1), format=versions.DateVersionFormat.quarter
-                    ),
-                    versions.MajorMinor(year=23, major=2),
-                ]
-            )
+            [
+                versions.Date(
+                    date(2024, 1, 1), format=versions.DateVersionFormat.quarter
+                ),
+                "2024-01-01",
+            ].sort()
 
     def test_bumping_versions(self):
         for bumped_part, bump_by, v, v_expected in [

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -188,15 +188,13 @@ def bump(
         previous_version = parse(previous_version)
     bump_by = bump_by or 1
     match previous_version, bump_type:
-        case MajorMinor(), None:
-            raise Exception("Must specify major or minor version to bump.")
         case MajorMinor(), VersionSubType.minor:
             return MajorMinor(
                 year=previous_version.year,
                 major=previous_version.major,
                 minor=previous_version.minor + bump_by,
             )
-        case MajorMinor(), VersionSubType.major:
+        case MajorMinor(), (VersionSubType.major | None):
             return MajorMinor(
                 year=previous_version.year, major=previous_version.major + bump_by
             )

--- a/products/facilities/recipe.yml
+++ b/products/facilities/recipe.yml
@@ -1,5 +1,5 @@
 name: Facilities
-version: 24v1
+version_strategy: bump_latest_release
 product: db-facilities
 inputs:
   dataset_defaults:


### PR DESCRIPTION
Implement @alexrichey's comment in #985 to allow comps of MajorMinor versions to Date versions if and only if they are from different years

passing facdb [here](https://github.com/NYCPlanning/data-engineering/actions/runs/9942177311)

Resolves failing facdb build in #1002 