### PR TITLE
add `pandoc` and `weasyprint` to docker images

### DIFF
--- a/docker/base/setup.sh
+++ b/docker/base/setup.sh
@@ -3,7 +3,7 @@
 source config.sh
 set -e
 
-COMMON_APT_PACKAGES="curl zip unzip git wget ca-certificates lsb-release build-essential sudo postgresql-client-15 libpq-dev jq locales"
+COMMON_APT_PACKAGES="curl zip unzip git wget ca-certificates lsb-release build-essential sudo postgresql-client-15 libpq-dev jq locales pandoc weasyprint"
 
 apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y -V install $COMMON_APT_PACKAGES \


### PR DESCRIPTION
during PR https://github.com/NYCPlanning/data-engineering/pull/1085, I had problems re-generating docker images based on multiple relevant commits. opened a new PR for a fresh start