### PR TITLE
ensure all ArcGIS Feature Server datasets are in github action

### DIFF
--- a/.github/workflows/data_library_arcgis_feature_server.yml
+++ b/.github/workflows/data_library_arcgis_feature_server.yml
@@ -28,8 +28,10 @@ jobs:
           - dcp_waterfront_access_map_pow
           - nysdec_freshwater_wetlands_checkzones
           - nysdec_freshwater_wetlands
+          - nysdec_lands
           - nysdec_natural_heritage_communities
           - nysdec_priority_lakes
+          - nysdec_priority_shorelines
           - nysdec_priority_estuaries
           - nysdec_priority_streams
           - nysdec_tidal_wetlands

--- a/dcpy/library/templates/nysdec_lands.yml
+++ b/dcpy/library/templates/nysdec_lands.yml
@@ -5,7 +5,6 @@ dataset:
     arcgis_feature_server:
       server: nys_clearinghouse
       name: NYS_DEC_Lands
-      layer_id: 0
     geometry:
       SRS: EPSG:26918
       type: MULTIPOLYGON

--- a/dcpy/test/library/data/arcgis_feature_server.yml
+++ b/dcpy/test/library/data/arcgis_feature_server.yml
@@ -1,5 +1,5 @@
 dataset:
-  name: nysparks_historicplaces_esri
+  name: nysparks_historicplaces
   acl: public-read
   source:
     arcgis_feature_server:


### PR DESCRIPTION
follow-up to https://github.com/NYCPlanning/data-engineering/pull/1054

I noticed a couple of datasets with `source: arcgis_feature_server: ...` weren't listed in `data_library_arcgis_feature_server.yml`