### PR TITLE
fix use of `metadata.attributes` values

### DIFF
--- a/dcpy/lifecycle/package/resources/data_dictionary_template.jinja
+++ b/dcpy/lifecycle/package/resources/data_dictionary_template.jinja
@@ -6,20 +6,20 @@
 </head>
 
 <body>
-    <h1>{{ metadata.display_name }}</h1>
+    <h1>{{ metadata.attributes.display_name }}</h1>
 
     <h2><strong>Description:</strong> </h2>
-    <p>{{ metadata.description }}</p>
+    <p>{{ metadata.attributes.description }}</p>
 
     <h2><strong>Tags:</strong></h2>
     <ul>
-        {% for tag in metadata.tags %}
+        {% for tag in metadata.attributes.tags %}
         <li>{{ tag }}</li>
         {% endfor %}
     </ul>
 
     <h2><strong>Each row is a: </strong> </h2>
-    <p>{{ metadata.each_row_is_a }}</p>
+    <p>{{ metadata.attributes.each_row_is_a }}</p>
 
         <h2><strong>Columns:</strong> </h2>
     <ul>

--- a/dcpy/lifecycle/package/resources/data_dictionary_template.jinja
+++ b/dcpy/lifecycle/package/resources/data_dictionary_template.jinja
@@ -2,26 +2,25 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Metadata</title>
+    <title>{{ metadata.attributes.display_name }}</title>
 </head>
 
 <body>
-    <h1>{{ metadata.attributes.display_name }}</h1>
-
-    <h2><strong>Description:</strong> </h2>
+    <h1>Data Dictionary</h1>
+    <h2><strong>Description</strong> </h2>
     <p>{{ metadata.attributes.description }}</p>
 
-    <h2><strong>Tags:</strong></h2>
+    <h2><strong>Tags</strong></h2>
     <ul>
         {% for tag in metadata.attributes.tags %}
         <li>{{ tag }}</li>
         {% endfor %}
     </ul>
 
-    <h2><strong>Each row is a: </strong> </h2>
+    <h2><strong>Each row is a</strong> </h2>
     <p>{{ metadata.attributes.each_row_is_a }}</p>
 
-        <h2><strong>Columns:</strong> </h2>
+        <h2><strong>Columns</strong> </h2>
     <ul>
         {% for col in metadata.columns %}
         <li>


### PR DESCRIPTION
related to #944

currently, some values from a dataset's yml file are missed

## before changes

![Screenshot 2024-08-29 at 2 08 05 PM](https://github.com/user-attachments/assets/7439341e-3aa3-4501-af0b-c3e55a00476e)

## after changes

![Screenshot 2024-08-29 at 2 04 22 PM](https://github.com/user-attachments/assets/7e3d329e-8e7c-4655-9e00-ff35d67b9fd6)
