### PR TITLE
add ability to pin version to source dataset

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -250,7 +250,7 @@ def promote_to_draft(
     build_metadata.draft_revision_name = draft_revision_label
     build_metadata_path = Path("build_metadata.json")
     with open(build_metadata_path, "w", encoding="utf-8") as f:
-        json.dump(build_metadata.model_dump(), f, indent=4)
+        json.dump(build_metadata.model_dump(mode="json"), f, indent=4)
 
     # promote from build to draft
     source = build_key.path + "/"
@@ -320,7 +320,7 @@ def publish(
         build_metadata.version = new_version
         build_metadata_path = Path("build_metadata.json")
         with open(build_metadata_path, "w", encoding="utf-8") as f:
-            json.dump(build_metadata.model_dump(), f, indent=4)
+            json.dump(build_metadata.model_dump(mode="json"), f, indent=4)
 
     source = draft_key.path + "/"
     target = f"{draft_key.product}/publish/{new_version}/"

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -292,7 +292,7 @@ def get_archival_metadata(
         name=name,
         version=version,
         timestamp=timestamp,
-        config=config.model_dump(),
+        config=config.model_dump(mode="json"),
         runner=runner,
     )
 

--- a/dcpy/library/ingest.py
+++ b/dcpy/library/ingest.py
@@ -62,7 +62,7 @@ def translator(func):
             config_dumped = library.Config(
                 dataset=dataset,
                 execution_details=execution_details,
-            ).model_dump()
+            ).model_dump(mode="json")
             with open(f"{folder_path}/config.json", "w") as f:
                 f.write(json.dumps(config_dumped, indent=4))
             output_files.append(f"{folder_path}/config.json")

--- a/dcpy/lifecycle/builds/metadata.py
+++ b/dcpy/lifecycle/builds/metadata.py
@@ -43,4 +43,4 @@ def write_build_metadata(recipe: Recipe, output_folder: Path):
     )
     with open(output_file, "w", encoding="utf-8") as f:
         logger.info(f"Writing build metadata to {str(output_file.absolute())}")
-        json.dump(build_metadata.model_dump(), f, indent=4)
+        json.dump(build_metadata.model_dump(mode="json"), f, indent=4)

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -209,7 +209,7 @@ def plan(recipe_file: Path, version: str | None = None) -> Path:
 
     with open(lock_file, "w", encoding="utf-8") as f:
         logger.info(f"Writing recipe lockfile to {str(lock_file.absolute())}")
-        yaml.dump(recipe.model_dump(), f)
+        yaml.dump(recipe.model_dump(mode="json"), f)
 
     return lock_file
 
@@ -282,7 +282,7 @@ def repeat_build(
     )
     with open(lock_file, "w", encoding="utf-8") as f:
         logger.info(f"Writing recipe lockfile to {str(lock_file.absolute())}")
-        yaml.dump(recipe.model_dump(), f)
+        yaml.dump(recipe.model_dump(mode="json"), f)
     return lock_file
 
 

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -182,35 +182,18 @@ def recipe_from_yaml(path: Path) -> Recipe:
         return recipe
 
 
-def repeat_recipe_from_source_data_versions(
-    version: str, source_data_versions: pd.DataFrame, template_recipe: Recipe
-) -> Recipe:
-    recipe = template_recipe.model_copy()
-    recipe.version = version
-    version_by_source_data_name = {
-        name: row["version"] for name, row in source_data_versions.iterrows()
-    }
-    for ds in recipe.inputs.datasets:
-        if ds.name in version_by_source_data_name:
-            ds.version = version_by_source_data_name[ds.name]
-        else:
-            raise Exception(
-                "Dataset found in template recipe not found in historical source data versions, \
-                cannot repeat build."
-            )
-
-    return recipe
-
-
-def plan(recipe_file: Path, version: str | None = None) -> Path:
+def generate_lock_file(recipe_file: Path, recipe: Recipe) -> Path:
     lock_file = recipe_file.parent / f"{recipe_file.stem}.lock.yml"
