### PR TITLE
Data Lifecycle Monitoring table

### DIFF
--- a/.github/workflows/promote_to_draft.yml
+++ b/.github/workflows/promote_to_draft.yml
@@ -79,6 +79,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup
         working-directory: ./

--- a/dcpy/configuration.py
+++ b/dcpy/configuration.py
@@ -8,3 +8,20 @@ DEV_FLAG = env.get("DEV_FLAG") == "true"
 
 RECIPES_BUCKET = env.get("RECIPES_BUCKET")
 PUBLISHING_BUCKET = env.get("PUBLISHING_BUCKET")
+
+LOGGING_DB = "edm-qaqc"
+LOGGING_SCHEMA = "product_data"
+LOGGING_TABLE_NAME = "event_logging"
+PRODUCTS_TO_LOG = [
+    "db-cbbr",
+    "db-checkbook",
+    "db-colp",
+    "db-cpdb",
+    "db-developments",
+    "db-facilities",
+    "db-green-fast-track",
+    "db-pluto",
+    "db-template",
+    "db-zoningtaxlots",
+]
+IGNORED_LOGGING_BUILDS = ["nightly_qa"]

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -13,15 +13,15 @@ from urllib.parse import urlencode, urljoin
 import yaml
 from zipfile import ZipFile
 
-from dcpy.configuration import PUBLISHING_BUCKET, CI, BUILD_NAME
+from dcpy.configuration import PUBLISHING_BUCKET, CI, BUILD_NAME, DEV_FLAG
 from dcpy.models.connectors.edm.publishing import (
     ProductKey,
     PublishKey,
     DraftKey,
     BuildKey,
 )
