### PR TITLE
Add path override option to library

### DIFF
--- a/apps/qa/src/pages/ingest/helpers.py
+++ b/apps/qa/src/pages/ingest/helpers.py
@@ -1,9 +1,10 @@
-import shutil
 from pathlib import Path
 import streamlit as st
-from time import sleep
-from dcpy.utils import s3
 from streamlit.runtime.uploaded_file_manager import UploadedFile
+from time import sleep
+
+from dcpy.utils import s3
+from dcpy.library.archive import Archive
 
 BUCKET = "edm-recipes"
 
@@ -36,6 +37,14 @@ def archive_raw_data(
             "Failed to archive Dataset {dataset_name} version {version} to {s3_path}: {e}"
         )
     return file_path
+
+
+def library_archive(
+    dataset_name: str, version: str, s3_path: str, latest: bool
+) -> None:
+    a = Archive()
+    # once we've tested and this is ready to go, need to add `push=True`
+    a(name=dataset_name, version=version, override_path=s3_path, latest=latest)
 
 
 def dummy_archive_raw_data(

--- a/dcpy/library/archive.py
+++ b/dcpy/library/archive.py
@@ -24,7 +24,7 @@ class Archive:
         clean: bool = False,
         latest: bool = False,
         name: str | None = None,
-        path_override: str | None = None,
+        source_path_override: str | None = None,
         *args,
         **kwargs,
     ) -> Config:
@@ -38,10 +38,11 @@ class Archive:
         push: if `True` then push to s3
         clean: if `True`, the temporary files created under `.library` will be removed
         latest: if `True` then tag this current version we are processing to be the `latest`
+        name: name of the dataset, if you would like to use templates already included in this package
+        source_path_override: if applicable, a str url/path to override the source path in the template
 
         Optional Parameters
         ----------
-        name: name of the dataset, if you would like to use templates already included in this package
         compress: if compression is needed, this is passed into the `ingestor`
         inplace: if compressed zip file will replace the original file, this is passed into the `ingestor`
         postgres_url: Please specify if `output_format=='postgres'`
@@ -92,7 +93,7 @@ class Archive:
 
         # Initiate ingestion
         output_files, config = ingestor_of_format(
-            path, *args, path_override=path_override, **kwargs  # type: ignore
+            path, *args, source_path_override=source_path_override, **kwargs  # type: ignore
         )
         version = config.dataset.version
         acl = config.dataset.acl

--- a/dcpy/library/archive.py
+++ b/dcpy/library/archive.py
@@ -24,6 +24,7 @@ class Archive:
         clean: bool = False,
         latest: bool = False,
         name: str | None = None,
+        path_override: str | None = None,
         *args,
         **kwargs,
     ) -> Config:
@@ -85,12 +86,14 @@ class Archive:
             )
 
         # Get ingestor by format