-    logger.info(f"Planning recipe from {recipe_file}")
-    recipe = plan_recipe(recipe_file, version)
-
     with open(lock_file, "w", encoding="utf-8") as f:
         logger.info(f"Writing recipe lockfile to {str(lock_file.absolute())}")
         yaml.dump(recipe.model_dump(mode="json"), f)
+    return lock_file
 
+
+def plan(recipe_file: Path, version: str | None = None) -> Path:
+    logger.info(f"Planning recipe from {recipe_file}")
+    recipe = plan_recipe(recipe_file, version)
+    lock_file = generate_lock_file(recipe_file, recipe)
     return lock_file
 
 
@@ -235,6 +218,26 @@ def write_source_data_versions(recipe_file: Path):
             writer.writerow([s, v, f])
 
 
+def repeat_recipe_from_source_data_versions(
+    version: str, source_data_versions: pd.DataFrame, template_recipe: Recipe
+) -> Recipe:
+    recipe = template_recipe.model_copy()
+    recipe.version = version
+    version_by_source_data_name = {
+        name: row["version"] for name, row in source_data_versions.iterrows()
+    }
+    for ds in recipe.inputs.datasets:
+        if ds.name in version_by_source_data_name:
+            ds.version = version_by_source_data_name[ds.name]
+        else:
+            raise Exception(
+                "Dataset found in template recipe not found in historical source data versions, \
+                cannot repeat build."
+            )
+
+    return recipe
+
+
 def repeat_build(
     product_key: publishing.ProductKey,
     recipe_file: Path | None = None,
@@ -245,27 +248,29 @@ def repeat_build(
             s = yaml.safe_load(file)["recipe"]
             recipe = Recipe(**s)
     elif publishing.file_exists(product_key, "source_data_versions.csv"):
-        if not recipe_file:
+        logger.info(
+            f"Attempting to repeat recipe for {product_key} from source_data_versions.csv"
+        )
+
+        if not (recipe_file and recipe_file.exists()):
             raise ValueError(
-                "Recipe file for template must be supplied in if repeating an older draft build without build_metadata.json"
+                "Recipe file for template must be supplied in if repeating an older build without build_metadata.json"
             )
 
-        if isinstance(product_key, publishing.PublishKey):
+        if isinstance(product_key, publishing.PublishKey) or isinstance(
+            product_key, publishing.DraftKey
+        ):
             version = product_key.version
         elif manual_version:
             version = manual_version
         else:
             raise ValueError(
-                "Version must be supplied manually if repeating an older draft build without build_metadata.json"
+                "Version must be supplied manually if repeating an older build without build_metadata.json"
             )
 
         template_recipe = recipe_from_yaml(recipe_file)
-        logger.info(f"Attempting to repeat recipe for {product_key}")
-        if not (recipe_file and recipe_file.exists()):
-            raise Exception(
-                "Template recipe file must be provided to repeat build from existing source_data_versions.csv"
-            )
         source_data_versions = publishing.get_source_data_versions(product_key)
+        print(source_data_versions)
         recipe = repeat_recipe_from_source_data_versions(
             version, source_data_versions, template_recipe
         )
@@ -275,14 +280,8 @@ def repeat_build(
             f"Neither 'build_metadata.json' nor 'source_data_versions.csv' can be found. '{product_key}' cannot be repeated"
         )
 
-    lock_file = (
-        recipe_file.parent / f"{recipe_file.stem}.lock.yml"
-        if recipe_file
-        else Path("recipe.lock.yml")
-    )
-    with open(lock_file, "w", encoding="utf-8") as f:
-        logger.info(f"Writing recipe lockfile to {str(lock_file.absolute())}")
-        yaml.dump(recipe.model_dump(mode="json"), f)
+    recipe_file = recipe_file or Path(DEFAULT_RECIPE)
+    lock_file = generate_lock_file(recipe_file, recipe)
     return lock_file
 
 

--- a/dcpy/models/connectors/edm/recipes.py
+++ b/dcpy/models/connectors/edm/recipes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 from typing import Literal
 
 ValidAclValues = Literal["public-read", "private"]
@@ -53,10 +53,3 @@ class Dataset(BaseModel, extra="forbid"):
 
     def s3_file_key(self, prefix: str) -> str:
         return f"{self.s3_folder_key(prefix)}/{self.file_name}"
-
-    @field_serializer("file_type")
-    def _serialize_type(self, t: DatasetType | None, _info) -> str | None:
-        if t is not None:
-            return t.value
-        else:
-            return t

--- a/dcpy/models/connectors/esri.py
+++ b/dcpy/models/connectors/esri.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 
 
 class Server(StrEnum):
@@ -29,10 +29,6 @@ class FeatureServer(BaseModel, extra="forbid"):
         server_id = servers[self.server]["id"]
         return f"https://{subdomain}.arcgis.com/{server_id}/ArcGIS/rest/services/{self.name}/FeatureServer"
 
-    @field_serializer("server")
-    def _serialize_server(self, s: Server, _info) -> str:
-        return s.value
-
 
 class FeatureServerLayer(BaseModel, extra="forbid"):
     server: Server
@@ -51,7 +47,3 @@ class FeatureServerLayer(BaseModel, extra="forbid"):
     @property
     def layer_label(self) -> str:
         return f"{self.layer_name} ({self.layer_id})"
-
-    @field_serializer("server")
-    def _serialize_server(self, s: Server, _info) -> str:
-        return s.value

--- a/dcpy/models/connectors/socrata.py
+++ b/dcpy/models/connectors/socrata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from enum import StrEnum
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 from typing import Literal
 
 
@@ -39,7 +39,3 @@ class Source(BaseModel, extra="forbid"):
             return "zip"
         else:
             return self.format
-
-    @field_serializer("org")
-    def _serialize_org(self, org: Org, _info) -> str:
-        return org.value

--- a/dcpy/models/library.py
+++ b/dcpy/models/library.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 from typing import Literal
 
 from dcpy.utils import metadata
@@ -71,10 +71,6 @@ class DatasetDefinition(BaseModel):
             @property
             def feature_server(self) -> esri.FeatureServer:
                 return esri.FeatureServer(server=self.server, name=self.name)
-
-            @field_serializer("server")
-            def _serialize_server(self, s: esri.Server, _info) -> str:
-                return s.value
 
     class DestinationSection(BaseModel):
         geometry: GeometryType

--- a/dcpy/models/lifecycle/builds.py
+++ b/dcpy/models/lifecycle/builds.py
@@ -48,40 +48,17 @@ class InputDataset(BaseModel, extra="forbid"):
             name=self.name, version=self.version, file_type=self.file_type
         )
 
-    @field_serializer("file_type", "destination")
-    def _serialize_str_enum(self, s: StrEnum | None, _info) -> str | None:
-        if s is not None:
-            return s.value
-        else:
-            return s
-
 
 class InputDatasetDefaults(BaseModel):
     file_type: recipes.DatasetType | None = None
     preprocessor: DataPreprocessor | None = None
     destination: InputDatasetDestination = InputDatasetDestination.postgres
 
-    @field_serializer("file_type", "destination")
-    def _serialize_str_enum(self, s: StrEnum | None, _info) -> str | None:
-        if s is not None:
-            return s.value
-        else:
-            return s
-
 
 class RecipeInputs(BaseModel):
     missing_versions_strategy: RecipeInputsVersionStrategy | None = None
     datasets: List[InputDataset] = []
     dataset_defaults: InputDatasetDefaults | None = None
-
-    @field_serializer("missing_versions_strategy")
-    def _serialize_strategy(
-        self, s: RecipeInputsVersionStrategy | None, _info
-    ) -> str | None:
-        if s:
-            return s.value
-        else:
-            return s
 
 
 class Recipe(BaseModel, extra="forbid", arbitrary_types_allowed=True):
@@ -100,23 +77,6 @@ class Recipe(BaseModel, extra="forbid", arbitrary_types_allowed=True):
             or len([x for x in self.inputs.datasets if not x.is_resolved()]) == 0
         )
 