-from dcpy.models.lifecycle.builds import BuildMetadata
-from dcpy.utils import s3, git, versions
+from dcpy.models.lifecycle.builds import BuildMetadata, EventLog, EventType
+from dcpy.utils import s3, git, versions, metadata, postgres
 from dcpy.utils.logging import logger
 
 assert (
@@ -30,6 +30,22 @@ assert (
 BUCKET = PUBLISHING_BUCKET
 
 BASE_DO_URL = f"https://cloud.digitalocean.com/spaces/{BUCKET}"
+LOGGING_DB = "edm-qaqc"
+LOGGING_SCHEMA = "product_data"
+LOGGING_TABLE_NAME = "event_logging"
+PRODUCTS_TO_LOG = [
+    "db-cbbr",
+    "db-checkbook",
+    "db-colp",
+    "db-cpdb",
+    "db-developments",
+    "db-facilities",
+    "db-green-fast-track",
+    "db-pluto",
+    "db-template",
+    "db-zoningtaxlots",
+]
+IGNORED_LOGGING_BUILDS = ["nightly_qa"]
 
 
 def get_build_metadata(product_key: ProductKey) -> BuildMetadata:
@@ -261,6 +277,18 @@ def upload_build(
     logger.info(f'Uploading {output_path} to {build_key.path} with ACL "{acl}"')
     upload(output_path, build_key, acl=acl, max_files=max_files)
 
+    version = get_version(build_key)
+    event_metadata = EventLog(
+        event_type=EventType.BUILD,
+        product=build_key.product,
+        release_version=version,
+        new_path=build_key.path,
+        old_path=None,
+        run_details=metadata.get_run_details(),
+    )
+    if build_key.build not in IGNORED_LOGGING_BUILDS:
+        log_event_in_db(event_metadata)
+
     return build_key
 
 
@@ -307,6 +335,16 @@ def promote_to_draft(
     )
     if not keep_build:
         s3.delete(BUCKET, source)
+
+    event_metadata = EventLog(
+        event_type=EventType.PROMOTE_TO_DRAFT,
+        product=draft_key.product,
+        release_version=draft_key.version,
+        new_path=draft_key.path,
+        old_path=build_key.path,
+        run_details=metadata.get_run_details(),
+    )
+    log_event_in_db(event_metadata)
 
     return draft_key
 
@@ -421,6 +459,16 @@ def publish(
             filepath="build_metadata.json",
         )
         logger.info(f"Downloaded build_metadata.json from {publish_key.path}")
+
+    event_metadata = EventLog(
+        event_type=EventType.PUBLISH,
+        product=publish_key.product,
+        release_version=draft_key.version,  # this is release version, not patched
+        new_path=publish_key.path,
+        old_path=draft_key.path,
+        run_details=metadata.get_run_details(),
+    )
+    log_event_in_db(event_metadata)
 
     return publish_key
 
@@ -613,6 +661,44 @@ def download_gis_dataset(dataset_name: str, version: str, target_folder: Path):
     return file_path
 
 
+def log_event_in_db(event_details: EventLog) -> None:
+    """
+    Logs event metadata to a PostgreSQL database if the product is in the approved list
+    of products and not in a development environment. Otherwise it skips logging.
+    """
+
+    if event_details.product not in PRODUCTS_TO_LOG:
+        logger.warn(
+            f"❗️ Product {event_details.product} not on the list of products to log in db. Skipping event metadata logging..."
+        )
+        return
+    if DEV_FLAG:
+        logger.info("DEV_FLAG env var found, skipping event metadata logging")
+        return
+    logger.info(
+        f"Logging event '{event_details.event_type}' metadata for product {event_details.product} in db..."
+    )
+    pg_client = postgres.PostgresClient(database=LOGGING_DB, schema=LOGGING_SCHEMA)
+    query = f"""
+        INSERT INTO {LOGGING_SCHEMA}.{LOGGING_TABLE_NAME} 
+        (product, version, event, path, old_path, timestamp, runner_type, runner, custom_fields)
+        VALUES 
+        (:product, :version, :event, :path, :old_path, :timestamp, :runner_type, :runner, :custom_fields)
+        """
+    pg_client.execute_query(
+        query,
+        product=event_details.product,
+        version=event_details.release_version,
+        event=event_details.event_type.value,
+        path=event_details.new_path,
+        old_path=event_details.old_path,
+        timestamp=event_details.run_details.timestamp,
+        runner_type=event_details.run_details.type,
+        runner=event_details.run_details.runner_string,
+        custom_fields=json.dumps(event_details.custom_fields),
+    )
+
+
 app = typer.Typer(add_completion=False)
 
 
@@ -736,9 +822,10 @@ def _cli_wrapper_promote_to_draft(
     acl: str = typer.Option(None, "-a", "--acl", help="Access level of file in s3"),
 ):
     acl_literal = s3.string_as_acl(acl)
-    logger.info(f'Promoting {product}/build/{build} to draft with ACL "{acl}"')
+    build_key = BuildKey(product, build)
+    logger.info(f'Promoting {build_key.path} to draft with ACL "{acl}"')
     promote_to_draft(
-        build_key=BuildKey(product, build),
+        build_key=build_key,
         draft_revision_summary=draft_summary,
         acl=acl_literal,
     )

--- a/dcpy/migrations/create_event_logging.sql
+++ b/dcpy/migrations/create_event_logging.sql
@@ -1,0 +1,19 @@
+/*
+This SQL file contains queries for creating the event_logging table.
+The table is used to track the lifecycle of data products, 
+from building to publishing, and is part of the de-qaqc database.
+*/
+
+CREATE TABLE product_data.event_logging (
+    product VARCHAR(50) NOT NULL,
+    version VARCHAR(20) NOT NULL,
+    event VARCHAR(30) NOT NULL,
+    path TEXT NOT NULL,
+    old_path TEXT,
+    runner_type VARCHAR,
+    runner VARCHAR,
+    timestamp TIMESTAMP NOT NULL,
+    custom_fields JSONB
+);
+
+CREATE INDEX idx_product_version_path ON product_data.event_logging (product, version, path);

--- a/dcpy/models/lifecycle/builds.py
+++ b/dcpy/models/lifecycle/builds.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, field_serializer
 from typing import List
 
 from dcpy.utils import versions
+from dcpy.utils.metadata import RunDetails
 from dcpy.models.connectors.edm import recipes
 
 
@@ -99,6 +100,22 @@ class LoadResult(BaseModel, extra="forbid"):
     name: str
     build_name: str
     datasets: dict[str, ImportedDataset]
+
+
+class EventType(StrEnum):
+    BUILD = "build"
+    PROMOTE_TO_DRAFT = "promote_to_draft"
+    PUBLISH = "publish"
+
+
+class EventLog(BaseModel, extra="forbid"):
+    event_type: EventType
+    product: str
+    release_version: str
+    new_path: str
+    old_path: str | None
+    run_details: RunDetails
+    custom_fields: dict = {}
 
 
 class BuildMetadata(BaseModel, extra="forbid"):

--- a/dcpy/models/lifecycle/builds.py
+++ b/dcpy/models/lifecycle/builds.py
@@ -109,13 +109,19 @@ class EventType(StrEnum):
 
 
 class EventLog(BaseModel, extra="forbid"):
-    event_type: EventType
+    event: EventType
     product: str
-    release_version: str
-    new_path: str
+    version: str
+    path: str
     old_path: str | None
-    run_details: RunDetails
+    timestamp: datetime
+    runner_type: str
+    runner: str
     custom_fields: dict = {}
+
+    @field_serializer("timestamp")
+    def _serialize_timestamp(self, timestamp: datetime, _info) -> str:
+        return timestamp.isoformat()
 
 
 class BuildMetadata(BaseModel, extra="forbid"):

--- a/dcpy/test/conftest.py
+++ b/dcpy/test/conftest.py
@@ -92,7 +92,7 @@ def mock_data_constants():
     yield constants
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def create_temp_filesystem(mock_data_constants):
     """Creates a new directory with files and removes it upon test completion.
     The directory is created and removed once per script ('module' scope)."""

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import pandas as pd
 from pathlib import Path
 import os
+import json
 import pytest
 from unittest.mock import patch
 
@@ -163,6 +164,38 @@ def test_upload_build_file_not_found(create_buckets, mock_data_constants):
             build=TEST_BUILD,
             acl=TEST_ACL,
         )
+
+
+@patch("dcpy.connectors.edm.publishing.log_event_in_db")
+def test_upload_build_validate_logging_logic(
+    mock_log_event,
+    create_buckets,
+    create_temp_filesystem,
+    mock_data_constants,
+):
+    data_path = mock_data_constants["TEST_DATA_DIR"]
+    build_to_ignore = publishing.IGNORED_LOGGING_BUILDS[0]
+    publishing.upload_build(
+        data_path,
+        product=TEST_PRODUCT_NAME,
+        build=build_to_ignore,
+        acl=TEST_ACL,
+    )
+    # Ensure log_event_in_db is not called since the build is ignored
+    mock_log_event.assert_not_called()
+
+    mock_log_event.reset_mock()
+
+    non_ignored_build = TEST_BUILD
+    assert non_ignored_build not in publishing.IGNORED_LOGGING_BUILDS  # sanity check
+    publishing.upload_build(
+        data_path,
+        product=TEST_PRODUCT_NAME,
+        build=non_ignored_build,
+        acl=TEST_ACL,
+    )
+    # Ensure log_event_in_db is called
+    mock_log_event.assert_called_once()
 
 
 def test_publish_patch(create_buckets, create_temp_filesystem, mock_data_constants):
@@ -560,3 +593,64 @@ def test_validate_or_patch_version_version_already_exists(get_published_versions
             version=version_to_patch,
             is_patch=False,
         )
+
+
+@pytest.fixture(scope="function")
+def mock_event_log():
+    return publishing.EventLog(
+        product=TEST_PRODUCT_NAME,
+        release_version=TEST_VERSION,
+        event_type=publishing.EventType.BUILD,
+        new_path="/new/path",
+        old_path="/old/path",
+        run_details=publishing.metadata.get_run_details(),
+        custom_fields={"key": "value"},
+    )
+
+
+@patch("dcpy.connectors.edm.publishing.postgres.PostgresClient")
+def test_log_event_skipped_conditions(mock_db_client, mock_event_log):
+    """
+    Test the `log_event_in_db` function to ensure that no database query is executed
+    when the product is not in the allowed list or when the DEV_FLAG is set to True.
+    """
+    mock_db_client_instance = mock_db_client.return_value
+    with patch("dcpy.connectors.edm.publishing.DEV_FLAG", False):
+        assert mock_event_log.product not in publishing.PRODUCTS_TO_LOG  # sanity check
+        publishing.log_event_in_db(mock_event_log)
+        mock_db_client_instance.execute_query.assert_not_called()
+
+    with patch("dcpy.connectors.edm.publishing.DEV_FLAG", True):
+        mock_event_log.product = "db-template"
+        assert mock_event_log.product in publishing.PRODUCTS_TO_LOG  # sanity check
+        publishing.log_event_in_db(mock_event_log)
+        mock_db_client_instance.execute_query.assert_not_called()
+
+
+@patch("dcpy.connectors.edm.publishing.postgres.PostgresClient")
+def test_log_event_success(mock_db_client, mock_event_log):
+    mock_db_client_instance = mock_db_client.return_value
+
+    mock_event_log.product = "db-template"
+    assert mock_event_log.product in publishing.PRODUCTS_TO_LOG  # sanity check
+
+    publishing.log_event_in_db(mock_event_log)
+
+    query = f"""
+        INSERT INTO {publishing.LOGGING_SCHEMA}.{publishing.LOGGING_TABLE_NAME} 
+        (product, version, event, path, old_path, timestamp, runner_type, runner, custom_fields)
+        VALUES 
+        (:product, :version, :event, :path, :old_path, :timestamp, :runner_type, :runner, :custom_fields)
+        """
+    mock_db_client_instance.execute_query.assert_called_once_with(
+        query,
+        product=mock_event_log.product,
+        version=mock_event_log.release_version,
+        event=mock_event_log.event_type.value,
+        path=mock_event_log.new_path,
+        old_path=mock_event_log.old_path,
+        timestamp=mock_event_log.run_details.timestamp,
+        runner_type=mock_event_log.run_details.type,
+        runner=mock_event_log.run_details.runner_string,
+        custom_fields=json.dumps(mock_event_log.custom_fields),
+    )

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -597,13 +597,16 @@ def test_validate_or_patch_version_version_already_exists(get_published_versions
 
 @pytest.fixture(scope="function")
 def mock_event_log():
+    run_details = publishing.metadata.get_run_details()
     return publishing.EventLog(
         product=TEST_PRODUCT_NAME,
-        release_version=TEST_VERSION,
-        event_type=publishing.EventType.BUILD,
-        new_path="/new/path",
+        version=TEST_VERSION,
+        event=publishing.EventType.BUILD,
+        path="/new/path",
         old_path="/old/path",
-        run_details=publishing.metadata.get_run_details(),
+        timestamp=run_details.timestamp,
+        runner_type=run_details.type,
+        runner=run_details.runner_string,
         custom_fields={"key": "value"},
     )
 
@@ -645,12 +648,12 @@ def test_log_event_success(mock_db_client, mock_event_log):
     mock_db_client_instance.execute_query.assert_called_once_with(
         query,
         product=mock_event_log.product,
-        version=mock_event_log.release_version,
-        event=mock_event_log.event_type.value,
-        path=mock_event_log.new_path,
+        version=mock_event_log.version,
+        event=mock_event_log.event.value,
+        path=mock_event_log.path,
         old_path=mock_event_log.old_path,
-        timestamp=mock_event_log.run_details.timestamp,
-        runner_type=mock_event_log.run_details.type,
-        runner=mock_event_log.run_details.runner_string,
+        timestamp=mock_event_log.timestamp,
+        runner_type=mock_event_log.runner_type,
+        runner=mock_event_log.runner,
         custom_fields=json.dumps(mock_event_log.custom_fields),
     )

--- a/products/checkbook/build_scripts/export.py
+++ b/products/checkbook/build_scripts/export.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     with open("version.txt", "w") as f:
         f.write(str(date.today()))
     build_environment = git.branch()
-    publishing.upload(
-        OUTPUT_DIR, publishing.BuildKey(PRODUCT, build_environment), acl="public-read"
+    publishing.upload_build(
+        OUTPUT_DIR, PRODUCT, acl="public-read", build=build_environment
     )
     print("Finished export!")

--- a/products/template/build_scripts/export.py
+++ b/products/template/build_scripts/export.py
@@ -87,4 +87,6 @@ def export():
 if __name__ == "__main__":
     generate_metadata()
     export()
-    publishing.upload(OUTPUT_DIR, BUILD_KEY, acl="public-read")
+    publishing.upload_build(
+        OUTPUT_DIR, BUILD_KEY.product, acl="public-read", build=BUILD_KEY.build
+    )


### PR DESCRIPTION
Related discussion on implementation [here](https://github.com/NYCPlanning/data-engineering/discussions/1083).

Closes #958. 

## What
1. Refactor `upload` CLI which is exclusively responsible for uploading product builds to S3. I moved all CLI logic into a separate function and added tests. This is done to increase test coverage.

2. Update "event" functions (upload build, promote, publish) to return a `ProductKey`. Previously, these functions didn't return anything. The returned value can be used for logging, specifically identifying old and new stages. For example, the function `publish` now returns `PublishKey`

3. Implement logging of data lifecycle events (upload build to s3, promote to draft folder, and publish) in db
    * Create pydentic `EventLog` model to represent an event. All the model fields go into monitoring table. I chose the model instead of event individual fields for validating data and keeping myself sane. 
    * Create a helper function `publishing.log_event_in_db()` to enter `EventLog` to database
    * Update build, promote to draft, publish functions to log an event using `publishing.log_event_in_db()`
    * The db table for lifecycle monitoring was manually created. There is no code creating the table - don't see a need for it. 
    * Create **unit** tests for `publishing.log_event_in_db()`. I couldn't find something similar to `moto` package but for `posgres` (or any database really) to mock interactions with a database.

## Testing functions interacting with a database
* As noted in # 3, I implemented unit tests for logging an event in db; these tests really just check whether a call was made to execute a query given various conditions. It doesn't check whether a table exists or a record is added correctly. To test the latter, we need integration tests. Since we don't have db integration tests yet, it would be nice to first decide on an approach and implement these tests uniformly in a separate PR.

* Some thoughts on how we could implement integration tests for postgres  code. 
   * use a local host db inside of a container or on our local machines to create test databases
   * another option is to create a test db in our production db and run tests there. Don't love this option personally because then results may not be deterministic due to connection issues
   * use ORM models to interact with a database. These models can also be used to set up test tables.

## Table
I ran [`build`](https://github.com/NYCPlanning/data-engineering/actions/runs/10799515995/job/29955436907), [`promote_to_draft`](https://github.com/NYCPlanning/data-engineering/actions/runs/10799695340/job/29956026749), and [`publish`](https://github.com/NYCPlanning/data-engineering/actions/runs/10799737146/job/29956165579) GH actions on `db-template` product. Resulting table (you can find this table under `edm-qaqc` db, `product_data.event_logging` table) below: 

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/ebd4d21f-11b5-4bde-9dca-d599caa156b7">

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/3b47b5e6-305e-4c3e-95f2-10f778442191">

One of the records came from this PR tests.