### PR TITLE
fix: UP GH per-page for branches/pulls

### DIFF
--- a/dcpy/connectors/github.py
+++ b/dcpy/connectors/github.py
@@ -43,7 +43,7 @@ def get_default_branch(repo: str) -> str:
 
 
 def get_branches(repo: str, branches_blacklist: List[str] | None = None):
-    url = f"https://api.github.com/repos/nycplanning/{repo}/branches"
+    url = f"https://api.github.com/repos/nycplanning/{repo}/branches?per_page=100"
     response = requests.get(url).json()
     all_branches = [branch_info["name"] for branch_info in response]
     if branches_blacklist is None:
@@ -52,7 +52,9 @@ def get_branches(repo: str, branches_blacklist: List[str] | None = None):
 
 
 def get_pull_requests(repo: str) -> list[str]:
-    url = f"https://api.github.com/repos/nycplanning/{repo}/pulls?state=open"
+    url = (
+        f"https://api.github.com/repos/nycplanning/{repo}/pulls?state=open&per_page=100"
+    )
     response = requests.get(url).json()
     return [str(pr_info["number"]) for pr_info in response]
 


### PR DESCRIPTION
Fixes the failing github get-branches test. I don't think that realistically we should hit this limit, unless our team grows massively and our branch hygiene deteriorates. 