-    @field_serializer("version_type")
-    def _serialize_str_enum(self, s: StrEnum | None, _info) -> str | None:
-        if s is not None:
-            return s.value
-        else:
-            return s
-
-    @field_serializer("version_strategy")
-    def _serialize_verstion_strategy(
-        self, s: versions.VersionStrategy | None, _info
-    ) -> str | versions.BumpLatestRelease | None:
-        match s:
-            case versions.SimpleVersionStrategy():
-                return s.value
-            case _:
-                return s
-
 
 class ImportedDataset(BaseModel, extra="forbid", arbitrary_types_allowed=True):
     name: str
@@ -133,10 +93,6 @@ class ImportedDataset(BaseModel, extra="forbid", arbitrary_types_allowed=True):
         return ImportedDataset(
             name=ds.name, version=ds.version, file_type=ds.file_type, destination=result
         )
-
-    @field_serializer("file_type")
-    def _serialize_str_enum(self, s: StrEnum, _info) -> str:
-        return s.value
 
 
 class LoadResult(BaseModel, extra="forbid"):

--- a/dcpy/models/lifecycle/ingest.py
+++ b/dcpy/models/lifecycle/ingest.py
@@ -14,10 +14,6 @@ class LocalFileSource(BaseModel, extra="forbid"):
     type: Literal["local_file"]
     path: Path
 
