### PR TITLE
Ingest preprocessing "modes" for ACS inputs

### DIFF
--- a/.github/workflows/ingest_single.yml
+++ b/.github/workflows/ingest_single.yml
@@ -16,6 +16,9 @@ on:
       version:
         description: "The version of the dataset (i.e. 22v2, 21C) if needed (optional)"
         required: false
+      mode:
+        description: "Preprocessing 'mode', if applicable"
+        required: false
       dev_image: 
         description: "Use dev image specific to this branch? (If exists)"
         type: boolean
@@ -44,5 +47,11 @@ jobs:
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
 
       - name: Finish container setup ...
-        working-directory: ./
         run: ./bash/docker_container_setup.sh
+
+      - name: Archive dataset
+        env:
+          latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
+          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
+          mode: ${{ github.event.inputs.mode && format('--mode {0}', github.event.inputs.mode) || '' }}
+        run: python3 -m dcpy.cli lifecycle ingest ${{ inputs.dataset }} $latest $version $mode

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -38,7 +38,7 @@ def _archive_dataset(config: ingest.Config, file_path: Path, s3_path: Path):
         tmp_dir_path = Path(tmp_dir)
         shutil.copy(file_path, tmp_dir_path)
         with open(tmp_dir_path / "config.json", "w") as f:
-            f.write(json.dumps(config.model_dump(), indent=4))
+            f.write(json.dumps(config.model_dump(exclude_none=True), indent=4))
         s3.upload_folder(
             BUCKET,
             tmp_dir_path,

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -56,12 +56,20 @@ def archive_raw_dataset(config: ingest.Config, file_path: Path):
     _archive_dataset(config, file_path, config.raw_dataset_key.s3_path(RAW_FOLDER))
 
 
-def archive_dataset(config: ingest.Config, file_path: Path):
+def archive_dataset(config: ingest.Config, file_path: Path, latest: bool = False):
     """
     Given a config and a path to a processed parquet file, archive it in edm-recipes
     Unique identifier of a raw dataset is its name and its version
     """
-    _archive_dataset(config, file_path, config.dataset_key.s3_path("ingest_datasets"))
+    s3_path = config.dataset_key.s3_path("ingest_datasets")
+    _archive_dataset(config, file_path, s3_path)
+    if latest:
+        s3.copy_folder(
+            BUCKET,
+            f"{s3_path}/",
+            f"ingest_datasets/{config.name}/latest/",
+            acl=config.acl,
+        )
 
 
 def get_config(name: str, version="latest") -> library.Config | ingest.Config:

--- a/dcpy/lifecycle/ingest/configure.py
+++ b/dcpy/lifecycle/ingest/configure.py
@@ -137,6 +137,7 @@ def get_config(
         target_crs=template.target_crs,
         source=template.source,
         file_format=template.file_format,
+        processing_mode=mode,
         processing_steps=processing_steps,
         run_details=run_details,
     )

--- a/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_demographic.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_demographic.yml
@@ -1,0 +1,52 @@
+name: dcp_pop_acs2010_demographic
+acl: public-read
+source:
+  type: local_file
+  path: .library/upload/CCD2023_ACS0610Data_for1822Update.xlsx
+file_format:
+  type: xlsx
+  sheet_name: CCD2023_Dem0610
+  dtype:
+    GeoID: str
+processing_steps:
+- name: clean_column_names
+  args:
+    lower: true
+- name: append_prev
+  mode: append
+- name: upsert_column_of_previous_version
+  args:
+    key: [geotype, geoid]
+    insert_behavior: error
+    missing_key_behavior: error
+  mode: update_column
+
+library_dataset:
+  name: dcp_pop_acs2010_demographic
+  version: ""
+  acl: public-read
+  source:
+    script: 
+      name: excel
+      path: https://nyc3.digitaloceanspaces.com/edm-recipes/inbox/dcp_pop_acs2010/{{ version }}/dcp_pop_acs.xlsx
+      sheet_name: Dem0610
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    geometry:
+      SRS: null
+      type: NONE
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## 2010 ACS file from Population
+      This file is produced internally by the Population division. 2010 version is used as a reference dataset
+      for the latest ACS data, and occasionally is modified so these different subsections are archived as their
+      own recipe datasets so that they can easily be updated individually
+      
+    url: null
+    dependents: []

--- a/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_economic.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_economic.yml
@@ -1,0 +1,52 @@
+name: dcp_pop_acs2010_economic
+acl: public-read
+source:
+  type: local_file
+  path: .library/upload/CCD2023_ACS0610Data_for1822Update.xlsx
+file_format:
+  type: xlsx
+  sheet_name: CCD2023_Econ0610_NotInflated
+  dtype:
+    GeoID: str
+processing_steps:
+- name: clean_column_names
+  args:
+    lower: true
+- name: append_prev
+  mode: append
+- name: upsert_column_of_previous_version
+  args:
+    key: [geotype, geoid]
+    insert_behavior: error
+    missing_key_behavior: error
+  mode: update_column
+
+library_dataset:
+  name: dcp_pop_acs2010_economic
+  version: ""
+  acl: public-read
+  source:
+    script: 
+      name: excel
+      path: https://nyc3.digitaloceanspaces.com/edm-recipes/inbox/dcp_pop_acs2010/{{ version }}/dcp_pop_acs.xlsx
+      sheet_name: Econ0610
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    geometry:
+      SRS: null
+      type: NONE
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## 2010 ACS file from Population
+      This file is produced internally by the Population division. 2010 version is used as a reference dataset
+      for the latest ACS data, and occasionally is modified so these different subsections are archived as their
+      own recipe datasets so that they can easily be updated individually
+      
+    url: null
+    dependents: []

--- a/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_housing.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_housing.yml
@@ -1,0 +1,53 @@
+name: dcp_pop_acs2010_housing
+acl: public-read
+source:
+  type: s3
+  bucket: edm-recipes
+  key: inbox/dcp/dcp_pop_acs2010_housing/20240624/CorrectedVarsOnly_Housing0610_2020Geog.xlsx
+file_format:
+  type: xlsx
+  sheet_name: Housing Vars Corrected
+  dtype:
+    GeoID: str
+processing_steps:
+- name: clean_column_names
+  args:
+    lower: true
+- name: append_prev
+  mode: append
+- name: upsert_column_of_previous_version
+  args:
+    key: [geotype, geoid]
+    insert_behavior: error
+    missing_key_behavior: error
+  mode: update_column
+
+library_dataset:
+  name: dcp_pop_acs2010_housing
+  version: ""
+  acl: public-read
+  source:
+    script: 
+      name: excel
+      path: https://nyc3.digitaloceanspaces.com/edm-recipes/inbox/dcp_pop_acs2010/{{ version }}/dcp_pop_acs.xlsx
+      sheet_name: Housing0610
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    geometry:
+      SRS: null
+      type: NONE
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## 2010 ACS file from Population
+      This file is produced internally by the Population division. 2010 version is used as a reference dataset
+      for the latest ACS data, and occasionally is modified so these different subsections are archived as their
+      own recipe datasets so that they can easily be updated individually
+      
+    url: null
+    dependents: []

--- a/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_social.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_pop_acs2010_social.yml
@@ -1,0 +1,56 @@
+name: dcp_pop_acs2010_social
+acl: public-read
+source:
+  type: local_file
+  path: .library/upload/CCD2023_ACS0610Data_for1822Update.xlsx
+file_format:
+  type: xlsx
+  sheet_name: CCD2023_Social0610
+  dtype:
+    GeoID: str
+processing_steps:
+- name: clean_column_names
+  args:
+    lower: true
+- name: append_prev
+  mode: append
+- name: upsert_column_of_previous_version
+  args:
+    key: [geotype, geoid]
+    insert_behavior: error
+    missing_key_behavior: error
+  mode: update_column
+
+library_dataset:
+  name: dcp_pop_acs2010_social
+  version: ""
+  acl: public-read
+  source:
+    script: 
+      name: excel
+      path: https://nyc3.digitaloceanspaces.com/edm-recipes/inbox/dcp_pop_acs2010_social/{{ version }}/ACS0610SocialData_for1822Update.xlsx
+      sheet_name: Social0610_ModFor1822Update
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    geometry:
+      SRS: null
+      type: NONE
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## 2010 ACS file from Population
+      This file is produced internally by the Population division. 2010 version is used as a reference dataset
+      for the latest ACS data, and occasionally is modified so these different subsections are archived as their
+      own recipe datasets so that they can easily be updated individually
+
+      In 2024, this file had to be loaded "as_is". This doesn't load the xlsx from pop due to the way "scriptors" currently work,
+      but rather the csv output by the "scriptor". This was needed because the input sheet has over 2000 columns, which seems
+      to be a limit for gdal.
+      
+    url: null
+    dependents: []

--- a/dcpy/models/file.py
+++ b/dcpy/models/file.py
@@ -32,7 +32,7 @@ class Csv(BaseModel, extra="forbid"):
     encoding: str = "utf-8"
     delimiter: str | None = None
     column_names: list[str] | None = None
-    dtype: str | None = None
+    dtype: str | dict | None = None
     geometry: Geometry | None = None
 
 
@@ -40,6 +40,7 @@ class Xlsx(BaseModel, extra="forbid"):
     type: Literal["xlsx"]
     unzipped_filename: str | None = None
     sheet_name: str
+    dtype: str | dict | None = None
     geometry: Geometry | None = None
 
 

--- a/dcpy/models/lifecycle/ingest.py
+++ b/dcpy/models/lifecycle/ingest.py
@@ -85,6 +85,7 @@ class Config(BaseModel, extra="forbid", arbitrary_types_allowed=True):
 
     source: Source
     file_format: file.Format
+    processing_mode: str | None = None
     processing_steps: list[PreprocessingStep] = []
 
     run_details: RunDetails

--- a/dcpy/models/lifecycle/ingest.py
+++ b/dcpy/models/lifecycle/ingest.py
@@ -42,9 +42,11 @@ Source: TypeAlias = (
 )
 
 
-class FunctionCall(BaseModel):
+class PreprocessingStep(BaseModel):
     name: str
     args: dict[str, Any] = {}
+    # mode allows for certain preprocessing steps only to be run if specified at runtime
+    mode: str | None = None
 
 
 class Template(BaseModel, extra="forbid", arbitrary_types_allowed=True):
@@ -61,18 +63,17 @@ class Template(BaseModel, extra="forbid", arbitrary_types_allowed=True):
     source: Source
     file_format: file.Format
 
-    processing_steps: list[FunctionCall] = []
+    processing_steps: list[PreprocessingStep] = []
 
     ## this is the original library template, included just for reference while we build out our new templates
     library_dataset: library.DatasetDefinition | None = None
 
 
-class Config(
-    BaseModel, extra="ignore", arbitrary_types_allowed=True
-):  # TODO switch extra back to "forbid" when library_dataset is dropped from template
-    """New object corresponding to computed template in dcpy.lifecycle.extract
-    Meant to be stored in config.json in edm-recipes/raw_datasets and edm-recipes/datasets
-    At some point backwards compatability with LibraryConfig should be considered"""
+class Config(BaseModel, extra="forbid", arbitrary_types_allowed=True):
+    """
+    Computed Template of ingest dataset
+    Stored in config.json in edm-recipes/raw_datasets and edm-recipes/datasets
+    """
 
     name: str
     version: str
@@ -84,7 +85,7 @@ class Config(
 
     source: Source
     file_format: file.Format
-    processing_steps: list[FunctionCall] = []
+    processing_steps: list[PreprocessingStep] = []
 
     run_details: RunDetails
 

--- a/dcpy/test/lifecycle/ingest/test_configure.py
+++ b/dcpy/test/lifecycle/ingest/test_configure.py
@@ -109,6 +109,19 @@ def test_get_config():
     """
     Tests that configure.get_config runs without exception
     Given other unit tests, mainly confirms that template is correctly converted to config pydantic class
+    Tests "mode" functionality
+    Should probably be mocked but this is straightforward for now
     """
-    configure.get_config("dcp_atomicpolygons", version="test")
-    assert True
+    standard = configure.get_config("dcp_pop_acs2010_demographic", version="test")
+    assert standard.processing_steps
+    assert "append_prev" not in [s.name for s in standard.processing_steps]
+
+    append = configure.get_config(
+        "dcp_pop_acs2010_demographic", version="test", mode="append"
+    )
+    assert "append_prev" in [s.name for s in append.processing_steps]
+
+    with pytest.raises(ValueError):
+        configure.get_config(
+            "dcp_pop_acs2010_demographic", version="test", mode="fake_mode"
+        )

--- a/dcpy/test/lifecycle/ingest/test_transform.py
+++ b/dcpy/test/lifecycle/ingest/test_transform.py
@@ -8,7 +8,7 @@ from pydantic import TypeAdapter, BaseModel
 from pathlib import Path
 
 from dcpy.models.file import Format
-from dcpy.models.lifecycle.ingest import FunctionCall
+from dcpy.models.lifecycle.ingest import PreprocessingStep
 from dcpy.lifecycle.ingest import transform
 
 from dcpy.utils import data
@@ -97,8 +97,8 @@ def test_validate_processing_steps():
     """
 
     steps = [
-        FunctionCall(name="no_arg_function"),
-        FunctionCall(name="drop_columns", args={"columns": ["col1", "col2"]}),
+        PreprocessingStep(name="no_arg_function"),
+        PreprocessingStep(name="drop_columns", args={"columns": ["col1", "col2"]}),
     ]
     compiled_steps = transform.validate_processing_steps("test", steps)
     assert len(compiled_steps) == 2
@@ -111,11 +111,11 @@ def test_validate_processing_steps():
     # test invalid steps
     error_steps = [
         # Non-existent function
-        FunctionCall(name="fake_function_name"),
+        PreprocessingStep(name="fake_function_name"),
         # Missing arg
-        FunctionCall(name="drop_columns", args={}),
+        PreprocessingStep(name="drop_columns", args={}),
         # Unexpected arg
-        FunctionCall(name="drop_columns", args={"columns": [0], "fake_arg": 0}),
+        PreprocessingStep(name="drop_columns", args={"columns": [0], "fake_arg": 0}),
     ]
     # validate each separately for ease of making sure that each throws an error
     for step in error_steps:
@@ -153,7 +153,7 @@ def test_call_pd_series_func():
     )
     manual_1 = pd.DataFrame({"column_a": ["VALUE 1", "VALUE 2"], "column_b": [1, 2]})
 
-    call_1 = FunctionCall(
+    call_1 = PreprocessingStep(
         name=func_name,
         args={
             "column_name": "column_a",
@@ -175,7 +175,7 @@ def test_call_pd_series_func():
     )
     manual_2 = pd.DataFrame({"column_a": ["other value 1", np.nan], "column_b": [1, 2]})
 
-    call_2 = FunctionCall(
+    call_2 = PreprocessingStep(
         name=func_name,
         args={
             "column_name": "column_a",

--- a/dcpy/test/utils/test_data.py
+++ b/dcpy/test/utils/test_data.py
@@ -72,3 +72,113 @@ def test_serialize_nested_objects():
         for value in serialized_df[col]:
             assert isinstance(value, str)
             assert value.startswith("{")
+
+
+def test_upsert_df_columns():
+    on = ["key1", "key2"]
+    df = lambda: pd.DataFrame(
+        {
+            "key1": ["foo", "bar", "bar"],
+            "key2": [1, 1, 2],
+            "other": [True, False, True],
+            "value": [1, 2, 3],
+        }
+    )
+    df_upsert = lambda: pd.DataFrame(
+        {
+            "key1": ["bar", "foo", "bar"],
+            "key2": [2, 1, 1],
+            "value": [6, 4, 5],
+            "value2": [7, 8, 9],
+        }
+    )
+
+    with pytest.raises(ValueError):
+        data.upsert_df_columns(df(), df_upsert(), on=on, insert_behavior="error")
+
+    updated = data.upsert_df_columns(df(), df_upsert(), on=on, insert_behavior="ignore")
+    assert updated.equals(
+        pd.DataFrame(
+            {
+                "key1": ["foo", "bar", "bar"],
+                "key2": [1, 1, 2],
+                "other": [True, False, True],
+                "value": [4, 5, 6],
+            }
+        )
+    )
+
+    inserted = data.upsert_df_columns(df(), df_upsert(), on=on)
+    assert inserted.equals(
+        pd.DataFrame(
+            {
+                "key1": ["foo", "bar", "bar"],
+                "key2": [1, 1, 2],
+                "other": [True, False, True],
+                "value": [4, 5, 6],
+                "value2": [8, 9, 7],
+            }
+        )
+    )
+
+    df_missing_key_column = pd.DataFrame({"key1": ["bar", "foo"], "value": [6, 5]})
+    with pytest.raises(ValueError):
+        data.upsert_df_columns(df(), df_missing_key_column, on=on)
+
+    df_multiple = pd.DataFrame(
+        {
+            "key1": ["bar", "foo", "bar", "foo"],
+            "key2": [2, 1, 1, 1],
+            "value": [6, 4, 5, 3],
+            "value2": [7, 8, 9, 10],
+        }
+    )
+    with pytest.raises(ValueError):
+        data.upsert_df_columns(df(), df_multiple, on=on)
+    upserted_multiple = data.upsert_df_columns(
+        df(), df_multiple, on=on, allow_duplicate_keys=True
+    )
+    assert upserted_multiple.equals(
+        pd.DataFrame(
+            {
+                "key1": ["foo", "foo", "bar", "bar"],
+                "key2": [1, 1, 1, 2],
+                "other": [True, True, False, True],
+                "value": [4, 3, 5, 6],
+                "value2": [8, 10, 9, 7],
+            }
+        )
+    )
+
+    df_missing_key = lambda: pd.DataFrame(
+        {"key1": ["bar", "foo"], "key2": [2, 1], "value": [6, 4]}
+    )
+    with pytest.raises(ValueError):
+        data.upsert_df_columns(df(), df_missing_key(), on=on)
+    updated_with_missing = data.upsert_df_columns(
+        df(), df_missing_key(), on=on, missing_key_behavior="null"
+    )
+    assert updated_with_missing.equals(
+        pd.DataFrame(
+            {
+                "key1": ["foo", "bar", "bar"],
+                "key2": [1, 1, 2],
+                "other": [True, False, True],
+                "value": [4, None, 6],
+            }
+        )
+    )
+
+    updated_with_missing_coalesced = data.upsert_df_columns(
+        df(), df_missing_key(), on=on, missing_key_behavior="coalesce"
+    )
+    assert updated_with_missing_coalesced.equals(
+        pd.DataFrame(
+            {
+                "key1": ["foo", "bar", "bar"],
+                "key2": [1, 1, 2],
+                "other": [True, False, True],
+                "value": [4, 2, 6],
+            }
+        )
+    )

--- a/dcpy/test/utils/test_data.py
+++ b/dcpy/test/utils/test_data.py
@@ -94,9 +94,11 @@ def test_upsert_df_columns():
     )
 
     with pytest.raises(ValueError):
-        data.upsert_df_columns(df(), df_upsert(), on=on, insert_behavior="error")
+        data.upsert_df_columns(df(), df_upsert(), key=on, insert_behavior="error")
 
-    updated = data.upsert_df_columns(df(), df_upsert(), on=on, insert_behavior="ignore")
+    updated = data.upsert_df_columns(
+        df(), df_upsert(), key=on, insert_behavior="ignore"
+    )
     assert updated.equals(
         pd.DataFrame(
             {
@@ -108,7 +110,7 @@ def test_upsert_df_columns():
         )
     )
 
-    inserted = data.upsert_df_columns(df(), df_upsert(), on=on)
+    inserted = data.upsert_df_columns(df(), df_upsert(), key=on)
     assert inserted.equals(
         pd.DataFrame(
             {
@@ -123,7 +125,7 @@ def test_upsert_df_columns():
 
     df_missing_key_column = pd.DataFrame({"key1": ["bar", "foo"], "value": [6, 5]})
     with pytest.raises(ValueError):
-        data.upsert_df_columns(df(), df_missing_key_column, on=on)
+        data.upsert_df_columns(df(), df_missing_key_column, key=on)
 
     df_multiple = pd.DataFrame(
         {
@@ -134,9 +136,9 @@ def test_upsert_df_columns():
         }
     )
     with pytest.raises(ValueError):
-        data.upsert_df_columns(df(), df_multiple, on=on)
+        data.upsert_df_columns(df(), df_multiple, key=on)
     upserted_multiple = data.upsert_df_columns(
-        df(), df_multiple, on=on, allow_duplicate_keys=True
+        df(), df_multiple, key=on, allow_duplicate_keys=True
     )
     assert upserted_multiple.equals(
         pd.DataFrame(
@@ -154,9 +156,9 @@ def test_upsert_df_columns():
         {"key1": ["bar", "foo"], "key2": [2, 1], "value": [6, 4]}
     )
     with pytest.raises(ValueError):
-        data.upsert_df_columns(df(), df_missing_key(), on=on)
+        data.upsert_df_columns(df(), df_missing_key(), key=on)
     updated_with_missing = data.upsert_df_columns(
-        df(), df_missing_key(), on=on, missing_key_behavior="null"
+        df(), df_missing_key(), key=on, missing_key_behavior="null"
     )
     assert updated_with_missing.equals(
         pd.DataFrame(
@@ -170,7 +172,7 @@ def test_upsert_df_columns():
     )
 
     updated_with_missing_coalesced = data.upsert_df_columns(
-        df(), df_missing_key(), on=on, missing_key_behavior="coalesce"
+        df(), df_missing_key(), key=on, missing_key_behavior="coalesce"
     )
     assert updated_with_missing_coalesced.equals(
         pd.DataFrame(

--- a/dcpy/utils/data.py
+++ b/dcpy/utils/data.py
@@ -236,7 +236,7 @@ def upsert_df_columns(
     if (missing_key_behavior == "error") and any(joined["_merge"] == "left_only"):
         raise ValueError("Not all keys in df found in upsert_df")
 
-    for column in upsert_df.columns:
+    for column in upsert_columns:
         col_type = joined[column].dtype
         upsert_column = column + suffix if column in cols else column
         if missing_key_behavior == "coalesce":

--- a/dcpy/utils/data.py
+++ b/dcpy/utils/data.py
@@ -223,14 +223,10 @@ def upsert_df_columns(
             f"Unexpected columns found in upsert_df: {upsert_cols.difference(cols)}"
         )
     if insert_behavior == "ignore":
-        upsert_df = upsert_df[
-            [c for c in upsert_df.columns if c in key or c in df.columns]
-        ]
+        upsert_df = upsert_df[[c for c in upsert_df.columns if c in cols]]
 
     upsert_columns = [c for c in upsert_df.columns if c not in key]
-    output_columns = list(df.columns) + [
-        c for c in upsert_columns if c not in df.columns
-    ]
+    output_columns = list(df.columns) + [c for c in upsert_columns if c not in cols]
 
     suffix = "__upsert"
     joined = df.merge(
@@ -240,9 +236,9 @@ def upsert_df_columns(
     if (missing_key_behavior == "error") and any(joined["_merge"] == "left_only"):
         raise ValueError("Not all keys in df found in upsert_df")
 
-    for column in upsert_columns:
+    for column in upsert_df.columns:
         col_type = joined[column].dtype
-        upsert_column = column + suffix if column in df.columns else column
+        upsert_column = column + suffix if column in cols else column
         if missing_key_behavior == "coalesce":
             joined[column] = joined.apply(
                 lambda row: (

--- a/dcpy/utils/data.py
+++ b/dcpy/utils/data.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import json
 import pandas as pd
 import geopandas as gpd
@@ -9,6 +10,21 @@ from dcpy.utils.logging import logger
 from dcpy.utils.geospatial.transform import df_to_gdf
 
 import zipfile
+
+
+def _get_dtype(dtype: str | dict | None) -> str | dict | defaultdict | None:
+    """
+    A helper function to have a way of specifying both kwarg and default dtypes for a file to be read
+    """
+    match dtype:
+        case dict():
+            if "__default__" in dtype:
+                default = dtype.pop("__default__")
+                return defaultdict(lambda: default, **dtype)
+            else:
+                return dtype
+        case _:
+            return dtype
 
 
 def read_data_to_df(
@@ -82,7 +98,7 @@ def read_data_to_df(
                 encoding=data_format.encoding,
                 delimiter=data_format.delimiter,
                 names=data_format.column_names,
-                dtype=data_format.dtype,
+                dtype=_get_dtype(data_format.dtype),
             )
             gdf = (
                 df if not data_format.geometry else df_to_gdf(df, data_format.geometry)

--- a/docker/build-base/requirements.txt
+++ b/docker/build-base/requirements.txt
@@ -18,6 +18,7 @@ PyYAML
 Requests
 retry
 Shapely
+socrata-py
 SQLAlchemy
 tqdm
 typer

--- a/docker/build-geosupport/requirements.txt
+++ b/docker/build-geosupport/requirements.txt
@@ -18,6 +18,7 @@ PyYAML
 Requests
 retry
 Shapely
+socrata-py
 SQLAlchemy
 tqdm
 typer

--- a/products/factfinder/acs.yml
+++ b/products/factfinder/acs.yml
@@ -10,7 +10,6 @@ inputs:
     - name: dcp_pop_acs2010_economic
     - name: dcp_pop_acs2010_housing
     - name: dcp_pop_acs2010_social
-      file_type: csv
     - name: dcp_pop_acs
       destination: file
       file_type: xlsx

--- a/products/factfinder/pipelines/acs_manual_update.py
+++ b/products/factfinder/pipelines/acs_manual_update.py
@@ -83,29 +83,13 @@ def process_2010_data(load_result: load.LoadResult):
         process_domain_data(df, domain, "2010")
 
 
-def process_2010_appendum_manual():
-    file_path = "dummy"
-    domains = {
-        "demographic": "CCD2023_Dem0610",
-        "economic": "CCD2023_Econ0610_NotInflated",
-        "housing": "CCD2023_Housing0610_NotInflated",
-        "social": "CCD2023_Social0610",
-    }
-    for domain in domains:
-        logging.logger.info(f"Processing ACS year 2010 2024 addendum domain {domain}")
-        df = pd.read_excel(file_path, sheet_name=domains[domain])
-        df = transform_dataframe(df)
-        df["domain"] = domain
-        df = rename_columns(df)
-        export_df(df, DATASET, "2010")
-
-
 def process_latest_data(file: Path, year: str):
     domain_sheets = sheet_names(year)
 
     for domain in DOMAINS:
         logging.logger.info(f"Processing ACS year {year} domain {domain}")
         df = pd.read_excel(file, sheet_name=domain_sheets[domain])
+        df = df[[c for c in df.columns if not c.endswith(".1")]]
         process_domain_data(df, domain, year)
 
 
@@ -113,7 +97,6 @@ def run(load_result: load.LoadResult, upload: bool = False):
     if OUTPUT_FOLDER.is_dir():
         shutil.rmtree(OUTPUT_FOLDER)
     process_2010_data(load_result)
-    process_2010_appendum_manual()
 
     latest = load_result.datasets["dcp_pop_acs"]
     assert isinstance(latest.destination, Path)

--- a/products/factfinder/pipelines/utils.py
+++ b/products/factfinder/pipelines/utils.py
@@ -142,6 +142,12 @@ def pivot_table_with_suffixes(
         raise Exception(f"Some field names missing certain suffixes: {field_names}")
 
     expected_columns = set(pivot_columns + suffix_columns)
+    for c in df.columns:
+        if c not in expected_columns:
+            print(f"unexpected: {c}")
+    for c in expected_columns:
+        if c not in df.columns:
+            print(f"missing: {c}")
     assert set(df.columns) == expected_columns
 
     output_df = pd.DataFrame()

--- a/products/factfinder/run.py
+++ b/products/factfinder/run.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import typer
 
-from dcpy.lifecycle.builds import load
+from dcpy.lifecycle.builds import load, plan
 from pipelines import acs_manual_update, decennial_manual_update
 
 app = typer.Typer(add_completion=False)
@@ -21,7 +21,8 @@ def _run(
         "acs",
         "decennial",
     ], "'acs' and 'decennial' only valid options for dataset."
-    load_result = load.load_source_data(Path(f"{dataset}.yml"), keep_files=True)
+    lockfile = plan.plan(Path(f"{dataset}.yml"))
+    load_result = load.load_source_data(lockfile, keep_files=True)
     match dataset:
         case "acs":
             acs_manual_update.run(load_result, upload)


### PR DESCRIPTION
Couple main things here

## data util to upsert columns in a df
I could imagine many cases where we want to upsert a column, with a variety of cases. This assumes that we want to upsert based on some key. So not just blindly `df["column"] = my_series_to_upsert` but rather taking in an "upsert_df" where we have keys, say `geotype` and `geoid` where we want to update values in our original df, so ensuring that geotype=CCD2023 and geoid=01 gets the right updated value as opposed to assuming order is consistent. I wanted this especially in cases where there's not a guarantee of the same number of rows.

There are a bunch of flags for this - how to handle "new" columns (i.e. only allow update rather than inserts as well), how to handle keys missing in the upsert df provided, etc. I think it's thoroughly tested

## "modes" for preprocessing in ingest
We have the case of PFF of having different types of dataset provided that necessitate different modes of updating. See #1016 for more context
- provide a brand new dataset (standard - no interaction with previous versions of dataset)
- provide additional rows (i.e. a new geotype - CCD2023 in this case, for 2010 acs data. In this case, we append to prev)
- provide updated columns (what the latest update is, hence the creation of the upsert util above)

To handle this, I've added a field to the processing step definitions in yml, they can have `mode` defined. Any steps without a `mode` are **always** run, while steps with `mode` defined are only run when the entire process is run with said `mode` (provided when running ingest from command line, option `-m` or `--mode`.

So for example, `python3 -m dcpy.cli lifecycle ingest dcp_pop_acs2010_social` will run ingest, looking for the dataset source as it usually does, and fairly naively process and dump it, without running any processing steps that have a `mode`. But running `python3 -m dcpy.cli lifecycle ingest dcp_pop_acs2010_social -m append` will instead append it to the previous, and running `python3 -m dcpy.cli lifecycle ingest dcp_pop_acs2010_social -m update_column` will run the step to update columns of the previous dataset

## Operational steps

Done as part of updating PFF with latest 2010 ACS data addendum

From my comp, I archived all 4 2010 acs datasets with mode `append` (which was previously being taken care of with that "manual" addendum logic in pff code) and then also ran housing with `update` to update the two problematic columns

[Passing ingest gha](https://github.com/NYCPlanning/data-engineering/actions/runs/10100406894)

[Passing acs build](https://github.com/NYCPlanning/data-engineering/actions/runs/10100183743)

I've also done some qa to ensure that only the desired changes occurred - read csvs into tables in duckdb, then looking at row counts as well as any missing combo of geoid and var
```python
con.sql("""
    select *
    from new_2 as new
    left join old 
        on new.labs_geotype = old.labs_geotype
        and new.labs_geoid = old.labs_geoid
        and new.pff_variable = old.pff_variable
    where new.labs_geotype is null
""")
```
and changes in values
```python
con.sql("""
    select new.labs_geotype, new.labs_geoid, old.m, new.m
    from new 
    left join old 
        on new.labs_geotype = old.labs_geotype
        and new.labs_geoid = old.labs_geoid
        and new.pff_variable = old.pff_variable
    where old.labs_geotype <> 'fb2000ltr'
    and old.m <> new.m
""")
```