### PR TITLE
format product readmes

### DIFF
--- a/products/cbbr/README.md
+++ b/products/cbbr/README.md
@@ -69,20 +69,19 @@ CBBR is primarily built for planning coordination and information purposes only
 2. Install pytest with `python3 -m pip install pytest`
 3. Run python tests with `python3 -m pytest`
 
-
 ### Processing Manually Digitized Geometry Files
 
 Typically, there are many records in the original CBBR Submissions source data that cannot/do not get programmatically geocoded by GeoSupport. This is usually do to insufficient location information or a particular record might not be applicable to a specific location (not a mappable project). To increase the number of mappable projects in the CBBR data, EDM set out to manually map records that were considered Priority A projects (that is projects identified as `Capital Projects` and which have been identified as a `Site` location).
 
-In order to properly preprocess these corrections to the existing CBBR data, the following steps are necessary: 
+In order to properly preprocess these corrections to the existing CBBR data, the following steps are necessary:
 
 1. Download the files (.shp and .gdb) from Sharepoint and bring them into QGIS.
 2. Merge “like” geometries using the ‘Vector` -> `Data Management Tool` -> `Merge Vector Layers` being cognizant that original CBBR geometries are projected in CRS/EPSG: 4236 (Export the file as 4236). EDM digitizers used different methods of digitizing and some used CRS/EPSG: 2263.
-    a. Note: you can merge Shapefiles and GDB files with like geometries 
+    a. Note: you can merge Shapefiles and GDB files with like geometries
 3. Repeat step for Points, Polygons, and Lines
 4. Export the files as CSV’s
-    a. Right Click the file you want to export: `Export` -> `Save Features As…` 
+    a. Right Click the file you want to export: `Export` -> `Save Features As…`
     b. Create file name for each individual file (e.g. `cbbr_line_corrections`)
     c. Select `Layer Options` -> `Geometry` - `AS_WKT`
-    d. Save the file(s) into the `cbbr/build/cbbr_geom_corrections/processed/` folder 
+    d. Save the file(s) into the `cbbr/build/cbbr_geom_corrections/processed/` folder
 5. Once that is done, the creation of the corrections files takes place programmatically.

--- a/products/ceqr/README.md
+++ b/products/ceqr/README.md
@@ -1,11 +1,13 @@
 # CEQR Application Data Pipelines
 
 This repository contains workflows to generate the data behind Planning Lab's City Environmental Quality Review Application. Currently, Data Engineering generates the datasets for the following CEQR chapters:
+
 + 6- Community Facilities
 + 16- Transportation
 + 17- Air Quality
 
 ## General workflow
+
 Each chapter consists of several datasets, organized into 'recipes.' In `/recipes`, you will find all of the pipelines currently maintained by Data Engineering. They are organized as follows:
 
 ```