-    @field_serializer("path")
-    def _serialize_path(self, path: Path, _info) -> str:
-        return str(path)
-
 
 class S3Source(BaseModel, extra="forbid"):
     type: Literal["s3"]

--- a/dcpy/test/conftest.py
+++ b/dcpy/test/conftest.py
@@ -114,7 +114,7 @@ def create_temp_filesystem(mock_data_constants):
             writer.writeheader()
             writer.writerows(file_data)
         with open(data_path / build_metadata_file, "w") as f:
-            yaml.dump(build_metadata.model_dump(), f)
+            yaml.dump(build_metadata.model_dump(mode="json"), f)
         print("Created test filesystem ✅")
 
     except Exception as exc:

--- a/dcpy/test/library/test_config.py
+++ b/dcpy/test/library/test_config.py
@@ -1,5 +1,4 @@
 import pytest
-from tempfile import TemporaryFile
 from unittest.mock import patch
 import yaml
 
@@ -22,8 +21,7 @@ def test_model_dump():
         if "version" not in config_dict:
             config_dict["version"] = "dummy"
         config = DatasetDefinition(**config_dict)
-        yml_str = yaml.dump(config.model_dump())
-        print(yml_str)
+        yml_str = yaml.dump(config.model_dump(mode="json"))
         config2 = DatasetDefinition(**yaml.safe_load(yml_str))
 
 

--- a/dcpy/test/lifecycle/builds/resources/build_metadata.json
+++ b/dcpy/test/lifecycle/builds/resources/build_metadata.json
@@ -1,0 +1,36 @@
+{
+    "timestamp": "2024-05-30T14:01:08.077641-04:00",
+    "commit": "",
+    "run_url": null,
+    "version": "22v1",
+    "recipe": {
+        "name": "Tester",
+        "product": "db-test",
+        "base_recipe": null,
+        "version_type": null,
+        "version_strategy": null,
+        "version": "22v1",
+        "vars": {
+            "VERSION": "22v1"
+        },
+        "inputs": {
+            "missing_versions_strategy": "find_latest",
+            "datasets": [
+                {
+                    "name": "has_no_version_or_type",
+                    "version": "v1",
+                    "file_type": "csv",
+                    "version_env_var": null,
+                    "import_as": null,
+                    "preprocessor": null,
+                    "destination": "postgres"
+                }
+            ],
+            "dataset_defaults": {
+                "file_type": null,
+                "preprocessor": null,
+                "destination": "postgres"
+            }
+        }
+    }
+}

