### PR TITLE
PLUTO: manually correct 2020 census tract 

### DIFF
--- a/products/pluto/pluto_build/03_corrections.sh
+++ b/products/pluto/pluto_build/03_corrections.sh
@@ -14,4 +14,5 @@ run_sql_file sql/corr_numfloors.sql
 run_sql_file sql/corr_units.sql
 run_sql_file sql/corr_inwoodrezoning.sql
 run_sql_file sql/corr_dropoldrecords.sql
+run_sql_file sql/corr_bct2020.sql
 run_sql_file sql/remove_unitlots.sql

--- a/products/pluto/pluto_build/data/pluto_input_research.csv
+++ b/products/pluto/pluto_build/data/pluto_input_research.csv
@@ -27397,3 +27397,4 @@ bbl,field,old_value,new_value,Type,reason,version
 3007987501,unitstotal,101,51,2,PTS error - units,24v3
 2033307501,unitsres,59,118,2,PTS error - units,24v3
 2033307501,unitstotal,60,119,2,PTS error - units,24v3
+4142600001,bct2020,4066401,4071600,2,Geosupport error - CensusTract,24v3

--- a/products/pluto/pluto_build/sql/corr_bct2020.sql
+++ b/products/pluto/pluto_build/sql/corr_bct2020.sql
@@ -1,0 +1,30 @@
+-- Take the year built from researched lpc_historic_districts table
+
+INSERT INTO pluto_changes_not_applied
+SELECT DISTINCT
+    b.*,
+    a.bct2020 AS found_value
+FROM pluto_input_research AS b, pluto AS a
+WHERE
+    b.bbl = a.bbl
+    AND b.field = 'bct2020'
+    AND b.old_value != a.bct2020;
+
+INSERT INTO pluto_changes_applied
+SELECT DISTINCT b.*
+FROM pluto_input_research AS b, pluto AS a
+WHERE
+    b.bbl = a.bbl
+    AND b.field = 'bct2020'
+    AND b.old_value = a.bct2020;
+
+-- Apply correction to PLUTO
+UPDATE pluto a
+SET
+    bct2020 = b.new_value,
+    dcpedited = 't'
+FROM pluto_input_research AS b
+WHERE
+    a.bbl = b.bbl
+    AND b.field = 'bct2020'
+    AND a.bct2020 = b.old_value;

--- a/products/pluto/pluto_build/sql/corr_bct2020.sql
+++ b/products/pluto/pluto_build/sql/corr_bct2020.sql
@@ -1,5 +1,3 @@
--- Take the year built from researched lpc_historic_districts table
-
 INSERT INTO pluto_changes_not_applied
 SELECT DISTINCT
     b.*,


### PR DESCRIPTION
During #976, GIS identified a few BBLs whose 2020 census tract values changed in PLUTO 24v3. Amanda advised to correct BBL 4142600001 (JFK airport lot) for PLUTO 24v3 version; the rest of BBLs are under investigation. 

### 🚨 Feedback needed: 
we haven't corrected for census tract and I'm using a brand new reason for the correction `Geosupport error - CensusTract`. We have only corrected geosupport errors with a reason `Geosupport error - CD`. Please let me know if it should be changed to something else.