### PR TITLE
Fix DevDB QA endpoint, run tests on pushes to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,9 @@ on:
   workflow_dispatch:
   workflow_call:
   pull_request:
-    branches:
-      - main
+    branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/products/developments/bash/config.sh
+++ b/products/developments/bash/config.sh
@@ -13,7 +13,7 @@ function import_qaqc_historic {
     local name="qaqc_historic"
     target_dir=$(pwd)/.library/data/$VERSION
     target_filename="${name}.csv"
-    qaqc_do_path=spaces/edm-publishing/db-developments/main/latest/output/${target_filename}
+    qaqc_do_path=spaces/edm-publishing/db-developments/publish/latest/${target_filename}
     if [ -f ${target_dir}/${target_filename} ]; then
         echo "✅ ${target_filename} exists in cache"
     else


### PR DESCRIPTION
fixes #1045 - this logic should really be reworked ideally to not be grabbing a raw file in bash (from latest folder) but this will at least get nightly_qa running. Will take care of slightly better in #1038 

Building [here](https://github.com/NYCPlanning/data-engineering/actions/runs/10274030552)