@@ -20,44 +22,54 @@ recipes/
 │   └── runner.sh
 ```
 
-In general, the `build` scripts retrieve relevant columns from the input data, either by pulling from an open data source or by quering Data Engineering's RECIPE database. If needed, `build.py` also geocodes the data. 
+In general, the `build` scripts retrieve relevant columns from the input data, either by pulling from an open data source or by quering Data Engineering's RECIPE database. If needed, `build.py` also geocodes the data.
 
 This then gets passed to the EDM production database using `create.sql`, where final filtering, mapping, and geometry creation happens. Outputs also get pushed to a staging folder in DigitalOcean Spaces. Publishing from staging requires an additional call to the CLI.
 
 ## Build instructions
-### To build using github (NYCPlanning Members Only):
+
+### To build using github (NYCPlanning Members Only)
+
 Running a recipe using github actions is easy! Simply open an
 issue with a title containing `[build]` and the name of the recipe you'd like to run.
-For example, `[build] ctpp_censustract_centroids`. 
+For example, `[build] ctpp_censustract_centroids`.
 
 This will automatically trigger a build. Once complete, github will comment on your issue, provide a link with details about the run (this is where you can find runtime warnings and errors), then close out the issue.
 
-### To build locally:
-1. at root directory (where the `ceqr` file is), run: 
+### To build locally
+
+1. at root directory (where the `ceqr` file is), run:
+
 ```
 ./ceqr run recipe {{ recipe name }}
 ```
+
 e.g.
+
 ```
 ./ceqr run recipe nysdec_title_v_facility_permits
 ```
 
 ## Datasets
+
 ### 6. Community Facilities
- + ceqr_school_buildings
- + sca_capacity_projects
- + sca_e_projections_by_boro
- + sca_e_projections_by_sd
- + doe_significant_utilization_changes
+
++ ceqr_school_buildings
++ sca_capacity_projects
++ sca_e_projections_by_boro
++ sca_e_projections_by_sd
++ doe_significant_utilization_changes
 
 ### 16. Transportation
- + ctpp_censustract_centroids, ctpp_censustract_variables, ctpp_journey_to_work
- + nysdot_aadt
- + nysdot_functional_class
- + nysdot_traffic_counts
- + dot_traffic_cameras
+
++ ctpp_censustract_centroids, ctpp_censustract_variables, ctpp_journey_to_work
++ nysdot_aadt
++ nysdot_functional_class
++ nysdot_traffic_counts
++ dot_traffic_cameras
 
 ### 17. Air Quality
+
 + atypical_roadways
 + dep_cats_permits
 + nysdec_air_monitoring_stations

--- a/products/checkbook/README.md
+++ b/products/checkbook/README.md
@@ -1,10 +1,10 @@
-# Capital Spending Database (CSDB) 
+# Capital Spending Database (CSDB)
 
 ## Overview
 
 ## __About the Capital Spending Database (CSDB)__
 
-The Capital Spending Database (CSDB), a data product produced by the New York City (NYC) Department of City Planning (DCP) Data Engineering team, presents the first-ever spatialized view of historical liquidations of the NYC capital budget. Each row in the dataset corresponds to a unique capital project and captures vital information such as the sum of all checks disbursed for the project, a list of agencies associated with the project, a category assignment based on keywords in project text fields (‘Fixed Asset’, ‘Lump Sum’, or ‘ITT, Vehicles, and Equipment’), and most importantly, geospatial information associated with the project when possible. 
+The Capital Spending Database (CSDB), a data product produced by the New York City (NYC) Department of City Planning (DCP) Data Engineering team, presents the first-ever spatialized view of historical liquidations of the NYC capital budget. Each row in the dataset corresponds to a unique capital project and captures vital information such as the sum of all checks disbursed for the project, a list of agencies associated with the project, a category assignment based on keywords in project text fields (‘Fixed Asset’, ‘Lump Sum’, or ‘ITT, Vehicles, and Equipment’), and most importantly, geospatial information associated with the project when possible.
 
 ...
 
@@ -17,15 +17,15 @@ Currently, the data product is created from two source datasets:
 
 > Note: All source data is in our DigitalOcean S3 storage in the `edm-recipes` bucket
 
-Checkbook NYC and the Capital Projects Database (CPDB). Checkbook NYC provides the information related to historical liquidations of the capital budget at the capital project level, while CPDB provides geospatial information for those projects. 
+Checkbook NYC and the Capital Projects Database (CPDB). Checkbook NYC provides the information related to historical liquidations of the capital budget at the capital project level, while CPDB provides geospatial information for those projects.
 
-Checkbook NYC is an open-source dataset and tool from the NYC Comptroller’s Office that publishes every check disbursed by the city. For the Historical Liquidations dataset, we limited the scope of this data source to only those checks pertaining to capital spending, as defined by Checkbook NYC. 
+Checkbook NYC is an open-source dataset and tool from the NYC Comptroller’s Office that publishes every check disbursed by the city. For the Historical Liquidations dataset, we limited the scope of this data source to only those checks pertaining to capital spending, as defined by Checkbook NYC.
 
 CPDB is a data product produced by the NYC DCP Data Engineering team that “captures key data points on potential, planned, and ongoing capital projects sponsored or maintained by a capital agency in and around NYC” [source]. CPDB is updated three times per year in response to the Capital Commitment Plan (CCP). Because only capital projects reported in the current fiscal year (FY)’s CCP are reflected in CPDB, the Historical Liquidations dataset utilizes the previous adopted versions of CPDB, in addition to the most recent version of CPDB from the current FY.
 
 ### Limitations
 
-Currently, roughly 25% of capital projects in Checkbook NYC can be assigned geometries. Because historical versions of CPDB only date back to 2017, the backwards scope of this data product is limited to geometries from 2017 onwards. Similarly, because Checkbook NYC only includes historical liquidations from 2010 onwards, the backwards scope of this data product is limited to capital projects from 2010 onwards. 
+Currently, roughly 25% of capital projects in Checkbook NYC can be assigned geometries. Because historical versions of CPDB only date back to 2017, the backwards scope of this data product is limited to geometries from 2017 onwards. Similarly, because Checkbook NYC only includes historical liquidations from 2010 onwards, the backwards scope of this data product is limited to capital projects from 2010 onwards.
 
 > 🚧 This data product is a work-in-progress. The outputs of this data product should not be cited as a definitive source of information until enhancements are complete.
 
@@ -54,8 +54,9 @@ Currently, roughly 25% of capital projects in Checkbook NYC can be assigned geom
 
     > 🚧 This is a work-in-progress and doesn't build the data product yet
 
-## Completed: 
-- YAML file to upload Checkbook NYC input data to `edm-recipes` Digital Ocean 
+## Completed
+
+- YAML file to upload Checkbook NYC input data to `edm-recipes` Digital Ocean
 - write empty(ish) bash/python scripts for `db-checkbook` product
 - YAML file to upload accepted CPDB geometries (2017-2022) and executive CPDB geometry (2023) to `edm-recipes` on Digital
 - `build_scripts/dataloading.py` correctly pulls down CPDB and Checkbook input data from DO
@@ -64,16 +65,16 @@ Currently, roughly 25% of capital projects in Checkbook NYC can be assigned geom
 - `build_scripts/summarization.py` provides relevant summary statistics about the output dataset
 - `test/test_build_output.py` is a unit test suite that uses pytest to validate outputs of build
 
-
-## In progress: 
+## In progress
 
 - exploring improving geospatial information by layering in parks properties dataset
 - working on adding a page for db-checkbook to the QAQC streamlit app
 
-
 ## Todo
+
 - [ ] make a data product-level requirements doc if needed, and update top-level requirements doc (requirements.in) in monorepo with python modules that are generally applicable to the team's work
 
 ## Eventually todo
+
 - [ ] add recipe for updating Checkbook NYC data from website
 - [ ] add recipe for automatically updating CPDB geometries

--- a/products/colp/README.md
+++ b/products/colp/README.md
@@ -1,12 +1,13 @@
-## City Owned and Leased Properties Database
+# City Owned and Leased Properties Database
 
 Various city authorities own or lease a large inventory of properties. This repo contains code to create a database of all city owned and leased properties, as required under Section 204 of the City Charter. The database contains information about each property's use, owning/leasing agency, location, and tenent agreements. This repo is a refactoring of the dataset found on [Bytes of the Big Apple](https://www1.nyc.gov/site/planning/about/publications/colp.page), and is currently in development.
 
 The input data for COLP is the Integrated Property Information System (IPIS), a real estate database maintained by the Department of Citywide Administrative Services (DCAS).
 
-### Links
+## Links
+
 [COLP on Open Data](https://data.cityofnewyork.us/d/fn4k-qyk2)
 [COLP on Bytes](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-colp.page)
-[`/resources`](https://github.com/NYCPlanning/data-engineering/tree/main/products/colp/resources) - Look-up tables for agency abbreviations and use types 
+[`/resources`](https://github.com/NYCPlanning/data-engineering/tree/main/products/colp/resources) - Look-up tables for agency abbreviations and use types
 
 For more in-depth information on COLP, check out its [wiki page](https://github.com/NYCPlanning/data-engineering/wiki/Product:-COLP)

--- a/products/developments/README.md
+++ b/products/developments/README.md
@@ -7,14 +7,17 @@ Processing DOB Job Application and Certificate of Occupancy data to identify job
 1. Create `.env` file and set environmental variables: `RECIPE_ENGINE`, `BUILD_ENGINE`, `EDM_DATA`
 
 2. Start postgis docker container for local database:
+
 ```bash
 docker run --name <custom_container_name> -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgis/postgis
 ```
 
 3. Check connection (e.g. via database app like Postico)
+
 > 💡 Note: If failing to connect on mac, try `brew services stop postgresql`
 
 4. Run scripts:
+
 ```bash
 ./bash/01_dataloading.sh
 ...
