### PR TITLE
QAQC App: Add new report to GRU constants

### DIFF
--- a/apps/qa/src/pages/gru/constants.py
+++ b/apps/qa/src/pages/gru/constants.py
@@ -5,7 +5,7 @@ qa_checks = pd.DataFrame(
         (
             "Address Points vs PAD",
             "address-points-vs-pad",
-            ["rejects_pad_addrpts"],
+            ["rejects_pad_addrpts", "geocode_bin_diffs_pad_addrpts"],
             ["dcp_addresspoints"],
         ),
         (


### PR DESCRIPTION
Follow-up to https://github.com/NYCPlanning/db-gru-qaqc/pull/269. Closes #1033. 

We received a request from GRU to add a report to an existing check "Address Points vs PAD" in the QAQC app. Report output has been confirmed with GRU over email.

Tested QAQC app locally (it now shows `geocode_bin_diffs_pad_addrpts` report): 

![image](https://github.com/user-attachments/assets/f7914631-6f51-42d7-9714-47ac4b1785ec)

Successfully ran GHA [here](https://github.com/NYCPlanning/db-gru-qaqc/actions/runs/10395259112) (same link as on the screenshot under "Status").
Link to the report [here](https://edm-publishing.nyc3.digitaloceanspaces.com/db-gru-qaqc/24c/address-points-vs-pad/latest/geocode_bin_diffs_pad_addrpts.csv).

`TODO`:
- [ ] re-deploy the app after PR is merged
- [ ] let GRU know it's available