### PR TITLE
typo in open data weekly pull

### DIFF
--- a/.github/workflows/data_library_open_data.yml
+++ b/.github/workflows/data_library_open_data.yml
@@ -24,7 +24,7 @@ jobs:
         dataset:
           - doitt_buildingfootprints
           - doitt_buildingfootprints_historical
-          - dot_projects_intersectiosn
+          - dot_projects_intersections
           - dot_projects_streets
           - dpr_capitalprojects
           - dpr_greenthumb

--- a/.github/workflows/promote_to_draft.yml
+++ b/.github/workflows/promote_to_draft.yml
@@ -34,3 +34,12 @@ on:
         options:
           - public-read 
           - private
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: stub
+        run: echo "this job is a stub"


### PR DESCRIPTION
Resolves #1031 

Successful job run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/10133886543)

Also flushed out stub for failing action on push