### PR TITLE
decrease severity of `dpr_greenthumb` test in Template DB

### DIFF
--- a/products/template/sql/_sources.yml
+++ b/products/template/sql/_sources.yml
@@ -51,9 +51,10 @@ sources:
           NYC DPR Greenthumb locations
         columns:
           - name: gardenname
-            description: Primary key of the dpr_greenthumb table
             tests:
-              - unique
+              - unique:
+                  config:
+                    severity: warn
               - not_null
           - name: borough
             tests:


### PR DESCRIPTION
related to #1058

@fvankrieken investigated and found that `dpr_greenthumb` now has a few duplicate rows

`dpr_greenthumb` is used in Template DB and PLUTO

In PLUTO [here](https://github.com/NYCPlanning/data-engineering/blob/main/products/pluto/pluto_build/sql/bldgclass.sql#L150), we use it to determine if vacant lots is "more than 15% covered by a greenthumb garden" or "more than 25% of the garden is in a lot". As far as I can tell, duplicate rows in `dpr_greenthumb` won't change the results of that script