### PR TITLE
export unzipped csvs to analysis folder

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -590,6 +590,9 @@ def _cli_wrapper_upload(
     ),
     build: str = typer.Option(None, "-b", "--build", help="Label of build"),
     acl: str = typer.Option(None, "-a", "--acl", help="Access level of file in s3"),
+    max_files: int = typer.Option(
+        s3.MAX_FILE_COUNT, "--max_files", help="Max number of files to upload"
+    ),
 ):
     acl_literal = s3.string_as_acl(acl)
     if not output_path.exists():
@@ -602,7 +605,12 @@ def _cli_wrapper_upload(
     logger.info(
         f'Uploading {output_path} to {product}/build/{build_name} with ACL "{acl}"'
     )
-    upload(output_path, BuildKey(product, build_name), acl=acl_literal)
+    upload(
+        output_path,
+        BuildKey(product, build_name),
+        acl=acl_literal,
+        max_files=max_files,
+    )
 
 
 @app.command("publish")

--- a/products/cpdb/bash/04_analysis.sh
+++ b/products/cpdb/bash/04_analysis.sh
@@ -25,6 +25,7 @@ run_sql_file sql/analysis/geospatial_check.sql -v ccp_v=$ccp_v
 
 mkdir -p $(pwd)/output/analysis && (
     cd $(pwd)/output/analysis
+
     csv_export cpdb_summarystats_magency &
     csv_export cpdb_summarystats_sagency &
     csv_export projects_by_communitydist &

--- a/products/cpdb/bash/05_export.sh
+++ b/products/cpdb/bash/05_export.sh
@@ -17,8 +17,6 @@ mkdir -p output && (
     csv_export checkbook_spending_by_year &
     csv_export geospatial_check &
     csv_export cpdb_projects_without_budget_data &
-    
-    cp ../projects_in_geographies.zip ./
 
     cp ../source_data_versions.csv ./
     cp ../build_metadata.json ./
@@ -27,6 +25,8 @@ mkdir -p output && (
     shp_export cpdb_dcpattributes_poly MULTIPOLYGON &
     shp_export cpdb_projects_pts MULTIPOINT &
     shp_export cpdb_projects_poly MULTIPOLYGON &
+    
+    cp -r ../projects_in_geographies ./
 
     echo $VERSION > version.txt
     wait 

--- a/products/cpdb/cpdb.sh
+++ b/products/cpdb/cpdb.sh
@@ -63,7 +63,7 @@ case $1 in
     analysis ) ./bash/04_analysis.sh ;;
     export ) ./bash/05_export.sh ;;
     archive ) cpdb_archive $@ ;;
-    upload ) python3 -m dcpy.connectors.edm.publishing upload -p db-cpdb -a private ;;
+    upload ) python3 -m dcpy.connectors.edm.publishing upload -p db-cpdb -a private --max_files 200;;
     share ) share $@ ;;
     sql) sql $@;;
     build)
@@ -72,5 +72,5 @@ case $1 in
         ./bash/03_adminbounds.sh
         ./bash/04_analysis.sh
         ./bash/05_export.sh
-        python3 -m dcpy.connectors.edm.publishing upload -p db-cpdb -a private
+        python3 -m dcpy.connectors.edm.publishing upload -p db-cpdb -a private --max_files 200
 esac

--- a/products/cpdb/python/admin_geographies.py
+++ b/products/cpdb/python/admin_geographies.py
@@ -25,7 +25,7 @@ class CityCouncilDistricts(AdminGeographies):
     cpdb_geography_type: str = "council"
 
     def generate_geography(self, geography_number: int) -> AdminGeography:
-        table_name = "city_council_district_" + str(geography_number)
+        table_name = "city_council_district_" + str(geography_number).rjust(2, "0")
         geography_id = str(geography_number)
         geography_name = "City Council District " + str(geography_number)
 

--- a/products/cpdb/python/projects_in_geographies.py
+++ b/products/cpdb/python/projects_in_geographies.py
@@ -64,11 +64,3 @@ if __name__ == "__main__":
             geography.geography_name,
         )
         export_table(geography.geography_type, geography.table_name)
-
-    # zip folder with all csv files
-    print(f"Zipping folder\n\t{OUTPUT_DIR}")
-    shutil.make_archive(
-        base_name=OUTPUT_DIR,
-        format="zip",
-        root_dir=OUTPUT_DIR,
-    )


### PR DESCRIPTION
related to https://github.com/NYCPlanning/ae-cp-map/issues/44

these changes allow AE to link to each csv in the new Capital Projects app. we've mentioned two more ideal long-term approaches (our package folder `product-dataset/cpdb/`, using signed links which expire) but this seems like a fair short-term approach for their MVP app

builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-cpdb-geographies-files) and repeat builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/repeat_build.yml?query=branch%3Adm-cpdb-geographies-files)

## files in draft build (a repeat of 24prelim)

<img width="309" alt="Screenshot 2024-08-29 at 3 48 40 PM" src="https://github.com/user-attachments/assets/19167a1f-5f07-4497-a372-3ae3c74da296">