@@ -24,21 +27,21 @@ docker run --name <custom_container_name> -e POSTGRES_PASSWORD=postgres -p 5432:
 
 > Note that these files are not official releases, they are provided for QAQC purposes only, for official releases, please checkout [Bytes of the Big Apple](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-housing-database.page#housingdevelopmentproject)
 
-#### Main Tables
+### Main Tables
 
   | Devdb | HousingDB
 -- | -- | --
 CSV | [devdb.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/devdb.csv) | [housing.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/housing.csv)
 Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/devdb.shp.zip) | [housing.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/housing.shp.zip)
 
-#### Aggregation Tables 2020 Geographies
+### Aggregation Tables 2020 Geographies
 
 [block](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_block_2020.csv) |
 [tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_tract_2020.csv) |
 [NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_nta_2020.csv) |
 [CDTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_cdta_2020.csv)
 
-#### Aggregation Tables 2010 Geographies
+### Aggregation Tables 2010 Geographies
 
 [block](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_block_2010.csv) |
 [tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_tract_2010.csv) |
@@ -46,7 +49,7 @@ Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/d
 [councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_councildst_2010.csv) |
 [NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/aggregate_nta_2010.csv)
 
-#### All files [bundle.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/output.zip)
+### All files [bundle.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/output.zip)
 
 ## Published Versions
 