--- a/dcpy/test/lifecycle/builds/resources/recipe.lock.yml
+++ b/dcpy/test/lifecycle/builds/resources/recipe.lock.yml
@@ -1,0 +1,43 @@
+base_recipe: null
+inputs:
+  dataset_defaults:
+    destination: postgres
+    file_type: csv
+    preprocessor:
+      function: dispatch
+      module: facdb.pipelines
+  datasets:
+  - destination: postgres
+    file_type: pg_dump
+    import_as: null
+    name: has_version_from_env
+    preprocessor:
+      function: dispatch
+      module: facdb.pipelines
+    version: 21v4
+    version_env_var: VERSION_PREV
+  - destination: postgres
+    file_type: csv
+    import_as: null
+    name: has_pinned_version
+    preprocessor:
+      function: dispatch
+      module: facdb.pipelines
+    version: other_pinned_version
+    version_env_var: null
+  - destination: postgres
+    file_type: csv
+    import_as: null
+    name: has_no_version_or_type
+    preprocessor:
+      function: dispatch
+      module: facdb.pipelines
+    version: v1
+    version_env_var: null
+  missing_versions_strategy: find_latest
+name: Tester
+product: db-test
+vars: null
+version: 23v1
+version_strategy: null
+version_type: null

--- a/dcpy/test/lifecycle/builds/resources/recipe_no_defaults.lock.yml
+++ b/dcpy/test/lifecycle/builds/resources/recipe_no_defaults.lock.yml
@@ -1,0 +1,21 @@
+base_recipe: null
+inputs:
+  dataset_defaults:
+    destination: postgres
+    file_type: null
+    preprocessor: null
+  datasets:
+  - destination: postgres
+    file_type: null
+    import_as: null
+    name: has_no_version_or_type
+    preprocessor: null
+    version: v1
+    version_env_var: null
+  missing_versions_strategy: null
+name: Tester
+product: db-test
+vars: null
+version: 21v1
+version_strategy: null
+version_type: null

--- a/dcpy/test/lifecycle/builds/resources/recipe_no_version.yml
+++ b/dcpy/test/lifecycle/builds/resources/recipe_no_version.yml
@@ -1,0 +1,18 @@
+name: Tester
+product: db-test
+inputs:
+  dataset_defaults:
+    file_type: csv
+    preprocessor:
+      module: facdb.pipelines
+      function: dispatch
+  missing_versions_strategy: find_latest
+  datasets:
+  - name: has_version_from_env
+    version_env_var: VERSION_PREV
+    file_type: pg_dump
+
+  - name: has_pinned_version
+    version: "pinned_version"
+
+  - name: has_no_version_or_type

--- a/dcpy/test/lifecycle/builds/resources/source_data_versions.csv
+++ b/dcpy/test/lifecycle/builds/resources/source_data_versions.csv
@@ -1,0 +1,2 @@
+dataset,version
+has_no_version_or_type,v1

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -163,12 +163,16 @@ class BumpLatestRelease(BaseModel):
     bump_latest_release: int
 
 
+class PinToSourceDataset(BaseModel):
+    pin_to_source_dataset: str
+
+
 class SimpleVersionStrategy(StrEnum):
     first_of_month = "first_of_month"
     bump_latest_release = "bump_latest_release"
 
 
-VersionStrategy = SimpleVersionStrategy | BumpLatestRelease
+VersionStrategy = SimpleVersionStrategy | BumpLatestRelease | PinToSourceDataset
 
 
 class VersionSubType(StrEnum):

--- a/products/green_fast_track/recipe.yml
+++ b/products/green_fast_track/recipe.yml
@@ -1,6 +1,7 @@
 name: Green Fast Track
 product: green_fast_track
-version: 0.0.1
+version_strategy:
+  pin_to_source_dataset: dcp_mappluto_wi
 inputs:
   datasets:
     # Boundaries


### PR DESCRIPTION
We've discussed basing GFT's version on PLUTO with GIS, so included here is the logic to do that.

Also figured I'd go ahead and get rid of the silly `StrEnum` deserializers and specify to call `model_dump(mode="json")` whenever we're actually dumping to a file instead

Final commit reworks a bit in plan, including adding a bit more test coverage (mainly to repeat build logic). They're getting a little hard to read with all the patching... but I think they largely make sense. 

I would go by commit

[gft build](https://github.com/NYCPlanning/data-engineering/actions/runs/10359663405) - will verify outputs are properly deserialized (build_metadata.json)