### PR TITLE
improve reporting of `pytest` coverage

### DIFF
--- a/.github/workflows/data/pytest.yml
+++ b/.github/workflows/data/pytest.yml
@@ -1,5 +1,5 @@
 - name: dcpy
-  calls: ["dcpy/test -s --verbose --verbose --cov-config=pyproject.toml --cov=dcpy"]
+  calls: ["dcpy/test -s --verbose --verbose --cov-config=pyproject.toml --cov=dcpy --cov-report=xml"]
 - name: checkbook
   db: db-checkbook
   calls: ["./products/checkbook -s --verbose --verbose"]

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -167,6 +167,7 @@ jobs:
         export-env: true
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        CODECOV_TOKEN: "op://Data Engineering/Codecov/CODECOV_TOKEN"
         AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
         AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
         AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
@@ -188,3 +189,10 @@ jobs:
           IFS=$'\n' arr=( $(xargs -n1 <<<"$call") )
           python3 -m pytest ${arr[@]}
         done
+
+    - name: Upload dcpy test coverage to Codecov
+      if: ${{ matrix.name =='dcpy' }}
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -129,8 +129,10 @@ jobs:
         run: |
           echo "path filters with changed files: ${{ inputs.path_filter }}"
           if [[ -z "${{ inputs.path_filter }}" ]]; then
+            echo "Path filters weren't checked, running all tests"
             matrix=$(cat .github/workflows/data/pytest.yml | yq -ro json | jq -rc)
           elif [[ "[]" = "${{ inputs.path_filter }}" ]]; then
+            echo "No relevant files changed, not running any tests"
             matrix="[]"
           else
             filter=$(echo '${{ inputs.path_filter }}' | sed 's/[][]//g' | sed -r 's/([\w-]+)(,|$)/"\1"\2/g')

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Data Engineering Team ![CI](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml/badge.svg)
+# Data Engineering Team
+
+[![CI](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml/badge.svg)](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml)
 
 This is the primary repository for the Data Engineering team at the NYC Department of City Planning (DCP). It is used to build data products for internal and external use. Each product has it's own folder in `products/` where their respective code and READMEs can be found.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Engineering Team
 
-[![CI](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml/badge.svg)](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml)
+[![nightly qa](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml/badge.svg)](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml) [![dcpy test covereage](https://codecov.io/gh/NYCPlanning/data-engineering/graph/badge.svg)](https://codecov.io/gh/NYCPlanning/data-engineering)
 
 This is the primary repository for the Data Engineering team at the NYC Department of City Planning (DCP). It is used to build data products for internal and external use. Each product has it's own folder in `products/` where their respective code and READMEs can be found.
 


### PR DESCRIPTION
## changes

- upload `dcpy` test coverage report to DCP's Codecov account
  - only happens when `dcpy` tests are run
- updates badge in the README:
  - make Nightly QA badge link to the action runs
  - add badge for test coverage percentage on `main` (it won't have valid results until this is merged to and tests are run on `main`)

## outcomes

PRs will now have:
- an auto-generated comment related to code coverage ([docs](https://docs.codecov.com/docs/pull-request-comments))
- status checks related to code coverage ([docs](https://docs.codecov.com/docs/commit-status))

Codecov report for this branch is [here](https://app.codecov.io/gh/NYCPlanning/data-engineering/tree/dm-test-coverage-report) (you should be prompted to login via github):

<img width="1299" alt="Screenshot 2024-08-05 at 8 47 10 PM" src="https://github.com/user-attachments/assets/8de3bd56-b452-4df5-ab6d-d96995f15415">

## background

we've found it's difficult to have confidence in code changes (especially to `dcpy`) without visibility of test coverage of the changes and/or code related to the changes

the two most popular/established options for code coverage reporting are [Codecov](https://about.codecov.io/) and [Coveralls](https://coveralls.io/). both seem great and are free for our type of usage

I chose Codecov because DCP has a history of using it (Labs aka AE), it seems more lightweight, and seems more user-friendly. if we ever want to switch to Coveralls, it would be easy to

`dcpy` tests are run on `main` as part of Nightly QA and on all PRs with changes to [these files](https://github.com/NYCPlanning/data-engineering/blob/main/.github/workflows/test.yml#L31-L35)