@@ -60,13 +63,13 @@ Shapefile  |  [dcp_housing.shp.zip](https://nyc3.digitaloceanspaces.com/edm-reci
   
 </details>
 
-# Data update details
+## Data update details
 
-## Update code
+### Update code
 
 - [ ] Add most recent full/half year to aggregate tables
 
-## Update source data
+### Update source data
 
 - [ ] Update version.env to:
 
@@ -76,6 +79,7 @@ CAPTURE_DATE_PREV= #Reference date for the DOB records (i.e. 22Q4 is a snapshot 
 ```
 
 - [ ] Update recipe.yml:
+
 ```yml
 env:
   GEOSUPPORT_VERSION: 23d
@@ -85,18 +89,20 @@ env:
 ### Make sure the following are up-to-date in Digital Ocean
 
 #### City Administrative Boundaries
+
 - [ ] `dcp_cdboundaries`  
 - [ ] `dcp_cb2010`  
-- [ ] `dcp_ct2010` 
-- [ ] `dcp_cb2020` 
-- [ ] `dcp_ct2020` 
-- [ ] `dcp_school_districts` 
+- [ ] `dcp_ct2010`
+- [ ] `dcp_cb2020`
+- [ ] `dcp_ct2020`
+- [ ] `dcp_school_districts`
 - [ ] `dcp_boroboundaries_wi`
-- [ ] `dcp_councildistricts` 
-- [ ] `dcp_firecompanies` 
-- [ ] `dcp_policeprecincts` 
-- [ ] `doitt_zipcodeboundaries` 
+- [ ] `dcp_councildistricts`
+- [ ] `dcp_firecompanies`
+- [ ] `dcp_policeprecincts`
+- [ ] `doitt_zipcodeboundaries`
 - [ ] `dof_shoreline`
+
 #### General
 
 - [ ] `dcp_mappluto_wi`
@@ -110,10 +116,12 @@ env:
 - [ ] `doe_mszones` -> same as above
 
 #### "Datasync" action
+
 [Run Data Sync action](https://github.com/NYCPlanning/data-engineering/actions/workflows/developments_datasync.yml) to update these. It runs weekly, so it's enough to see that the latest ran successfully
+
 - [ ] `hpd_hny_units_by_building`
-- [ ] `hny_geocode_results` 
-- [ ]  `dob_permitissuance` 
+- [ ] `hny_geocode_results`
+- [ ]  `dob_permitissuance`
 - [ ]  `dob_permitissuance`
 
 #### Other DOB data

--- a/products/facilities/README.md
+++ b/products/facilities/README.md
@@ -14,7 +14,7 @@ While each source agency classifies its facilities according to their own naming
 
 Within each of these domains, each record is further categorized into a set of facility groups, subgroups, and types that are intended to make the data easy to navigate and more useful for specific planning purposes. Facility types and names appear as they do in source datasets, wherever possible. A full listing of the facility categories is provided in the data dictionary.
 
-### Important files
+## Important files
 
  ```bash
 facilities/
@@ -41,7 +41,7 @@ Additionally:
 
 [`Github workflow`](https://github.com/NYCPlanning/data-engineering/blob/main/.github/workflows/facilities_build.yml) - config file used to build Facilities via Github Actions
 
-### Links
+## Links
 
 [FacDB on Bytes](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-selfac.page)  
 

--- a/products/factfinder/README.md
+++ b/products/factfinder/README.md
@@ -1,10 +1,13 @@
 # db-factfinder
+
 [![PyPI version](https://badge.fury.io/py/pff-factfinder.svg)](https://badge.fury.io/py/pff-factfinder)
 
 data ETL for population fact finder (decennial + acs)
 
-# Instructions
+## Instructions
+
 1. initialize
+
 ```python
 from factfinder.calculate import Calculate
 
@@ -15,7 +18,9 @@ calculate = Calculate(
     geography='2010_to_2020'
 )
 ```
+
 > or for decennial calculations:
+
 ```python
 
 calculate = Calculate(
@@ -25,13 +30,17 @@ calculate = Calculate(
     geography='2010_to_2020'
 )
 ```
+
 2. Calculate
+
 > Calling `calculate`
->    1. Downloads necessary census variables,
->    2. Aggregates using appropriate technique (both vertically and horizontally)
->    3. Calculates c, e, m, p, z fields
->    4. Rounds calculated values based on standards in the metadata
->    5. Cleans edge-cases of 0 and null values
+>
+> 1. Downloads necessary census variables,
+> 2. Aggregates using appropriate technique (both vertically and horizontally)
+> 3. Calculates c, e, m, p, z fields
+> 4. Rounds calculated values based on standards in the metadata
+> 5. Cleans edge-cases of 0 and null values
+>
 ```python
 df = calculate('pop', 'tract')
 df = calculate('pop', 'borough')

--- a/products/knownprojects/README.md
+++ b/products/knownprojects/README.md
@@ -1,6 +1,6 @@
 # Known Projects Database (KPDB)
 
-This repo contains code for creating the Known Projects Database (KPDB). The build process has multiple automated phases, separated by manual review. 
+This repo contains code for creating the Known Projects Database (KPDB). The build process has multiple automated phases, separated by manual review.
 
 For detailed information on the tables created throughout the build process, see the [build environment table descriptions](https://github.com/NYCPlanning/db-knownprojects/wiki/Build-environment-tables).
 
@@ -13,9 +13,9 @@ For detailed information on the tables created throughout the build process, see
 - Build database: `./02_build.sh`
 - Export: `./03_export.sh`
 
-# Update source data
+### Update source data
 
-## Partner Agency Data
+#### Partner Agency Data
 
 > It's important to note that when pulling the most recent data from `db-knownprojects-data` repo that the latest commit of that repo's copy in `db-knownprojects` should match that of the data repo. Without double-checking, you could be pulling stale data. List of source data that should be updated (via `db-knownprojects-data`) but double checked in this repo (after updating the submodule):
 
@@ -23,9 +23,9 @@ For detailed information on the tables created throughout the build process, see
 - [ ] `EDC projects for DCP housing projections` - `edc_projects`
 - [ ] `EDC Shapefile` - `edc_dcp_inputs`
 - [ ] `Neighborhood Study Commitments` - `dcp_n_study`
-- [ ] `Future Neighborhood Rezonings` - `dcp_n_study_future` 
+- [ ] `Future Neighborhood Rezonings` - `dcp_n_study_future`
 - [ ] `Past Neighborhood Rezonings` - `dcp_n_study_projected`
-- [ ] `HPD Requests for Proposals (RFPs)` - `hpd_rfp` 
+- [ ] `HPD Requests for Proposals (RFPs)` - `hpd_rfp`
 - [ ] `HPD Projected Closing` - `hpd_pc`
 - [ ] `DCP Planner Added Projects` - `dcp_planneradded`
 

--- a/products/pluto/README.md
+++ b/products/pluto/README.md
@@ -1,8 +1,9 @@
-## PLUTO
+# PLUTO
 
 The Primary Land Use Tax Lot Output (PLUTO™) contains extensive land use and geographic data at the tax lot level. PLUTO contain over seventy data fields derived from data files maintained by the Department of City Planning (DCP), Department of Finance (DOF), Department of Citywide Administrative Services (DCAS), and Landmarks Preservation Commission (LPC). DCP has created additional fields based on data obtained from one or more of the major data sources
 
-### Overall file structure
+## Overall file structure
+
 ```bash
 pluto
 ├── README.md # this file
@@ -20,7 +21,8 @@ pluto
 ├── schemas
 ```
 
-### Important files
+## Important files
+
 [metadata](https://github.com/NYCPlanning/product-metadata/blob/main/products/pluto/pluto/metadata.yml)
 [recipe](https://github.com/NYCPlanning/data-engineering/blob/main/products/pluto/recipe.yml)
 [recipe-minor](https://github.com/NYCPlanning/data-engineering/blob/main/products/pluto/recipe-minor.yml) - holds most source data versions constant from last published build
@@ -29,7 +31,8 @@ pluto
 [Github workflow - PTS input data](https://github.com/NYCPlanning/data-engineering/blob/main/.github/workflows/pluto_input_cama.yml) - config file used to ingest CAMA via data library. See template in `pluto_build/templates` folder as well.
 [Github workflow - PTS input data](https://github.com/NYCPlanning/data-engineering/blob/main/.github/workflows/pluto_input_numbldgs.yml) - config file used to ingest numbldgs data via data library. See template in `pluto_build/templates` folder as well.
 
-### Links
+## Links
+
 [PLUTO on Bytes](https://home.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page)
 [PLUTO on OpenData](https://data.cityofnewyork.us/City-Government/Primary-Land-Use-Tax-Lot-Output-PLUTO-/64uk-42ks/about_data)
 

--- a/products/zoningtaxlots/README.md
+++ b/products/zoningtaxlots/README.md
@@ -9,8 +9,7 @@ commercial overlays, a tax lot is assigned a value if 10% or more of the tax lot
 commercial overlay and/or 50% or more of the commercial overlay feature is within the tax lot.
 The zoning features are taken from the Department of City Planning NYC GIS Zoning Features.
 
-
-### Important files
+## Important files
 
 ```bash
 zoningtaxlots/


### PR DESCRIPTION
I've been using the VS code extension [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) with the following configuration in `settings.json`:

```json
"markdownlint.config": {
    
    "MD024": false,
    "MD033": false
},
```

this ignores two rules that we're likely to continue breaking:
- [MD024](https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md024.md) no-duplicate-heading - Multiple headings with the same content
- [MD033](https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md033.md) no-inline-html - Inline HTML