### PR TITLE
Fix patching in publishing

### DIFF
--- a/apps/qa/src/shared/components/sidebar.py
+++ b/apps/qa/src/shared/components/sidebar.py
@@ -43,7 +43,9 @@ def data_selection(
                     )
         case "Published":
             label = "Select a version"
-            options = publishing.get_published_versions(product)
+            options = publishing.get_published_versions(
+                product=product, exclude_latest=False
+            )
             select = st.sidebar.selectbox(label, options, key=f"{section_label}_output")
             if select:
                 return publishing.PublishKey(product, select)

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -279,12 +279,19 @@ def validate_or_patch_version(
     is_patch: bool,
 ) -> str:
     """Given input arguments, determine the publish version, bumping it if necessary."""
-    version_already_published = version in get_published_versions(product=product)
+    published_versions = get_published_versions(product=product)
+
+    # Filters existing published versions for same version (patched or non-patched)
+    published_same_version = versions.group_versions_by_base(
+        version, published_versions
+    )
+    version_already_published = version in published_same_version
 
     if version_already_published:
         if is_patch:
+            latest_version = published_same_version[-1]
             patched_version = versions.bump(
-                previous_version=version,
+                previous_version=latest_version,
                 bump_type=versions.VersionSubType.patch,
                 bump_by=1,
             ).label

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pandas as pd
 from pathlib import Path
 import pytest
+from unittest.mock import patch
 
 from dcpy.utils import s3, versions
 from dcpy.connectors.edm import publishing
@@ -406,3 +407,44 @@ def test_promote_to_draft_revison_versioning(
         "2-correct-zoning",
         "1",
     ]
+
+
+@patch("dcpy.connectors.edm.publishing.get_published_versions")
+def test_validate_or_patch_version_patch_version(get_published_versions):
+    get_published_versions.return_value = [
+        "24v3",
+        "24v3.0.1",
+        "23v3",
+        "24v3.1",
+        "24v3.1.1",
+    ]
+    version_to_patch = "24v3"
+    assert (
+        publishing.validate_or_patch_version(
+            product=TEST_PRODUCT_NAME,
+            version=version_to_patch,
+            is_patch=True,
+        )
+        == "24v3.0.2"
+    )
+
+
+@patch("dcpy.connectors.edm.publishing.get_published_versions")
+def test_validate_or_patch_version_version_already_exists(get_published_versions):
+    get_published_versions.return_value = [
+        "24v3",
+        "24v3.0.1",
+        "23v3",
+        "24v3.1",
+        "24v3.1.1",
+    ]
+    version_to_patch = "24v3"
+    with pytest.raises(
+        ValueError,
+        match="already exists in published",
+    ):
+        publishing.validate_or_patch_version(
+            product=TEST_PRODUCT_NAME,
+            version=version_to_patch,
+            is_patch=False,
+        )

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -99,7 +99,7 @@ def test_publish_patch(create_buckets, create_temp_filesystem, mock_data_constan
     ).label
     bumped_publish_key = publishing.PublishKey(publish_key.product, bumped_version)
     assert set(publishing.get_published_versions(product=draft_key.product)) == set(
-        [TEST_VERSION, bumped_version, "latest"]
+        [TEST_VERSION, bumped_version]
     )
     # tests version in metadata was updated to patched version
     assert publishing.get_version(bumped_publish_key) == bumped_version

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -139,7 +139,7 @@ class TestVersions(TestCase):
         for version, versions_list, expected_output in [
             [
                 "24v3",
-                ["24v3.0.2", "24v3", "24v3.0.1", "24v3.1", "24Q1", "latest"],
+                ["24v3.0.2", "24v3", "24v3.0.1", "24v3.1", "24Q1"],
                 ["24v3", "24v3.0.1", "24v3.0.2"],
             ],
             ["24v4", ["24v3", "24v3.0.1", "24v3.1", "24Q1", "24v4"], ["24v4"]],

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -135,6 +135,20 @@ class TestVersions(TestCase):
         ]:
             self.assertEqual(v_expected, versions.bump(v, bumped_part, bump_by).label)
 
+    def test_group_versions_by_base(self):
+        for version, versions_list, expected_output in [
+            [
+                "24v3",
+                ["24v3.0.2", "24v3", "24v3.0.1", "24v3.1", "24Q1", "latest"],
+                ["24v3", "24v3.0.1", "24v3.0.2"],
+            ],
+            ["24v4", ["24v3", "24v3.0.1", "24v3.1", "24Q1", "24v4"], ["24v4"]],
+            ["24v3", ["23v2"], []],
+        ]:
+            self.assertEqual(
+                expected_output, versions.group_versions_by_base(version, versions_list)
+            )
+
     def test_parse_draft_version_valid_versions(self):
         for draft_version, expected_draft_num, expected_draft_summary in [
             ["1-start", 1, "start"],

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -271,9 +271,8 @@ def group_versions_by_base(version: str, versions_list: list[str]) -> list[str]:
     ```
     """
     parsed_version = parse(version)
-    version_list_wo_latest = [v for v in versions_list if v != "latest"]
     same_version_type_lst = [
-        v for v in version_list_wo_latest if isinstance(parse(v), type(parsed_version))
+        v for v in versions_list if isinstance(parse(v), type(parsed_version))
     ]
 
     def is_matching_version(base_version: Version, compare_version: Version) -> bool:

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -6,7 +6,6 @@ from dateutil.relativedelta import relativedelta
 from enum import StrEnum
 from functools import total_ordering
 from pydantic import BaseModel
-from typing import TypeVar
 import re
 
 

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 from abc import abstractmethod
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import date
 from dateutil.relativedelta import relativedelta
 from enum import StrEnum
 from functools import total_ordering
 from pydantic import BaseModel
+from typing import TypeVar
 import re
 
 
@@ -278,6 +279,11 @@ def group_versions_by_base(version: str, versions_list: list[str]) -> list[str]:
 
     def is_matching_version(base_version: Version, compare_version: Version) -> bool:
         """Helper function to check if compare_version matches base_version except for the patch."""
+        assert is_dataclass(base_version) and is_dataclass(
+            compare_version
+        )  # This line is to appease mypy
+
+        # Get Version key-value pairs excluding "patch" attribute to use for comparison
         base_fields = {
             field.name: getattr(base_version, field.name)
             for field in fields(base_version)


### PR DESCRIPTION
As mentioned in #1092, the current logic doesn't do correct version bumping when publishing. 

### This PR:
1. adds a function to `versions.py` that takes in a version and a list of versions and then returns a list of same versions (patched or non-patched). This sentence is too much so here is an example:
   * input version: `24Q1`
   * input version list: [`24Q1`, `24Q1.1`, `24Q2`, `23v1`, `22v3`] (could be mixed types of versions)

   * The new function returns: [`24Q1`, `24Q1.1`]
2. modifies existing `publishing.py` fn that validates or bumps a version, using the function from step 1.


### Testing
1. I wrote additional tests and they all pass
2. Additionally, I ran [this](https://github.com/NYCPlanning/data-engineering/actions/runs/10599912048/job/29376064105) GHA to patch template db and it works:
    * GHA settings:    
    <img width="335" alt="image" src="https://github.com/user-attachments/assets/60444bf0-706a-48f5-a5ec-5d04f8b90db5">

    * **Before** GHA:  
    ![image](https://github.com/user-attachments/assets/e9cef605-87e6-44f8-b90f-e15894d55ede)

    * **After** GHA:     
    ![image](https://github.com/user-attachments/assets/8a8739c0-420b-42f4-8d7f-0abfe48e7deb)


