### PR TITLE
Publishing: temp fix for patch

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -283,11 +283,15 @@ def validate_or_patch_version(
 
     if version_already_published:
         if is_patch:
-            return versions.bump(
+            patched_version = versions.bump(
                 previous_version=version,
                 bump_type=versions.VersionSubType.patch,
                 bump_by=1,
             ).label
+            assert patched_version not in get_published_versions(
+                product=product
+            )  # sanity check
+            return patched_version
         else:
             raise ValueError(
                 f"Version '{version}' already exists in published folder and patch wasn't selected"


### PR DESCRIPTION
I noticed that current patching doesn't work as expected and I missed a test for this case:

Regular and patched versions already exist in the published folder. For example, `24Q1` & `24Q1.1`. 
Expected patched version is `24Q1.2`; however, the current code will publish `24Q1.1`, overwriting the initial existing patch. 

See comment in the code below where this is happening exactly. 

In this PR, I'm adding a temp fix to prevent overwriting of existing patches (it will simply fail if patch already exists). I'm working on the actual fix in #1091, but it may take a bit.