### PR TITLE
Add Metadata v2 models and tests

### DIFF
--- a/dcpy/models/base.py
+++ b/dcpy/models/base.py
@@ -1,10 +1,11 @@
+from pathlib import Path
 from pydantic import BaseModel, model_serializer
 from pydantic.fields import PrivateAttr
 
 import typing
+import yaml
 
 
-# BASE
 class SortedSerializedBase(BaseModel):
     """A Pydantic BaseModel that will allow for sensible (and overrideable) deserialization order.
 
@@ -72,3 +73,39 @@ class SortedSerializedBase(BaseModel):
                 ordered_items_tail, key=lambda x: self._tail_sort_order.index(x[0])
             )
         )
+
+
+class YamlWriter(BaseModel):
+    class _YamlTopLevelSpacesDumper(yaml.SafeDumper):
+        """YAML serializer that will insert lines between top-level entries,
+        which is nice in longer files."""
+
+        def write_line_break(self, data=None):
+            super().write_line_break(data)
+
+            if len(self.indents) == 1:
+                super().write_line_break()
+
+    def write_to_yaml(self, path: Path):
+        def str_presenter(dumper, data):
+            # To maintain readabily for dumping multiline strings. Otherwise the dumped text has no consistency,
+            # leading to, sometimes:
+            # \ text of varying\n\n \
+            # \ readability\n\n \
+            if len(data.splitlines()) > 1:  # check for multiline string
+                return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+        yaml.add_representer(str, str_presenter)
+        yaml.representer.SafeRepresenter.add_representer(str, str_presenter)
+
+        with open(path, "w", encoding="utf8") as f:
+            f.write(
+                yaml.dump(
+                    self.model_dump(exclude_none=True),
+                    sort_keys=False,
+                    default_flow_style=False,
+                    Dumper=YamlWriter._YamlTopLevelSpacesDumper,
+                    allow_unicode=True,
+                )
+            )

--- a/dcpy/models/base.py
+++ b/dcpy/models/base.py
@@ -1,0 +1,72 @@
+from pydantic import BaseModel, model_serializer
+from pydantic.fields import PrivateAttr
+
+
+# BASE
+class SortedSerializedBase(BaseModel):
+    """A Pydantic BaseModel that will allow for sensible (and overrideable) deserialization order.
+
+    The serialization order is as follows:
+    - model attributes defined in the head sort order
+    - simple (and nullable simple) types: strings, ints, bools, literals
+    - complex types
+    - model attributes defined in the tail sort order
+
+    Note: This is put in its own class because it might be useful for other
+    classes unrelated to product metadata in the future.
+    """
+
+    _exclude_falsey_values: bool = True
+    _head_sort_order: list[str] = PrivateAttr(default=["id"])
+    _tail_sort_order: list[str] = PrivateAttr(default=["custom"])
+
+    @model_serializer(mode="wrap")
+    def _model_dump_ordered(self, handler):
+        unordered = handler(self)
+
+        ordered_items_head = []
+        ordered_items_tail = []
+        simple_type_items = []
+        other_items = []
+
+        for model_field in list(unordered.items()):
+            model_key, model_val = model_field
+
+            if not model_val and model_val != 0 and self._exclude_falsey_values:
+                # If an object's values are all None, it will serialize as {}.
+                # These aren't removed by model_dump(exclude_none=True), so we have to do it manually.
+                continue
+            field_type = self.model_fields[
+                model_key
+            ].annotation  # Need to retrieve type from the class def, not the instance
+            is_literal = type(field_type) is typing._LiteralGenericAlias  # type: ignore
+            simple_types = {
+                bool,
+                bool | None,  # This is a little hacky, but does the job.
+                str,
+                str | None,
+                int,
+                int | None,
+                float,
+                float | None,
+                type(None),
+            }
+
+            if model_key in self._head_sort_order:
+                ordered_items_head.append(model_field)
+            elif model_key in self._tail_sort_order:
+                ordered_items_tail.append(model_field)
+            elif field_type in simple_types or is_literal:
+                simple_type_items.append(model_field)
+            else:
+                other_items.append(model_field)
+
+        # As of python 3.7, dict keys are ordered, and so will serialize in the order below
+        return dict(
+            sorted(ordered_items_head, key=lambda x: self._head_sort_order.index(x[0]))
+            + sorted(simple_type_items, key=lambda x: x[0])
+            + sorted(other_items, key=lambda x: x[0])
+            + sorted(
+                ordered_items_tail, key=lambda x: self._tail_sort_order.index(x[0])
+            )
+        )

--- a/dcpy/models/base.py
+++ b/dcpy/models/base.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, model_serializer
 from pydantic.fields import PrivateAttr
 
+import typing
+
 
 # BASE
 class SortedSerializedBase(BaseModel):

--- a/dcpy/models/product/dataset/metadata_v2.py
+++ b/dcpy/models/product/dataset/metadata_v2.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import jinja2
 
 from pathlib import Path
-from pydantic import BaseModel, field_validator, model_serializer
-from pydantic.fields import PrivateAttr
-from typing import Any, List, Literal, get_args, Self
-import typing
+from pydantic import BaseModel, field_validator
+from typing import Any, List, Literal, get_args
 import unicodedata
 import yaml
 
 from dcpy.utils.logging import logger
 from dcpy.utils.collections import deep_merge_dict as merge
+from dcpy.models.base import SortedSerializedBase
 
 
 # MISC UTILS
@@ -33,76 +32,6 @@ def normalize_text(s):
     # Apply the translation
     cleaned = normalized.translate(translator)
     return cleaned.strip()
-
-
-# BASE
-class SortedSerializedBase(BaseModel):
-    """A Pydantic BaseModel that will allow for sensible (and overrideable) deserialization order.
-
-    The serialization order is as follows:
-    - model attributes defined in the head sort order
-    - simple (and nullable simple) types: strings, ints, bools, literals
-    - complex types
-    - model attributes defined in the tail sort order
-
-    Note: This is put in its own class because it might be useful for other
-    classes unrelated to product metadata in the future.
-    """
-
-    _exclude_falsey_values: bool = True
-    _head_sort_order: list[str] = PrivateAttr(default=["id"])
-    _tail_sort_order: list[str] = PrivateAttr(default=["custom"])
-
-    @model_serializer(mode="wrap")
-    def _model_dump_ordered(self, handler):
-        unordered = handler(self)
-
-        ordered_items_head = []
-        ordered_items_tail = []
-        simple_type_items = []
-        other_items = []
-
-        for model_field in list(unordered.items()):
-            model_key, model_val = model_field
-
-            if not model_val and model_val != 0 and self._exclude_falsey_values:
-                # If an object's values are all None, it will serialize as {}.
-                # These aren't removed by model_dump(exclude_none=True), so we have to do it manually.
-                continue
-            field_type = self.model_fields[
-                model_key
-            ].annotation  # Need to retrieve type from the class def, not the instance
-            is_literal = type(field_type) is typing._LiteralGenericAlias  # type: ignore
-            simple_types = {
-                bool,
-                bool | None,  # This is a little hacky, but does the job.
-                str,
-                str | None,
-                int,
-                int | None,
-                float,
-                float | None,
-                type(None),
-            }
-
-            if model_key in self._head_sort_order:
-                ordered_items_head.append(model_field)
-            elif model_key in self._tail_sort_order:
-                ordered_items_tail.append(model_field)
-            elif field_type in simple_types or is_literal:
-                simple_type_items.append(model_field)
-            else:
-                other_items.append(model_field)
-
-        # As of python 3.7, dict keys are ordered, and so will serialize in the order below
-        return dict(
-            sorted(ordered_items_head, key=lambda x: self._head_sort_order.index(x[0]))
-            + sorted(simple_type_items, key=lambda x: x[0])
-            + sorted(other_items, key=lambda x: x[0])
-            + sorted(
-                ordered_items_tail, key=lambda x: self._tail_sort_order.index(x[0])
-            )
-        )
 
 
 class CustomizableBase(SortedSerializedBase, extra="forbid"):

--- a/dcpy/models/product/dataset/metadata_v2.py
+++ b/dcpy/models/product/dataset/metadata_v2.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import jinja2
+
+from pathlib import Path
+from pydantic import BaseModel, field_validator, model_serializer
+from pydantic.fields import PrivateAttr
+from typing import Any, List, Literal, get_args, Self
+import typing
+import unicodedata
+import yaml
+
+from dcpy.utils.logging import logger
+from dcpy.utils.collections import deep_merge_dict as merge
+
+
+# MISC UTILS
+def normalize_text(s):
+    """
+    Normalize the text we may receive from the various metadata sources.
+    Primarily useful for cleaning long-text like descriptions.
+    """
+    char_map = {
+        "–": "-",  # en dash to hyphen
+        "—": "-",  # em dash to hyphen
+        "’": "'",  # curly apostrophe
+        "“": '"',  # lcurly quote
+        "”": '"',  # rcurly quote
+    }
+    translator = str.maketrans(char_map)
+    # Normalize Unicode characters
+    normalized = unicodedata.normalize("NFKD", s)
+    # Apply the translation
+    cleaned = normalized.translate(translator)
+    return cleaned.strip()
+
+
+# BASE
+class SortedSerializedBase(BaseModel):
+    """A Pydantic BaseModel that will allow for sensible (and overrideable) deserialization order.
+
+    The serialization order is as follows:
+    - model attributes defined in the head sort order
+    - simple (and nullable simple) types: strings, ints, bools, literals
+    - complex types
+    - model attributes defined in the tail sort order
+
+    Note: This is put in its own class because it might be useful for other
+    classes unrelated to product metadata in the future.
+    """
+
+    _exclude_falsey_values: bool = True
+    _head_sort_order: list[str] = PrivateAttr(default=["id"])
+    _tail_sort_order: list[str] = PrivateAttr(default=["custom"])
+
+    @model_serializer(mode="wrap")
+    def _model_dump_ordered(self, handler):
+        unordered = handler(self)
+
+        ordered_items_head = []
+        ordered_items_tail = []
+        simple_type_items = []
+        other_items = []
+
+        for model_field in list(unordered.items()):
+            if not model_field[1] and self._exclude_falsey_values:
+                # If an object's values are all None, it will serialize as {}.
+                # These aren't removed by model_dump(exclude_none=True), so we have to do it manually.
+                continue
+            field_type = self.model_fields[
+                model_field[0]
+            ].annotation  # Need to retrieve type from the class def, not the instance
+            is_literal = type(field_type) is typing._LiteralGenericAlias  # type: ignore
+            simple_types = {
+                bool,
+                bool | None,  # This is a little hacky, but does the job.
+                str,
+                str | None,
+                int,
+                int | None,
+                float,
+                float | None,
+                type(None),
+            }
+
+            if model_field[0] in self._head_sort_order:
+                ordered_items_head.append(model_field)
+            elif model_field[0] in self._tail_sort_order:
+                ordered_items_tail.append(model_field)
+            elif field_type in simple_types or is_literal:
+                simple_type_items.append(model_field)
+            else:
+                other_items.append(model_field)
+
+        # As of python 3.7, dict keys are ordered, and so will serialize in the order below
+        return dict(
+            sorted(ordered_items_head, key=lambda x: self._head_sort_order.index(x[0]))
+            + sorted(simple_type_items, key=lambda x: x[0])
+            + sorted(other_items, key=lambda x: x[0])
+            + sorted(
+                ordered_items_tail, key=lambda x: self._tail_sort_order.index(x[0])
+            )
+        )
+
+
+class CustomizableBase(SortedSerializedBase, extra="forbid"):
+    """A Base Pydantic class to allow extensibility of our models via a `custom`
+    dictionary.
+
+    Any additional attributes that aren't defined on our models should
+    be added to `custom`. This is intended for domain-specific, non-generalized uses
+    like data-dictionary generation (e.g. the `readme_data_type` field on the columns)
+
+    It's also important that custom be preserved in the
+    course of overriding, specifically with a deep merge of the dictionary elements.
+    """
+
+    custom: dict[str, Any] = {}
+
+
+class YamlWriter(BaseModel):
+    class _YamlTopLevelSpacesDumper(yaml.SafeDumper):
+        """YAML serializer that will insert lines between top-level entries,
+        which is nice in longer files."""
+
+        def write_line_break(self, data=None):
+            super().write_line_break(data)
+
+            if len(self.indents) == 1:
+                super().write_line_break()
+
+    def write_to_yaml(self, path: Path):
+        def str_presenter(dumper, data):
+            # To maintain readabily for dumping multiline strings. Otherwise the dumped text has no consistency,
+            # leading to, sometimes:
+            # \ text of varying\n\n \
+            # \ readability\n\n \
+            if len(data.splitlines()) > 1:  # check for multiline string
+                return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+        yaml.add_representer(str, str_presenter)
+        yaml.representer.SafeRepresenter.add_representer(str, str_presenter)
+
+        with open(path, "w", encoding="utf8") as f:
+            f.write(
+                yaml.dump(
+                    self.model_dump(exclude_none=True),
+                    sort_keys=False,
+                    default_flow_style=False,
+                    Dumper=YamlWriter._YamlTopLevelSpacesDumper,
+                    allow_unicode=True,
+                )
+            )
+
+
+# COLUMNS
+# TODO: move to share with ingest.validate
+class Checks(CustomizableBase):
+    is_primary_key: bool | None = None
+    non_nullable: bool | None = None
+
+
+# TODO: move to share with ingest.validate
+COLUMN_TYPES = Literal[
+    "text", "integer", "decimal", "geometry", "bool", "bbl", "datetime"
+]
+
+
+class ColumnValue(CustomizableBase):
+    _head_sort_order = ["value", "description"]
+
+    value: str
+    description: str | None = None
+
+
+class DatasetColumnOverrides(CustomizableBase):
+    _head_sort_order = ["id", "name", "data_type", "description"]
+    _tail_sort_order = ["example", "values", "custom"]
+    _validate_data_type = (
+        True  # override, to generate md where we don't know the data_type
+    )
+
+    # Note: id isn't intended to be overrideable, but is always required as a
+    # pointer back to the original column, so it is required here.
+    id: str
+    name: str | None = None
+    data_type: str | None = None
+    data_source: str | None = None
+    description: str | None = None
+    example: str | None = None
+    checks: Checks | None = None
+    deprecated: bool | None = None
+    values: list[ColumnValue] | None = None
+
+    @field_validator("data_type")
+    def _validate_colum_types(cls, v):
+        if cls._validate_data_type:
+            assert v in get_args(COLUMN_TYPES)
+        return v
+
+
+class DatasetColumn(DatasetColumnOverrides):
+    """Like DatasetColumnOverrides, but with constraints for non-null fields"""
+
+    @field_validator("name")
+    def _validate_name(cls, dn):
+        assert dn, "name may not be null"
+        return dn
+
+    @field_validator("data_type")
+    def _validate_data_type(cls, dt):
+        assert dt, "data_type may not be null"
+        return dt
+
+    def override(self, overrides: DatasetColumnOverrides) -> DatasetColumn:
+        return DatasetColumn(**merge(self.model_dump(), overrides.model_dump()))
+
+
+# FILE
+class FileOverrides(CustomizableBase):
+    filename: str | None = None
+    type: str | None = None
+
+
+class File(CustomizableBase):
+    """Describes an actual dataset file, e.g. dataset files or attachments."""
+
+    id: str
+    filename: str
+    type: str | None = None
+    is_metadata: bool | None = (
+        None  # e.g. readmes, data_dictionaries, version_files, etc.
+    )
+
+    def override(self, overrides: FileOverrides) -> File:
+        return File(
+            **(self.model_dump() | overrides.model_dump()),
+        )
+
+
+# PACKAGE / ASSEMBLY
+class PackageFile(CustomizableBase):
+    """File found in a Package, e.g. a Zip. `filename` here refers to it's name
+    in the package
+    """
+
+    id: str
+    filename: str | None = None
+
+
+class Package(CustomizableBase):
+    """Container for lists of files. Used as assembly instructions."""
+
+    id: str
+    type: str = "zip"
+    filename: str
+    contents: List[PackageFile]
+
+
+# DATASET
+class DatasetAttributesOverride(CustomizableBase):
+    display_name: str | None = None
+    description: str | None = None
+    each_row_is_a: str | None = None
+    tags: List[str] | None = None
+
+
+class DatasetAttributes(CustomizableBase):
+    display_name: str
+    description: str
+    each_row_is_a: str
+    tags: List[str]
+
+    def override(
+        self,
+        overrides: DatasetAttributesOverride,
+    ) -> DatasetAttributes:
+        return DatasetAttributes(**merge(self.model_dump(), overrides.model_dump()))
+
+
+class DatasetOverrides(CustomizableBase):
+    overridden_columns: list[DatasetColumnOverrides] = []
+    omitted_columns: list[str] = []
+    attributes: DatasetAttributesOverride = DatasetAttributesOverride()
+
+
+class Dataset(CustomizableBase):
+    columns: list[DatasetColumn]
+    attributes: DatasetAttributes
+
+    def override(self, overrides: DatasetOverrides) -> Dataset:
+        """Apply column updates and prune any columns specified as omitted"""
+        overriden_cols_by_id = {c.id: c for c in overrides.overridden_columns}
+
+        columns = [
+            c.override(overriden_cols_by_id.get(c.id, DatasetColumnOverrides(id=c.id)))
+            for c in self.columns
+            if c.id not in overrides.omitted_columns
+        ]
+
+        return Dataset(
+            columns=columns, attributes=self.attributes.override(overrides.attributes)
+        )
+
+
+# DESTINATION
+class Destination(CustomizableBase):
+    id: str
+    type: str
+
+
+class DestinationWithFiles(Destination):
+    files: List[DestinationFile] = []
+
+
+class FileAndOverrides(SortedSerializedBase):
+    _head_sort_order = ["file"]
+
+    dataset_overrides: DatasetOverrides = DatasetOverrides()
+    file: File
+
+
+class DestinationFile(CustomizableBase):
+    """Pointer to an actual `File`, with specifiable overrides."""
+
+    id: str
+    dataset_overrides: DatasetOverrides = DatasetOverrides()
+    file_overrides: FileOverrides = FileOverrides()
+
+
+class DestinationMetadata(SortedSerializedBase):
+    dataset: Dataset
+    destination: Destination
+    file: File
+
+
+class Metadata(CustomizableBase, YamlWriter):
+    id: str
+    attributes: DatasetAttributes
+    assembly: List[Package] = []
+    columns: List[DatasetColumn]
+    files: List[FileAndOverrides]
+    destinations: List[DestinationWithFiles]
+
+    _head_sort_order = [
+        "id",
+        "attributes",
+    ]
+    _tail_sort_order = ["columns"]
+    _exclude_falsey_values = False  # We never want to prune top-level attrs
+
+    @property
+    def dataset(self):
+        return Dataset(attributes=self.attributes, columns=self.columns)
+
+    def get_package(self, id: str) -> Package:
+        packages = [p for p in self.assembly if p.id == id]
+        if len(packages) != 1:
+            raise Exception(f"There should exist one package with id: {id}")
+        return packages[0]
+
+    def get_destination(self, id: str) -> DestinationWithFiles:
+        dests = [d for d in self.destinations if d.id == id]
+        if len(dests) != 1:
+            raise Exception(f"There should exist one destination with id: {id}")
+        return dests[0]
+
+    def get_file_and_overrides(self, file_id: str) -> FileAndOverrides:
+        files = [f for f in self.files if f.file.id == file_id]
+        if len(files) != 1:
+            raise Exception(f"There should exist one file with id: {file_id}")
+        return files[0]
+
+    def calculate_file_dataset_metadata(self, *, file_id: str) -> Dataset:
+        return self.dataset.override(
+            self.get_file_and_overrides(file_id).dataset_overrides
+        )
+
+    def calculate_destination_metadata(
+        self, *, file_id: str, destination_id: str
+    ) -> DestinationMetadata:
+        dataset_file = self.get_file_and_overrides(file_id)
+
+        destination = self.get_destination(destination_id)
+        dest_files = [f for f in destination.files if f.id == file_id]
+        if len(dest_files) != 1:
+            raise Exception(
+                f"Can't calculate overrides, because destination: {destination_id} doesn't reference file: {file_id}"
+            )
+        dest_file = dest_files[0]
+
+        dataset_metadata = self.calculate_file_dataset_metadata(
+            file_id=file_id
+        ).override(dest_file.dataset_overrides)
+
+        destination_file = (
+            dataset_file.file
+            if not dest_file
+            else dataset_file.file.override(dest_file.file_overrides)
+        )
+
+        return DestinationMetadata(
+            file=destination_file,
+            dataset=dataset_metadata,
+            destination=destination,
+        )
+
+    @staticmethod
+    def from_yaml(yaml_str: str, *, template_vars=None):
+        if template_vars:
+            logger.info(f"Templating metadata with vars: {template_vars}")
+            templated = jinja2.Template(
+                yaml_str, undefined=jinja2.StrictUndefined
+            ).render(template_vars or {})
+            return Metadata(**yaml.safe_load(templated))
+        else:
+            logger.info("No Template vars supplied. Skipping templating.")
+        return Metadata(**yaml.safe_load(yaml_str))
+
+    @classmethod
+    def from_path(cls, path: Path, *, template_vars=None):
+        with open(path, "r", encoding="utf-8") as raw:
+            return cls.from_yaml(raw.read(), template_vars=template_vars)

--- a/dcpy/models/product/dataset/metadata_v2.py
+++ b/dcpy/models/product/dataset/metadata_v2.py
@@ -63,12 +63,14 @@ class SortedSerializedBase(BaseModel):
         other_items = []
 
         for model_field in list(unordered.items()):
-            if not model_field[1] and self._exclude_falsey_values:
+            model_key, model_val = model_field
+
+            if not model_val and model_val != 0 and self._exclude_falsey_values:
                 # If an object's values are all None, it will serialize as {}.
                 # These aren't removed by model_dump(exclude_none=True), so we have to do it manually.
                 continue
             field_type = self.model_fields[
-                model_field[0]
+                model_key
             ].annotation  # Need to retrieve type from the class def, not the instance
             is_literal = type(field_type) is typing._LiteralGenericAlias  # type: ignore
             simple_types = {
@@ -83,9 +85,9 @@ class SortedSerializedBase(BaseModel):
                 type(None),
             }
 
-            if model_field[0] in self._head_sort_order:
+            if model_key in self._head_sort_order:
                 ordered_items_head.append(model_field)
-            elif model_field[0] in self._tail_sort_order:
+            elif model_key in self._tail_sort_order:
                 ordered_items_tail.append(model_field)
             elif field_type in simple_types or is_literal:
                 simple_type_items.append(model_field)

--- a/dcpy/test/models/product/dataset/test_metadata_v2.py
+++ b/dcpy/test/models/product/dataset/test_metadata_v2.py
@@ -1,0 +1,384 @@
+from pathlib import Path
+from pytest import fixture
+import pytest
+import tempfile
+
+from dcpy.models.product.dataset import metadata_v2 as m
+
+OVERRIDDEN_SHP_NAME_AT_DEST = "overridden_shp_name_at_dest.zip"
+DESTINATION_OVERRIDDEN_DISPLAY_NAME = "overridden dest display name"
+SHAPEFILE_OVERRIDDEN_DISPLAY_NAME = "overridden dest display name"
+
+BBL_SHAPEFILE_COL_DESC = "bbl description overridden at the column level"
+BBL_SOCRATA_COL_DESC = """
+bbl description overridden at Socrata
+
+With some bonus new-lines and
+• Special Characters
+   o to exercise up the (de)serialization tests
+"""
+OVERRIDDEN_SHAPEFILE_TEMPLATED_FILE_NAME = "my_file_{{ version }}.zip"
+
+# Files
+BASIC_SHAPEFILE_ID = "my_basic_shapefile"
+OVERRIDDEN_SHAPEFILE_ID = "my_overridden_shapefile"
+ZIP_FILE_ID = "my_zip"
+
+# Destinations
+SOCRATA_DESTINATION_ID = "socrata_shapefile_dest"
+NO_FILES_DEST_ID = "no files dest id"
+
+# COLUMNS
+OMITTED_FROM_SHAPEFILE_COL_ID = "omitted_from_shapefile_col_id"
+OMITTED_FROM_SOCRATA_SHAPEFILE_COL_ID = "omitted_from_socrata_shapefile_col_id"
+
+
+@fixture
+def md():
+    return m.Metadata(
+        id="test",
+        attributes=m.DatasetAttributes(
+            display_name="attrs_display_name",
+            description="attrs_description",
+            each_row_is_a="attrs_each_row_is_a",
+            tags=["attrs_1", "attrs_2"],
+            custom={
+                "custom_attr_key": "custom_attr_val",
+                "custom_attr_key_to_override": "custom_attr_val_to_override",
+            },
+        ),
+        columns=[
+            m.DatasetColumn(id="id", data_type="text", description="id description"),
+            m.DatasetColumn(
+                id="geom",
+                data_type="geometry",
+                description="geom description",
+                name="the_geom",
+                custom={"api_name": "geom_api_name"},
+            ),
+            m.DatasetColumn(
+                id="bbl",
+                description="bbl description at column level",
+                custom={
+                    "not_overridden": "should_not_be_overridden",
+                    "api_name": "bbl_col_api_name",
+                },
+            ),
+            m.DatasetColumn(
+                id="borough",
+                description="",
+                values=[
+                    m.ColumnValue(value="1", description="Manhattan"),
+                    m.ColumnValue(value="2", description="Kings"),
+                ],
+            ),
+            m.DatasetColumn(
+                id=OMITTED_FROM_SHAPEFILE_COL_ID,
+            ),
+            m.DatasetColumn(
+                id=OMITTED_FROM_SOCRATA_SHAPEFILE_COL_ID,
+            ),
+        ],
+        files=[
+            m.FileAndOverrides(
+                file=m.File(
+                    id=BASIC_SHAPEFILE_ID,
+                    filename="shp.zip",
+                    type="shapefile",
+                    custom={"hi": "there"},
+                ),
+            ),
+            m.FileAndOverrides(
+                file=m.File(
+                    id=OVERRIDDEN_SHAPEFILE_ID,
+                    filename="overridden_shp.zip",
+                    type="shapefile",
+                ),
+                dataset_overrides=m.DatasetOverrides(
+                    attributes=m.DatasetAttributesOverride(
+                        display_name=SHAPEFILE_OVERRIDDEN_DISPLAY_NAME,
+                        custom={
+                            "api_name": "geom_api_name_at_shapefiles_level",
+                            "custom_attr_key_to_override": "overridden_custom_attr_key_at_file_level",
+                        },
+                    ),
+                    omitted_columns=[OMITTED_FROM_SHAPEFILE_COL_ID],
+                    overridden_columns=[
+                        m.DatasetColumnOverrides(
+                            id="bbl",
+                            description=BBL_SHAPEFILE_COL_DESC,
+                            custom={"api_name": "bbl_shapefile_api_name"},
+                        ),
+                        m.DatasetColumnOverrides(
+                            id="borough",
+                            description="borough overridden at shapefile",
+                            values=[m.ColumnValue(value="3", description="Queens")],
+                        ),
+                    ],
+                ),
+            ),
+        ],
+        destinations=[
+            m.DestinationWithFiles(
+                id=SOCRATA_DESTINATION_ID,
+                type="socrata",
+                files=[
+                    m.DestinationFile(
+                        id=OVERRIDDEN_SHAPEFILE_ID,
+                        file_overrides=m.FileOverrides(
+                            filename=OVERRIDDEN_SHP_NAME_AT_DEST
+                        ),
+                        dataset_overrides=m.DatasetOverrides(
+                            attributes=m.DatasetAttributesOverride(
+                                display_name=DESTINATION_OVERRIDDEN_DISPLAY_NAME,
+                                custom={
+                                    "custom_attr_key_to_override": "overridden_custom_attr_key_at_dest_level",
+                                },
+                            ),
+                            omitted_columns=[OMITTED_FROM_SOCRATA_SHAPEFILE_COL_ID],
+                            overridden_columns=[
+                                m.DatasetColumnOverrides(
+                                    id="bbl",
+                                    description=BBL_SOCRATA_COL_DESC,
+                                    custom={"api_name": "bbl_dest_api_name"},
+                                ),
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+            m.DestinationWithFiles(
+                id="bytes_dest",
+                type="bytes",
+                files=[
+                    m.DestinationFile(id=ZIP_FILE_ID),
+                ],
+            ),
+            m.DestinationWithFiles(
+                id=NO_FILES_DEST_ID,
+                type="bytes",
+                files=[],
+            ),
+        ],
+        assembly=[
+            m.Package(
+                id=ZIP_FILE_ID,
+                filename="my.zip",
+                contents=[
+                    m.PackageFile(id=BASIC_SHAPEFILE_ID),
+                    m.PackageFile(
+                        id=OVERRIDDEN_SHAPEFILE_ID,
+                        filename=OVERRIDDEN_SHAPEFILE_TEMPLATED_FILE_NAME,
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+@fixture
+def overridden_shapefile_dataset(md):
+    return md.calculate_file_dataset_metadata(file_id=OVERRIDDEN_SHAPEFILE_ID)
+
+
+@fixture
+def overridden_socrata_dataset(md):
+    return md.calculate_destination_metadata(
+        file_id=OVERRIDDEN_SHAPEFILE_ID, destination_id=SOCRATA_DESTINATION_ID
+    )
+
+
+def test_filename_override(overridden_socrata_dataset):
+    """
+    Tests overriding at the destination.
+
+    Rationale: Certain files have different filenames in our packages vs destinations.
+    E.g. we might have metadata.pdf in the package, and metadata_24c.pdf on Socrata.
+    """
+    assert (
+        OVERRIDDEN_SHP_NAME_AT_DEST == overridden_socrata_dataset.file.filename
+    ), "The filename should have been overridden by the destination"
+
+
+def test_attribute_overrides_at_file_level(md, overridden_shapefile_dataset: m.Dataset):
+    """
+    Often a file will contain data with a slight variation from another file, e.g. Water Included
+    vs Water Not Included. This tests that we can override those dataset attributes at the file level.
+    """
+
+    # Simple Case: Check Non-overriden files
+    non_overridden_file_dataset = md.calculate_file_dataset_metadata(
+        file_id=BASIC_SHAPEFILE_ID
+    )
+    assert (
+        md.attributes.description == non_overridden_file_dataset.attributes.description
+    ), "The description shouldn't have changed for the non-overridden shapefile."
+
+    # Check that Overrides Work for an overridden file
+    assert (
+        SHAPEFILE_OVERRIDDEN_DISPLAY_NAME
+        == overridden_shapefile_dataset.attributes.display_name
+    ), "The display_name field should have been changed by the file override"
+
+    # Check that custom values are merged
+    shapefile_overrides = md.get_file_and_overrides(OVERRIDDEN_SHAPEFILE_ID)
+    expected_custom_attrs = (
+        md.attributes.custom | shapefile_overrides.dataset_overrides.attributes.custom
+    )
+    assert (
+        expected_custom_attrs == overridden_shapefile_dataset.attributes.custom
+    ), "The custom attributes should have been merged"
+
+
+def test_attribute_overrides_at_destination_level(
+    md, overridden_socrata_dataset: m.DestinationMetadata
+):
+    """
+    Similar to overrides at a file-level, sometimes it makes sense to override at the destination-level
+    in addition to the file-level. This tests that the `name` is overridden, as well as the
+    `custom` attributes.
+    """
+    assert (
+        DESTINATION_OVERRIDDEN_DISPLAY_NAME
+        == overridden_socrata_dataset.dataset.attributes.display_name
+    )
+
+    # Check custom attrs
+    shapefile_with_overrides = md.get_file_and_overrides(OVERRIDDEN_SHAPEFILE_ID)
+    socrata_dest = md.get_destination(SOCRATA_DESTINATION_ID)
+    socrata_dest_file_overrides = [
+        f.dataset_overrides
+        for f in socrata_dest.files
+        if f.id == shapefile_with_overrides.file.id
+    ][0]
+    expected_custom_attrs = (
+        md.attributes.custom
+        | shapefile_with_overrides.dataset_overrides.attributes.custom
+        | socrata_dest_file_overrides.attributes.custom
+    )
+    assert expected_custom_attrs == overridden_socrata_dataset.dataset.attributes.custom
+
+
+def test_omitted_columns(
+    md,
+    overridden_shapefile_dataset: m.Dataset,
+    overridden_socrata_dataset: m.DestinationMetadata,
+):
+    """
+    Test omitting columns when calculating overrides. In particular, the following case.
+    Starting from the pure columns in the metadata:
+    - a shapefile omits one of the columns
+    - then the socrata destination for that shapefile omits another column
+    """
+    expected_file_col_ids = {
+        c.id for c in md.columns if c.id != OMITTED_FROM_SHAPEFILE_COL_ID
+    }
+    expected_socrata_col_ids = {
+        c for c in expected_file_col_ids if c != OMITTED_FROM_SOCRATA_SHAPEFILE_COL_ID
+    }
+
+    assert expected_file_col_ids == {
+        c.id for c in overridden_shapefile_dataset.columns
+    }, "The omitted shapefile column should not be present"
+    assert expected_socrata_col_ids == {
+        c.id for c in overridden_socrata_dataset.dataset.columns
+    }, "The omitted destination column should not be present"
+
+
+def test_column_overrides_at_file_level(md, overridden_shapefile_dataset: m.Dataset):
+    shapefile_with_overrides = md.get_file_and_overrides(OVERRIDDEN_SHAPEFILE_ID)
+
+    # Test that the description column is overridden for the `bbl` column
+    actual_overridden_bbl_col = [
+        c for c in overridden_shapefile_dataset.columns if c.id == "bbl"
+    ][0]
+
+    assert (
+        BBL_SHAPEFILE_COL_DESC == actual_overridden_bbl_col.description
+    ), "The description field on the bbl column should have been overridden at the shapefile level."
+
+    # Check the `custom` attributes
+    base_bbl_col = [c for c in md.columns if c.id == "bbl"][0]
+    shapefile_bbl_col = [
+        c
+        for c in shapefile_with_overrides.dataset_overrides.overridden_columns
+        if c.id == "bbl"
+    ][0]
+    assert (
+        actual_overridden_bbl_col.custom
+        == base_bbl_col.custom | shapefile_bbl_col.custom
+    )
+    assert (
+        actual_overridden_bbl_col.custom["not_overridden"] == "should_not_be_overridden"
+    ), "Sanity check on the `not_overridden` field."
+
+    # Check that Values fields are overwritten, not merged
+    # base_borough_col = [c for c in md.columns if c.id == "borough"][0]
+    shapefile_borough_col_overrides = [
+        c
+        for c in shapefile_with_overrides.dataset_overrides.overridden_columns
+        if c.id == "borough"
+    ][0]
+    actual_overridden_borough_col = [
+        c for c in overridden_shapefile_dataset.columns if c.id == "borough"
+    ][0]
+    assert (
+        shapefile_borough_col_overrides.values == actual_overridden_borough_col.values
+    )
+
+
+def test_column_overrides_at_destination_level(
+    overridden_socrata_dataset: m.DestinationMetadata,
+):
+    actual_overridden_bbl_col = [
+        c for c in overridden_socrata_dataset.dataset.columns if c.id == "bbl"
+    ][0]
+
+    assert BBL_SOCRATA_COL_DESC == actual_overridden_bbl_col.description
+
+
+def test_writing_to_yaml(md):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        out_file = Path(temp_dir) / "metadata.yml"
+        md.write_to_yaml(out_file)
+
+        deserialized = m.Metadata.from_path(out_file)
+
+        assert md.model_dump() == deserialized.model_dump()
+
+
+def test_templating(md):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        out_file = Path(temp_dir) / "metadata.yml"
+        md.write_to_yaml(out_file)
+
+        version = "24b"
+        deserialized = m.Metadata.from_path(
+            out_file, template_vars={"version": version}
+        )
+
+        assert (
+            OVERRIDDEN_SHAPEFILE_TEMPLATED_FILE_NAME.replace("{{ version }}", version)
+            == [
+                f
+                for f in deserialized.get_package(ZIP_FILE_ID).contents
+                if f.id == OVERRIDDEN_SHAPEFILE_ID
+            ][0].filename
+        )
+
+
+def test_getting_non_existant_packages_dests_files(md: m.Metadata):
+    with pytest.raises(Exception):
+        md.get_package("blah")
+
+    with pytest.raises(Exception):
+        md.get_destination("blah")
+
+    with pytest.raises(Exception):
+        md.get_file_and_overrides("blah")
+
+    with pytest.raises(Exception):
+        # "This destination has no files, so an exception should be raised when we pass a file."
+        md.calculate_destination_metadata(
+            file_id=BASIC_SHAPEFILE_ID, destination_id=NO_FILES_DEST_ID
+        )

--- a/dcpy/test/models/product/dataset/test_model_serializing.py
+++ b/dcpy/test/models/product/dataset/test_model_serializing.py
@@ -43,7 +43,7 @@ ordered_args = {
     "z_put_me_first": ["hi"],
 }
 simple_args = {
-    "a": 1,
+    "a": 0,
     "b": None,
     "c": "hi",
     "d": None,
@@ -68,6 +68,9 @@ def test_dump_prune_falsey_vals():
     assert (
         not "child_to_be_serialized" in dumped
     ), "Falsey values should have been excluded from serialization."
+    assert (
+        "a" in dumped
+    ), "The falsey value of 0 should not have been excluded from the model"
 
 
 def test_dumping():

--- a/dcpy/test/models/product/dataset/test_model_serializing.py
+++ b/dcpy/test/models/product/dataset/test_model_serializing.py
@@ -1,0 +1,97 @@
+from typing import Literal
+
+from dcpy.models.product.dataset import metadata_v2 as md_v2
+
+
+class MySortedBaseClass(md_v2.SortedSerializedBase):
+    _head_sort_order = ["z_put_me_first"]
+    _tail_sort_order = ["z_put_me_last"]
+    _exclude_falsey_values = False
+
+
+class ChildToBeSerialized(MySortedBaseClass):
+    # Fully defining the order here for ease of testing
+    _head_sort_order = ["b", "a", "c"]
+
+    a: str | None = None
+    b: str | None = None
+    c: str | None = None
+
+
+class ToBeSerialized(MySortedBaseClass):
+    z_put_me_first: list[str]
+    z_put_me_last: str
+
+    # Complex Values
+    f: list[str]
+    g: dict[str, str]
+
+    # Simple values. (disordered, to make sure tests don't pass by default)
+    c: str
+    b: int | None
+    a: int
+    e: Literal["z"]
+    d: str | None
+
+    _private_unserialized_field = "I shouldn't show up in outputs"
+
+    child_to_be_serialized: ChildToBeSerialized
+
+
+ordered_args = {
+    "z_put_me_last": "hi",
+    "z_put_me_first": ["hi"],
+}
+simple_args = {
+    "a": 1,
+    "b": None,
+    "c": "hi",
+    "d": None,
+    "e": "z",
+}
+complex_args = {
+    "f": ["hi"],
+    "g": {"hi": "hi"},
+}
+
+
+def test_dump_prune_falsey_vals():
+    """Construct a model where the child model is composed entirely of None values.
+    The child model should serialize to {} due to built-in `exclude_none=True`,
+    and {} should then be pruned from the serialization."""
+    model = ToBeSerialized(
+        child_to_be_serialized=ChildToBeSerialized(),  # should be pruned
+        **(ordered_args | simple_args | complex_args),
+    )
+    model._exclude_falsey_values = True
+    dumped = model.model_dump(exclude_none=True)
+    assert (
+        not "child_to_be_serialized" in dumped
+    ), "Falsey values should have been excluded from serialization."
+
+
+def test_dumping():
+    """Tests serializing of simple and complex fields on a subclass, where the sort_order overrides
+    are defined on the parent class. Also tests that model serializing is recursive (ie child classes also sort correctly).
+    """
+    model = ToBeSerialized(
+        child_to_be_serialized=ChildToBeSerialized(a="a", b="b", c="c"),
+        **(ordered_args | simple_args | complex_args),
+    )
+
+    expected_key_order = (
+        model._head_sort_order
+        + sorted(list(simple_args.keys()))
+        + sorted(["child_to_be_serialized"] + list(complex_args.keys()))
+        + model._tail_sort_order
+    )
+
+    dumped = model.model_dump()
+
+    assert (
+        list(dumped.keys()) == expected_key_order
+    ), "The model should serialize with keys in the correct order."
+
+    assert model.child_to_be_serialized._head_sort_order == list(
+        dumped["child_to_be_serialized"].keys()
+    ), "Child objects should also deserialize in order."

--- a/dcpy/test/models/product/dataset/test_text_cleaning.py
+++ b/dcpy/test/models/product/dataset/test_text_cleaning.py
@@ -1,0 +1,19 @@
+import dcpy.models.product.dataset.metadata_v2 as md_v2
+
+
+def test_description_cleaning():
+    messy_description = """
+
+    Newlines Above (Should be removed)
+    Weird Characters: Apostrophe’s big–dash “lquote rquote”
+
+    Two Newlines Above (Should be Preserved)
+    Newline below (Should be removed)
+    """
+
+    clean_description = """Newlines Above (Should be removed)
+    Weird Characters: Apostrophe's big-dash "lquote rquote"
+
+    Two Newlines Above (Should be Preserved)
+    Newline below (Should be removed)"""
+    assert md_v2.normalize_text(messy_description) == clean_description

--- a/dcpy/test/models/test_base_serialization.py
+++ b/dcpy/test/models/test_base_serialization.py
@@ -1,9 +1,9 @@
 from typing import Literal
 
-from dcpy.models.product.dataset import metadata_v2 as md_v2
+from dcpy.models.base import SortedSerializedBase
 
 
-class MySortedBaseClass(md_v2.SortedSerializedBase):
+class MySortedBaseClass(SortedSerializedBase):
     _head_sort_order = ["z_put_me_first"]
     _tail_sort_order = ["z_put_me_last"]
     _exclude_falsey_values = False

--- a/dcpy/test/utils/test_collections.py
+++ b/dcpy/test/utils/test_collections.py
@@ -1,0 +1,8 @@
+from dcpy.utils import collections
+
+
+def test_deep_merge():
+    assert collections.deep_merge_dict(
+        {"a": "1", "b": {"c": {"d": "e"}}},
+        {"a": "1", "b": {"c": {"x": "y"}}},
+    ) == {"a": "1", "b": {"c": {"d": "e", "x": "y"}}}

--- a/dcpy/utils/collections.py
+++ b/dcpy/utils/collections.py
@@ -1,0 +1,18 @@
+def deep_merge_dict(dict1, dict2):
+    """
+    Recursively merge two dictionaries.
+
+    Args:
+        dict1 (dict): The first dictionary to merge.
+        dict2 (dict): The second dictionary to merge.
+
+    Returns:
+        dict: A new dictionary with the merged contents of dict1 and dict2.
+    """
+    result = dict1.copy()
+    for key, value in dict2.items():
+        if isinstance(value, dict) and key in result and isinstance(result[key], dict):
+            result[key] = deep_merge_dict(result[key], value)
+        else:
+            result[key] = value
+    return result


### PR DESCRIPTION
### Part 1 of the Metadata upgrade to v2. 

[Metadata Output Here](https://github.com/NYCPlanning/product-metadata/pull/8)

Adds v2 of the product metadata and tests. I'd recommend starting with the test for overrides, as that makes a lot of the rationale clear. But the general idea is that we have three core entities:
1. dataset (composed of columns and attributes)
2. files (can override dataset attributes)
3. destinations (can override files and datasets)

When we calculate eventual metadata for a destination, we start with the basic dataset, then apply file overrides, then destination overrides. 

Part 2 (incoming, mostly finished, different PR) 
upgrading the connectors and lifecycle modules to use v2.

### The Plan
The plan overall is to get this reviewed, upgrade all dependencies (e.g. connectors, lifecycle modules) to md_v2, delete v1 metadata, then merge the PR in the product metadata repo.