-        ingestor_of_format: Callable[[str, Any, Any], tuple[list[str], Config]] = (
-            getattr(self.ingestor, output_format)
+        ingestor_of_format: Callable[[Any], tuple[list[str], Config]] = getattr(
+            self.ingestor, output_format
         )
 
         # Initiate ingestion
-        output_files, config = ingestor_of_format(path, *args, **kwargs)
+        output_files, config = ingestor_of_format(
+            path, *args, path_override=path_override, **kwargs  # type: ignore
+        )
         version = config.dataset.version
         acl = config.dataset.acl
 

--- a/dcpy/library/cli.py
+++ b/dcpy/library/cli.py
@@ -28,6 +28,7 @@ def archive(
     inplace: bool = typer.Option(False, "--inplace", help="Only keeping zipped file"),
     postgres_url: str = typer.Option(None, "--postgres-url", help="Postgres connection url"),
     version: str = typer.Option(None, "--version", "-v", help="Custom version input"),
+    path_override: str = typer.Option(None, "--path-override", help="Overrides path source if applicable")
 ) -> None:
 # fmt: on
     """
@@ -51,6 +52,7 @@ def archive(
                 inplace=inplace,
                 postgres_url=postgres_url,
                 version=version,
+                path_override=path_override,
             )
         assert config
         if push:

--- a/dcpy/library/cli.py
+++ b/dcpy/library/cli.py
@@ -28,7 +28,7 @@ def archive(
     inplace: bool = typer.Option(False, "--inplace", help="Only keeping zipped file"),
     postgres_url: str = typer.Option(None, "--postgres-url", help="Postgres connection url"),
     version: str = typer.Option(None, "--version", "-v", help="Custom version input"),
-    path_override: str = typer.Option(None, "--path-override", help="Overrides path source if applicable")
+    source_path_override: str = typer.Option(None, "--source-path-override", help="Overrides path source if applicable")
 ) -> None:
 # fmt: on
     """
@@ -52,7 +52,7 @@ def archive(
                 inplace=inplace,
                 postgres_url=postgres_url,
                 version=version,
-                path_override=path_override,
+                source_path_override=source_path_override,
             )
         assert config
         if push:

--- a/dcpy/library/config.py
+++ b/dcpy/library/config.py
@@ -22,11 +22,14 @@ class Config:
     """
 
     def __init__(
-        self, path: str, version: str | None = None, path_override: str | None = None
+        self,
+        path: str,
+        version: str | None = None,
+        source_path_override: str | None = None,
     ):
         self.path = path
         self.version = version
-        self.path_override = path_override
+        self.source_path_override = source_path_override
 
     @property
     def unparsed_unrendered_template(self) -> str:
@@ -90,9 +93,9 @@ class Config:
         config = self.parsed_rendered_template(version=version)
 
         if config.source.script:
-            if self.path_override:
+            if self.source_path_override:
                 if config.source.script.path:
-                    config.source.script.path = self.path_override
+                    config.source.script.path = self.source_path_override
                 else:
                     raise ValueError(
                         "Cannot override path of script dataset without path argument"
@@ -105,7 +108,7 @@ class Config:
             config.source.gdalpath = format_url(path)
 
         elif config.source.socrata:
-            if self.path_override:
+            if self.source_path_override:
                 raise ValueError("Cannot override path of socrata dataset")
             socrata = config.source.socrata
             if socrata.format == "csv":
@@ -124,7 +127,7 @@ class Config:
             config.source.gdalpath = format_url(path)
 
         elif config.source.arcgis_feature_server:
-            if self.path_override:
+            if self.source_path_override:
                 raise ValueError(
                     "Cannot override path of arcgis feature server dataset"
                 )
@@ -142,8 +145,8 @@ class Config:
             config.source.gdalpath = format_url(str(file))
 
         elif config.source.url:
-            if self.path_override:
-                config.source.url.path = self.path_override
+            if self.source_path_override:
+                config.source.url.path = self.source_path_override
             config.source.gdalpath = format_url(
                 config.source.url.path, config.source.url.subpath
             )

--- a/dcpy/library/ingest.py
+++ b/dcpy/library/ingest.py
@@ -37,7 +37,7 @@ def translator(func):
 
         output_files = []
         path = args[0]
-        c = Config(path, kwargs.get("version", None))
+        c = Config(path, kwargs.get("version"), kwargs.get("path_override"))
         dataset = c.compute
         assert dataset.source.gdalpath
         assert dataset.version

--- a/dcpy/library/ingest.py
+++ b/dcpy/library/ingest.py
@@ -37,7 +37,7 @@ def translator(func):
 
         output_files = []
         path = args[0]
-        c = Config(path, kwargs.get("version"), kwargs.get("path_override"))
+        c = Config(path, kwargs.get("version"), kwargs.get("source_path_override"))
         dataset = c.compute
         assert dataset.source.gdalpath
         assert dataset.version

--- a/dcpy/models/library.py
+++ b/dcpy/models/library.py
@@ -60,6 +60,7 @@ class DatasetDefinition(BaseModel):
 
         class Script(BaseModel, extra="allow"):
             name: str | None = None
+            path: str | None = None
 
     class DestinationSection(BaseModel):
         geometry: GeometryType

--- a/dcpy/test/library/data/arcgis_feature_server.yml
+++ b/dcpy/test/library/data/arcgis_feature_server.yml
@@ -1,0 +1,34 @@
+dataset:
+  name: nysparks_parks_polygons
+  acl: public-read
+  source:
+    arcgis_feature_server:
+      server: nys_parks
+      name: NYS_Park_Polygons
+      layer: 0
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:26918
+      type: POLYGON
+
+  destination:
+    geometry:
+      SRS: EPSG:4326
+      type: POLYGON
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## New York State Office of Parks, Recreation and Historic Preservation Property
+
+      This service contains the NY state park boundary polygon data, current to August 2022.  Data is updated on a regular basis and should be requested from NY State Parks if current data is needed for your project.
+      All boundaries are shown as approximate.
+    url: https://data.gis.ny.gov/datasets/nysparks::ny-state-parks-property/about
+    dependents: []

--- a/dcpy/test/library/data/script_no_path.yml
+++ b/dcpy/test/library/data/script_no_path.yml
@@ -1,0 +1,22 @@
+dataset:
+  name: script_no_path
+  acl: public-read
+  source:
+    script: {}
+    options:
+    geometry:
+      SRS: NONE
+      type: NONE
+
+  destination:
+    geometry:
+      SRS: NONE
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "GEOMETRY=AS_WKT"
+
+  info:
+    description: ""
+    url: ""
+    dependents: []

--- a/dcpy/test/library/test_config.py
+++ b/dcpy/test/library/test_config.py
@@ -50,7 +50,14 @@ def test_config_compute():
 
 def test_config_script():
     config = Config(f"{template_path}/bpl_libraries.yml").compute
-    assert True
+    assert config.source.gdalpath
+
+
+@patch("dcpy.connectors.esri.arcgis_feature_service.get_dataset")
+def test_arcgis_feature_server(get_dataset):
+    get_dataset.return_value = {}
+    config = Config(get_config_file("arcgis_feature_server")).compute
+    assert config.source.gdalpath.endswith(f"{config.name}.geojson")
 
 
 def test_backwards_compatility_with_jinja_version():

--- a/dcpy/test/library/test_config.py
+++ b/dcpy/test/library/test_config.py
@@ -67,7 +67,7 @@ def test_backwards_compatility_with_jinja_version():
 
 
 def test_url_with_override_path():
-    config = Config(get_config_file("url"), path_override=FAKE_PATH)
+    config = Config(get_config_file("url"), source_path_override=FAKE_PATH)
     dataset = config.compute
     assert dataset.source.url
     assert dataset.source.url.path == FAKE_PATH
@@ -77,7 +77,9 @@ def test_url_with_override_path():
 @patch("dcpy.library.script.bpl_libraries.Scriptor.runner")
 def test_script_with_override_path(runner):
     runner.return_value = FAKE_PATH
-    config = Config(get_config_file("bpl_libraries_sql"), path_override=FAKE_PATH)
+    config = Config(
+        get_config_file("bpl_libraries_sql"), source_path_override=FAKE_PATH
+    )
     dataset = config.compute
     assert dataset.source.script
     assert dataset.source.script.path == FAKE_PATH
@@ -86,10 +88,12 @@ def test_script_with_override_path(runner):
 
 def test_override_path_failures():
     with pytest.raises(ValueError, match="Cannot override"):
-        Config(get_config_file("socrata"), path_override=FAKE_PATH).compute
+        Config(get_config_file("socrata"), source_path_override=FAKE_PATH).compute
     with pytest.raises(ValueError, match="Cannot override"):
         Config(
-            get_config_file("arcgis_feature_server"), path_override=FAKE_PATH
+            get_config_file("arcgis_feature_server"), source_path_override=FAKE_PATH
         ).compute
     with pytest.raises(ValueError, match="Cannot override"):
-        Config(get_config_file("script_no_path"), path_override=FAKE_PATH).compute
+        Config(
+            get_config_file("script_no_path"), source_path_override=FAKE_PATH
+        ).compute

--- a/dcpy/test/library/test_config.py
+++ b/dcpy/test/library/test_config.py
@@ -1,6 +1,10 @@
+import pytest
+from unittest.mock import patch
 from dcpy.library.config import Config
 
 from . import template_path, get_config_file
+
+FAKE_PATH = "./fake_file.csv"
 
 
 def test_config_parsed_rendered_template():
@@ -53,3 +57,32 @@ def test_backwards_compatility_with_jinja_version():
     config = Config(get_config_file("bpl_libraries_sql_deprecated"))
     computed = config.compute
     assert computed.version == config.version_today
+
+
+def test_url_with_override_path():
+    config = Config(get_config_file("url"), path_override=FAKE_PATH)
+    dataset = config.compute
+    assert dataset.source.url
+    assert dataset.source.url.path == FAKE_PATH
+    assert dataset.source.gdalpath == f"{FAKE_PATH}/{dataset.source.url.subpath}"
+
+
+@patch("dcpy.library.script.bpl_libraries.Scriptor.runner")
+def test_script_with_override_path(runner):
+    runner.return_value = FAKE_PATH
+    config = Config(get_config_file("bpl_libraries_sql"), path_override=FAKE_PATH)
+    dataset = config.compute
+    assert dataset.source.script
+    assert dataset.source.script.path == FAKE_PATH
+    assert dataset.source.gdalpath == FAKE_PATH
+
+
+def test_override_path_failures():
+    with pytest.raises(ValueError, match="Cannot override"):
+        Config(get_config_file("socrata"), path_override=FAKE_PATH).compute
+    with pytest.raises(ValueError, match="Cannot override"):
+        Config(
+            get_config_file("arcgis_feature_server"), path_override=FAKE_PATH
+        ).compute
+    with pytest.raises(ValueError, match="Cannot override"):
+        Config(get_config_file("script_no_path"), path_override=FAKE_PATH).compute


### PR DESCRIPTION
For work on the streamlit ingest page, we need the ability to feed in a `path` to grab a dataset from. This can be done for datasets with a `url` source

Writing this now, I debated if this would better be covered by simply editing relevant templates to come from `path: s3://edm-recipes/inbox/{{ name }}/{{ version }}/filename.csv`, then no override is needed. I do think in principle it makes sense to have path to dataset be a parameterized thing - if a filename changes between times that its emailed to us, I'm fine with preserving the original filename (and not have to manually edit it - that was sort of the whole point of this exercise). 

So I do think in principle this is the right approach, even if it's a bit clunky in `library`. Though maybe for these templates we'd want to essentially make it a required arg, rather than a possible override. Anyways, very open to feedback.