### PR TITLE
fix codecov upload

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -193,6 +193,8 @@ jobs:
     - name: Upload dcpy test coverage to Codecov
       if: ${{ matrix.name =='dcpy' }}
       uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
       with:
         fail_ci_if_error: true
         verbose: true

--- a/dcpy/test/utils/test_geospatial.py
+++ b/dcpy/test/utils/test_geospatial.py
@@ -127,7 +127,7 @@ class TestTransform:
 
 
 class TestParquet:
-    def test_read_parquet_metadata(self, gdf):
+    def test_read_geoparquet_metadata(self, gdf):
         with TemporaryDirectory() as dir:
             filepath = f"{dir}/tmp.parquet"
             gdf.to_parquet(filepath)
@@ -135,6 +135,10 @@ class TestParquet:
             meta = parquet.read_metadata(filepath)
 
             assert meta.geo_parquet.primary_column.crs_string == "EPSG:4236"
+
+    def test_read_parquet_metadata(self):
+        with pytest.raises(TypeError, match="is not a geoparquet file."):
+            meta = parquet.read_metadata(RESOURCES_DIR / "simple.parquet")
 
     def test_read_parquet(self):
         df = parquet.read_df(RESOURCES_DIR / "simple.parquet")


### PR DESCRIPTION
## changes

- explicitly pass the codecov token envar to upload the coverage report
- add a test (to trigger codeov on this PR and to increase test coverage)

## background

I noticed that all branches were failing to upload test coverage reports to codecov (examples [1](https://github.com/NYCPlanning/data-engineering/actions/runs/10378222369/job/28734066295), [2](https://github.com/NYCPlanning/data-engineering/actions/runs/10378221079/job/28734050150), [3](https://github.com/NYCPlanning/data-engineering/actions/runs/10377201464/job/28730913449)).

To trigger tests on this branch, I chose to add a test for [this uncovered line](https://app.codecov.io/gh/NYCPlanning/data-engineering/blob/main/dcpy%2Futils%2Fgeospatial%2Fparquet.py#L17).

(un)fortunately, the upload failed and then succeeded on this branch with no changes in between:
<img width="345" alt="Screenshot 2024-08-13 at 7 12 57 PM" src="https://github.com/user-attachments/assets/81037fea-30c4-4e57-bedd-a596a8b129f8">

rerunning on any branch seemed to work now (example [1](https://github.com/NYCPlanning/data-engineering/actions/runs/10378222369/job/28735222724)). but the issue has returned (nightly QA [failed](https://github.com/NYCPlanning/data-engineering/actions/runs/10381736804/job/28743670492))

