### PR TITLE
fix pandoc command extra space

### DIFF
--- a/dcpy/lifecycle/package/generate_metadata_assets.py
+++ b/dcpy/lifecycle/package/generate_metadata_assets.py
@@ -21,10 +21,9 @@ def generate_pdf_from_yml(
         [
             "pandoc",
             output_html_path,
-            "o",
+            "-o",
             output_pdf_path,
-            "--metadata-file=",
-            pdf_metadata_path,
+            f"--metadata-file={pdf_metadata_path}",
         ],
         check=True,
     )


### PR DESCRIPTION
Fix errors in Pandoc commands where there is an extra space between --metadata-file= and the path provided, resulting in Pandoc being unable to find the metadata file.