### PR TITLE
Utilities to create dev buckets

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -116,6 +116,7 @@ jobs:
           mypy apps/qa/src
           mypy products/facilities
           mypy products/template
+          mypy admin/ops
 
   template-db:
     if: (inputs.path_filter == '') || contains(inputs.path_filter, 'template')

--- a/admin/ops/setup_dev_bucket.py
+++ b/admin/ops/setup_dev_bucket.py
@@ -3,6 +3,7 @@ import importlib
 import os
 from pathlib import Path
 import typer
+from typing import Literal
 
 PROD_RECIPES_BUCKET = "edm-recipes"
 PROD_PUBLISHING_BUCKET = "edm-publishing"
@@ -24,6 +25,7 @@ from dcpy.lifecycle.builds import plan
 
 ROOT_PATH = Path(__file__).parent.parent.parent
 BUCKET_PREFIX = "de-dev-"
+ACL: Literal["private"] = "private"
 PRODUCTS = [
     "db-cbbr",
     "db-colp",
@@ -57,7 +59,7 @@ def resolve_latest_recipe(
         bucket=target_bucket,
         source_path=input.s3_folder_key("datasets") + "/",
         target_path=resolved.s3_folder_key("datasets") + "/",
-        acl="private",
+        acl=ACL,
     )
 
 
@@ -79,7 +81,7 @@ def resolve_latest_publish(target_bucket: str, data_product: str):
         bucket=target_bucket,
         source_path=input.path + "/",
         target_path=resolved.path + "/",
-        acl="private",
+        acl=ACL,
     )
 
 
@@ -98,7 +100,7 @@ def clone_recipe(
         target_bucket=target_bucket,
         source_path=f"{key.s3_path("datasets")}/",
         target_path=f"{key.s3_path("datasets")}/",
-        acl="private",
+        acl=ACL,
     )
     if version == "latest":
         resolve_latest_recipe(target_bucket, dataset_id)
@@ -155,7 +157,7 @@ def clone_data_products(
             target_bucket=target_bucket,
             source_path=key.path + "/",
             target_path=key.path + "/",
-            acl="private",
+            acl=ACL,
         )
 
         resolve_latest_publish(target_bucket, product)
@@ -176,7 +178,7 @@ def clone_data_product_by_key(
         target_bucket=target_bucket,
         source_path=key.path + "/",
         target_path=key.path + "/",
-        acl="private",
+        acl=ACL,
     )
     if include_recipe_datasets:
         for _index, row in publishing.get_source_data_versions(key).iterrows():
@@ -193,7 +195,7 @@ def setup(id: str, clean: bool = False) -> str:
     if bucket not in [
         bucket["Name"] for bucket in s3.client().list_buckets()["Buckets"]
     ]:
-        s3.client().create_bucket(Bucket=bucket, ACL="private")
+        s3.client().create_bucket(Bucket=bucket, ACL=ACL)
     else:
         if not clean:
             raise Exception(

--- a/admin/ops/setup_dev_bucket.py
+++ b/admin/ops/setup_dev_bucket.py
@@ -18,7 +18,6 @@ from dcpy.models.connectors.edm.publishing import (
     PublishKey,
 )
 from dcpy.utils import s3
-from dcpy.utils.logging import logger
 from dcpy.connectors.edm import recipes, publishing
 from dcpy.lifecycle.builds import plan
 

--- a/admin/ops/setup_dev_bucket.py
+++ b/admin/ops/setup_dev_bucket.py
@@ -138,8 +138,8 @@ def clone_recipes_latest(
     datasets = get_subfolders(bucket=PROD_RECIPES_BUCKET, prefix="datasets/")
     if include:
         datasets = include
-    if exclude == "exclude":
-        datasets = [ds for ds in datasets if ds not in datasets]
+    if exclude:
+        datasets = [ds for ds in datasets if ds not in exclude]
 
     for ds in datasets:
         clone_recipe(target_bucket, ds)

--- a/admin/ops/setup_dev_bucket.py
+++ b/admin/ops/setup_dev_bucket.py
@@ -24,7 +24,7 @@ from dcpy.lifecycle.builds import plan
 
 
 ROOT_PATH = Path(__file__).parent.parent.parent
-BUCKET_PREFIX = "de-dev-"
+DEV_BUCKET_PREFIX = "de-dev-"
 ACL: Literal["private"] = "private"
 PRODUCTS = [
     "db-cbbr",
@@ -54,7 +54,7 @@ def resolve_latest_recipe(
     resolved = recipes.Dataset(name=ds, version=recipes.get_latest_version(ds))
     os.environ["RECIPES_BUCKET"] = PROD_RECIPES_BUCKET
     importlib.reload(configuration)
-    assert target_bucket.startswith(BUCKET_PREFIX)
+    assert target_bucket.startswith(DEV_BUCKET_PREFIX)
     s3.copy_folder(
         bucket=target_bucket,
         source_path=input.s3_folder_key("datasets") + "/",
@@ -191,7 +191,7 @@ def setup(id: str, clean: bool = False) -> str:
     Creates bucket if it doesn't exist.
     If clean flag provided, deletes all objects within bucket
     """
-    bucket = f"{BUCKET_PREFIX}{id}"
+    bucket = f"{DEV_BUCKET_PREFIX}{id}"
     if bucket not in [
         bucket["Name"] for bucket in s3.client().list_buckets()["Buckets"]
     ]:
@@ -204,14 +204,14 @@ def setup(id: str, clean: bool = False) -> str:
         aws_s3_endpoint = os.environ.get("AWS_S3_ENDPOINT")
         aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
         aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
-        assert bucket.startswith(BUCKET_PREFIX)
+        assert bucket.startswith(DEV_BUCKET_PREFIX)
         bucket_obj = boto3.resource(
             "s3",
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             endpoint_url=aws_s3_endpoint,
         ).Bucket(bucket)
-        assert bucket_obj.name.startswith(BUCKET_PREFIX)
+        assert bucket_obj.name.startswith(DEV_BUCKET_PREFIX)
         bucket_obj.objects.all().delete()
     return bucket
 
@@ -225,7 +225,7 @@ def _recipe_single(
     dataset_id: str = typer.Option(None, "--dataset", "-d"),
     version: str = typer.Option(None, "--version", "-v"),
 ):
-    clone_recipe(f"{BUCKET_PREFIX}{target_bucket_id}", dataset_id, version)
+    clone_recipe(f"{DEV_BUCKET_PREFIX}{target_bucket_id}", dataset_id, version)
 
 
 @app.command("recipes_all")
@@ -234,7 +234,7 @@ def _recipes(
     include: list[str] | None = typer.Option(None, "--include", "-i"),
     exclude: list[str] | None = typer.Option(None, "--exclude", "-e"),
 ):
-    clone_recipes_latest(f"{BUCKET_PREFIX}{target_bucket_id}", include, exclude)
+    clone_recipes_latest(f"{DEV_BUCKET_PREFIX}{target_bucket_id}", include, exclude)
 
 
 @app.command("product")
@@ -242,7 +242,7 @@ def _publishing_single(
     target_bucket_id: str = typer.Option(None, "--bucket-id"),
     product: str = typer.Option(None, "--product", "-p"),
 ):
-    clone_data_products(f"{BUCKET_PREFIX}{target_bucket_id}", [product])
+    clone_data_products(f"{DEV_BUCKET_PREFIX}{target_bucket_id}", [product])
 
 
 @app.command("publishing_build_key")
@@ -253,7 +253,7 @@ def _build_key(
     include_sources: bool = typer.Option(False, "--include-sources"),
 ):
     clone_data_product_by_key(
-        f"{BUCKET_PREFIX}{target_bucket_id}",
+        f"{DEV_BUCKET_PREFIX}{target_bucket_id}",
         BuildKey(product=product, build=build),
         include_recipe_datasets=include_sources,
     )
@@ -268,7 +268,7 @@ def _draft_key(
     include_sources: bool = typer.Option(False, "--include-sources"),
 ):
     clone_data_product_by_key(
-        f"{BUCKET_PREFIX}{target_bucket_id}",
+        f"{DEV_BUCKET_PREFIX}{target_bucket_id}",
         DraftKey(product=product, version=version, revision=revision),
         include_recipe_datasets=include_sources,
     )
@@ -282,7 +282,7 @@ def _publish_key(
     include_sources: bool = typer.Option(False, "--include-sources"),
 ):
     clone_data_product_by_key(
-        f"{BUCKET_PREFIX}{target_bucket_id}",
+        f"{DEV_BUCKET_PREFIX}{target_bucket_id}",
         PublishKey(product=product, version=version),
         include_recipe_datasets=include_sources,
     )
@@ -293,7 +293,7 @@ def _publish(
     target_bucket_id: str = typer.Option(None, "--bucket-id"),
 ):
     clone_data_products(
-        f"{BUCKET_PREFIX}{target_bucket_id}",
+        f"{DEV_BUCKET_PREFIX}{target_bucket_id}",
         PRODUCTS,
         include_recipe_datasets=False,
     )
@@ -316,7 +316,7 @@ def _standard(
     assert set(products).issubset(set(PRODUCTS))
 
     clone_data_products(
-        f"{BUCKET_PREFIX}{target_bucket_id}",
+        f"{DEV_BUCKET_PREFIX}{target_bucket_id}",
         products,
         include_recipe_datasets=True,
     )

--- a/admin/ops/setup_dev_bucket.py
+++ b/admin/ops/setup_dev_bucket.py
@@ -1,0 +1,340 @@
+import boto3
+import importlib
+import os
+from pathlib import Path
+import typer
+
+PROD_RECIPES_BUCKET = "edm-recipes"
+PROD_PUBLISHING_BUCKET = "edm-publishing"
+os.environ["RECIPES_BUCKET"] = PROD_RECIPES_BUCKET
+os.environ["PUBLISHING_BUCKET"] = PROD_PUBLISHING_BUCKET
+
+from dcpy import configuration
+from dcpy.models.connectors.edm.recipes import DatasetKey
+from dcpy.models.connectors.edm.publishing import (
+    ProductKey,
+    BuildKey,
+    DraftKey,
+    PublishKey,
+)
+from dcpy.utils import s3
+from dcpy.utils.logging import logger
+from dcpy.connectors.edm import recipes, publishing
+from dcpy.lifecycle.builds import plan
+
+
+ROOT_PATH = Path(__file__).parent.parent
+BUCKET_PREFIX = "de-dev-"
+PRODUCTS = [
+    "db-cbbr",
+    "db-colp",
+    "db-cpdb",
+    "db-developments",
+    "db-facilities",
+    "db-green_fast_track",
+    "db-template",
+    "db-pluto",
+    "db-zoningtaxlots",
+]
+
+
+def copy_folder(
+    source_bucket: str,
+    target_bucket: str,
+    path: str,
+) -> None:
+    """Copies folder from a production bucket to a dev bucket"""
+    assert target_bucket.startswith(BUCKET_PREFIX)
+    logger.info(f"Copying {source_bucket}/{path} to ./tmp")
+    s3.download_folder(
+        source_bucket, prefix=path, export_path=Path("./tmp/dev_bucket_setup")
+    )
+    logger.info(f"Copying ./tmp to {target_bucket}/{path}")
+    s3.upload_folder(
+        target_bucket,
+        Path(f"./tmp/dev_bucket_setup/{path}"),
+        Path(path),
+        "private",
+        contents_only=True,
+    )
+
+
+def resolve_latest_recipe(
+    target_bucket: str,
+    ds: str,
+):
+    """
+    Within a dev bucket, resolves/copies the dataset currently in "latest"
+    into its versioned folder under "datasets/{dataset_id}"
+    """
+    os.environ["RECIPES_BUCKET"] = target_bucket
+    importlib.reload(configuration)
+    assert PROD_RECIPES_BUCKET != PROD_RECIPES_BUCKET
+    input = recipes.Dataset(name=ds, version="latest")
+    resolved = recipes.Dataset(name=ds, version=recipes.get_latest_version(ds))
+    os.environ["RECIPES_BUCKET"] = PROD_RECIPES_BUCKET
+    importlib.reload(configuration)
+    assert target_bucket.startswith(BUCKET_PREFIX)
+    s3.copy_folder(
+        target_bucket,
+        input.s3_folder_key("datasets") + "/",
+        resolved.s3_folder_key("datasets") + "/",
+        "private",
+    )
+
+
+def resolve_latest_publish(target_bucket: str, data_product: str):
+    """
+    Within a dev bucket, resolves/copies the data product currently in "publish/latest"
+    into its versioned folder within "{product}/publish"
+    """
+    os.environ["PUBLISHING_BUCKET"] = target_bucket
+    importlib.reload(configuration)
+    assert configuration.PUBLISHING_BUCKET != PROD_PUBLISHING_BUCKET
+    input = PublishKey(product=data_product, version="latest")
+    latest = publishing.get_latest_version(data_product)
+    assert latest
+    resolved = PublishKey(product=data_product, version=latest)
+    os.environ["PUBLISHING_BUCKET"] = PROD_PUBLISHING_BUCKET
+    importlib.reload(configuration)
+    s3.copy_folder(
+        target_bucket,
+        input.path + "/",
+        resolved.path + "/",
+        "private",
+    )
+
+
+def clone_recipe(
+    target_bucket: str,
+    dataset_id: str,
+    version: str = "latest",
+):
+    """
+    Given a dataset id, copy it from edm-recipes
+    If provided version is "latest", also resolve it to its versioned folder
+    """
+    key = DatasetKey(name=dataset_id, version=version)
+    copy_folder(
+        source_bucket=PROD_RECIPES_BUCKET,
+        target_bucket=target_bucket,
+        path=f"{key.s3_path("datasets")}/",
+    )
+    if version == "latest":
+        resolve_latest_recipe(target_bucket, dataset_id)
+
+
+def clone_recipes_latest(
+    target_bucket: str,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+):
+    """
+    Clone latest versions of various recipe datasets from production bucket to dev bucket
+    By default, targets all datasets
+    Specific datasets can be excluded or included with `include` or 'exclude_dataset`
+    If `include` is specified, only the specified datasets are cloned
+    """
+    if include and exclude:
+        raise ValueError("Only one of `include` and `exclude` may be provided")
+    datasets = s3.get_subfolders(bucket=PROD_RECIPES_BUCKET, prefix="datasets/")
+    if include:
+        datasets = include
+    if exclude == "exclude":
+        datasets = [ds for ds in datasets if ds not in datasets]
+
+    for ds in datasets:
+        clone_recipe(target_bucket, ds)
+
+
+def clone_data_products(
+    target_bucket: str,
+    data_products: list[str],
+    include_recipe_datasets: bool = True,
+):
+    """
+    Clone latest published version of each provided data product
+    If `include_recipe_datasets`, input datasets for all provided products are collected and then cloned (latest versions only)
+
+    This is a good target if setting up a dev bucket to work on enhancements for a data product
+    """
+    if include_recipe_datasets:
+        recipe_datasets = []
+        for product in data_products:
+            recipe = plan.recipe_from_yaml(
+                ROOT_PATH / "products" / product.strip("db-") / "recipe.yml"
+            )
+            recipe_datasets += [ds.name for ds in recipe.inputs.datasets]
+        for ds in set(recipe_datasets):
+            clone_recipe(target_bucket, ds)
+
+    for product in data_products:
+        key = PublishKey(product=product, version="latest")
+        copy_folder(
+            source_bucket=PROD_PUBLISHING_BUCKET,
+            target_bucket=target_bucket,
+            path=key.path + "/",
+        )
+
+        resolve_latest_publish(target_bucket, product)
+
+
+def clone_data_product_by_key(
+    target_bucket: str,
+    key: ProductKey,
+    include_recipe_datasets: bool = False,
+):
+    """
+    Clone specific product key and optionally the input datasets that went into it
+
+    This is a good target if working on an enhancement that involves rebuilding a specific product instance
+    """
+    copy_folder(
+        source_bucket=PROD_PUBLISHING_BUCKET,
+        target_bucket=target_bucket,
+        path=key.path + "/",
+    )
+    if include_recipe_datasets:
+        for _index, row in publishing.get_source_data_versions(key).iterrows():
+            clone_recipe(target_bucket, row["datalibrary_name"], row["version"])
+
+
+def setup(id: str, clean: bool = False) -> str:
+    """
+    Sets up a dev bucket
+    Creates bucket if it doesn't exist.
+    If clean flag provided, deletes all objects within bucket
+    """
+    bucket = f"{BUCKET_PREFIX}{id}"
+    if bucket not in [
+        bucket["Name"] for bucket in s3.client().list_buckets()["Buckets"]
+    ]:
+        s3.client().create_bucket(Bucket=bucket, ACL="private")
+    else:
+        if not clean:
+            raise Exception(
+                f"bucket {bucket} already exists. specify '-c' to clean contents of bucket"
+            )
+        aws_s3_endpoint = os.environ.get("AWS_S3_ENDPOINT")
+        aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
+        aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+        assert bucket.startswith(BUCKET_PREFIX)
+        bucket_obj = boto3.resource(
+            "s3",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            endpoint_url=aws_s3_endpoint,
+        ).Bucket(bucket)
+        assert bucket_obj.name.startswith(BUCKET_PREFIX)
+        bucket_obj.objects.all().delete()
+    return bucket
+
+
+app = typer.Typer()
+
+
+@app.command("recipe_single")
+def _recipe_single(
+    target_bucket_id: str = typer.Option(None, "--bucket-id"),
+    dataset_id: str = typer.Option(None, "--dataset", "-d"),
+    version: str = typer.Option(None, "--version", "-v"),
+):
+    clone_recipe(f"{BUCKET_PREFIX}{target_bucket_id}", dataset_id, version)
+
+
+@app.command("recipes_all")
+def _recipes(
+    target_bucket_id: str = typer.Option(None, "--bucket-id"),
+    include: list[str] | None = typer.Option(None, "--include", "-i"),
+    exclude: list[str] | None = typer.Option(None, "--exclude", "-e"),
+):
+    clone_recipes_latest(f"{BUCKET_PREFIX}{target_bucket_id}", include, exclude)
+
+
+@app.command("product")
+def _publishing_single(
+    target_bucket_id: str = typer.Option(None, "--bucket-id"),
+    product: str = typer.Option(None, "--product", "-p"),
+):
+    clone_data_products(f"{BUCKET_PREFIX}{target_bucket_id}", [product])
+
+
+@app.command("publishing_build_key")
+def _build_key(
+    target_bucket_id: str = typer.Option(None, "--bucket-id"),
+    product: str = typer.Option(None, "--product", "-p"),
+    build: str = typer.Option(None, "--build", "-b"),
+    include_sources: bool = typer.Option(False, "--include-sources"),
+):
+    clone_data_product_by_key(
+        f"{BUCKET_PREFIX}{target_bucket_id}",
+        BuildKey(product=product, build=build),
+        include_recipe_datasets=include_sources,
+    )
+
+
+@app.command("publishing_draft_key")
+def _draft_key(
+    target_bucket_id: str = typer.Option(None, "--bucket-id"),
+    product: str = typer.Option(None, "--product", "-p"),
+    version: str = typer.Option(None, "--version", "-v"),
+    revision: str = typer.Option(None, "--revision", "-r"),
+    include_sources: bool = typer.Option(False, "--include-sources"),
+):
+    clone_data_product_by_key(
+        f"{BUCKET_PREFIX}{target_bucket_id}",
+        DraftKey(product=product, version=version, revision=revision),
+        include_recipe_datasets=include_sources,
+    )
+
+
+@app.command("publishing_publish_key")
+def _publish_key(
+    target_bucket_id: str = typer.Option(None, "--bucket-id"),
+    product: str = typer.Option(None, "--product", "-p"),
+    version: str = typer.Option(None, "--version", "-v"),
+    include_sources: bool = typer.Option(False, "--include-sources"),
+):
+    clone_data_product_by_key(
+        f"{BUCKET_PREFIX}{target_bucket_id}",
+        PublishKey(product=product, version=version),
+        include_recipe_datasets=include_sources,
+    )
+
+
+@app.command("publishing_all")
+def _publish(
+    target_bucket_id: str = typer.Option(None, "--bucket-id"),
+):
+    clone_data_products(
+        f"{BUCKET_PREFIX}{target_bucket_id}",
+        PRODUCTS,
+        include_recipe_datasets=False,
+    )
+
+
+@app.command("setup")
+def _setup(
+    target_bucket_id: str = typer.Argument(),
+    clean: bool = typer.Option(False, "--clean", "-c"),
+):
+    setup(target_bucket_id, clean)
+
+
+@app.command("standard")
+def _standard(
+    target_bucket_id: str = typer.Argument(),
+    products: list[str] = typer.Option(None, "--product", "-p"),
+):
+    assert products, "At least one product must be provided"
+    assert set(products).issubset(set(PRODUCTS))
+
+    clone_data_products(
+        f"{BUCKET_PREFIX}{target_bucket_id}",
+        products,
+        include_recipe_datasets=True,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/admin/ops/setup_dev_bucket.py
+++ b/admin/ops/setup_dev_bucket.py
@@ -22,7 +22,7 @@ from dcpy.connectors.edm import recipes, publishing
 from dcpy.lifecycle.builds import plan
 
 
-ROOT_PATH = Path(__file__).parent.parent
+ROOT_PATH = Path(__file__).parent.parent.parent
 BUCKET_PREFIX = "de-dev-"
 PRODUCTS = [
     "db-cbbr",
@@ -47,7 +47,7 @@ def resolve_latest_recipe(
     """
     os.environ["RECIPES_BUCKET"] = target_bucket
     importlib.reload(configuration)
-    assert PROD_RECIPES_BUCKET != PROD_RECIPES_BUCKET
+    assert configuration.RECIPES_BUCKET != PROD_RECIPES_BUCKET
     input = recipes.Dataset(name=ds, version="latest")
     resolved = recipes.Dataset(name=ds, version=recipes.get_latest_version(ds))
     os.environ["RECIPES_BUCKET"] = PROD_RECIPES_BUCKET
@@ -97,7 +97,7 @@ def clone_recipe(
         bucket=PROD_RECIPES_BUCKET,
         target_bucket=target_bucket,
         source_path=f"{key.s3_path("datasets")}/",
-        target_path=key.path + "/",
+        target_path=f"{key.s3_path("datasets")}/",
         acl="private",
     )
     if version == "latest":

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -119,12 +119,10 @@ def _dataset_type_from_extension(s: str) -> DatasetType | None:
 
 
 def get_file_types(dataset: Dataset) -> set[DatasetType]:
-    files = s3.get_filenames(
+    suffixes = s3.get_suffixes(
         bucket=BUCKET, prefix=f"{dataset.s3_folder_key(DATASET_FOLDER)}/{dataset.name}"
     )
-    valid_types = {
-        _dataset_type_from_extension(Path(file).suffix.strip(".")) for file in files
-    }
+    valid_types = {_dataset_type_from_extension(s.strip(".")) for s in suffixes}
     return {t for t in valid_types if t is not None}
 
 

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -350,7 +350,7 @@ def copy_folder(
         logger.info(
             f"Deleting any existing files in {target_bucket_}/{target} from bucket "
         )
-        delete(bucket, target)
+        delete(target_bucket_, target)
 
     logger.info(f"Copying {bucket}/{source} to {target_bucket_}/{target}")
     for obj in objects:

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -14,6 +14,7 @@ from rich.progress import (
     TextColumn,
     TimeRemainingColumn,
 )
+from tempfile import TemporaryDirectory
 import typer
 from typing import Any, Literal, TYPE_CHECKING, cast, get_args
 from pydantic import BaseModel
@@ -107,7 +108,12 @@ def list_buckets() -> list[str]:
 
 
 def get_bucket_region(bucket: str) -> str:
-    """Gets region (with subregion suffix) of specific bucket"""
+    """
+    Gets region (with subregion suffix) of specific bucket
+    DISCLAIMER - this might only work for Digital Ocean Spaces.
+        Documentation on format of these responses is not the clearest,
+        nor is there evident documentation on format of these id strings
+    """
     bucket_id = client().head_bucket(Bucket=bucket)["ResponseMetadata"]["RequestId"]
     return bucket_id.split("-")[-1]
 
@@ -266,11 +272,11 @@ def download_folder(
     *,
     include_prefix_in_export: bool = True,
 ) -> list[dict]:
-    """Download contents of folder from s3 recursively.
+    """
+    Download contents of folder from s3 recursively.
     Returns list of objects downloaded.
     """
-    if prefix[-1] != "/":
-        raise NotADirectoryError("prefix must be a folder path, ending with '/'")
+    prefix = _folderize(prefix)
 
     objs = list_objects(bucket, prefix)
     if not objs:
@@ -323,10 +329,28 @@ def upload_folder(
         upload_file(bucket, file, str(key), acl=acl, metadata=metadata)
 
 
+def copy_folder_via_download(
+    source_bucket: str, target_bucket: str, source_path: str, target_path: str, acl: ACL
+) -> None:
+    """If cross-bucket copying is not possible, this utility downloads and then uploads a folder"""
+    with TemporaryDirectory() as _dir:
+        dir = Path(_dir)
+        logger.info(f"Copying {source_bucket}/{source_path} to temporary directory")
+        download_folder(source_bucket, prefix=source_path, export_path=dir)
+        logger.info(f"Copying temporary directory to {target_bucket}/{source_path}")
+        upload_folder(
+            target_bucket,
+            dir / source_path,
+            Path(target_path),
+            acl,
+            contents_only=True,
+        )
+
+
 def copy_folder(
     bucket: str,
-    source: str,
-    target: str,
+    source_path: str,
+    target_path: str,
     acl: ACL,
     *,
     max_files: int = MAX_FILE_COUNT,
@@ -335,35 +359,44 @@ def copy_folder(
     keep_existing: bool = False,
 ) -> None:
     """Given bucket, prefix filter, and export path, download contents of folder from s3 recursively"""
-    if source[-1] != "/":
-        raise NotADirectoryError("prefix must be a folder path, ending with '/'")
-    target = _folderize(target)
+    source_path = _folderize(source_path)
+    target_path = _folderize(target_path)
 
-    objects = list_objects(bucket, source)
+    objects = list_objects(bucket, source_path)
     if max_files and (len(objects) > max_files):
         raise Exception(
-            f"{len(objects)} found in folder '{source}' which is greater than limit. Make sure target folder is correct, then supply 'max_files' arg"
+            f"{len(objects)} found in folder '{source_path}' which is greater than limit. Make sure target folder is correct, then supply 'max_files' arg"
         )
-
     target_bucket_ = target_bucket or bucket
     if not keep_existing:
         logger.info(
-            f"Deleting any existing files in {target_bucket_}/{target} from bucket "
+            f"Deleting any existing files in {target_bucket_}/{target_path} from bucket "
         )
-        delete(target_bucket_, target)
+        delete(target_bucket_, target_path)
 
-    logger.info(f"Copying {bucket}/{source} to {target_bucket_}/{target}")
-    for obj in objects:
-        key = obj["Key"].replace(source, "")
-        if key and (key[-1] != "/"):
-            copy_file(
-                bucket,
-                obj["Key"],
-                f"{target}{key}",
-                acl,
-                metadata=metadata,
-                target_bucket=target_bucket,
+    if target_bucket and get_bucket_region(bucket) != get_bucket_region(target_bucket):
+        if get_bucket_region(bucket) != get_bucket_region(target_bucket):
+            copy_folder_via_download(
+                bucket, target_bucket, source_path, target_path, acl
             )
+            return
+    else:
+        target_bucket = target_bucket or bucket
+
+        logger.info(f"Copying {bucket}/{source_path} to {target_bucket}/{target_path}")
+        for obj in objects:
+            key = obj["Key"].replace(source_path, "")
+            print(key)
+            print(target_path)
+            if key and (key[-1] != "/"):
+                copy_file(
+                    bucket,
+                    obj["Key"],
+                    f"{target_path}{key}",
+                    acl,
+                    metadata=metadata,
+                    target_bucket=target_bucket,
+                )
 
 
 def delete(bucket: str, path: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ ignore = ["D100", "D101", "D102", "D107", "D104", "D213", "D407", "D413"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "E402"]
 "conftest.py" = ["E402"]
+"setup_dev_bucket.py" = ["E402"]
 
 [[tool.mypy.overrides]]
 module = "geopandas.*,geosupport.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*,moto.*,matplotlib.*,contextily,leafmap.*,shapely,socrata.*,faker.*,ruamel.*" # no stubs available


### PR DESCRIPTION
Decided to spin this out from #1070 to reduce clutter - that one can stay focused on using buckets that exist already

Some complications with our hope to just quickly spin up dev buckets.

Copy commands are not allowed across clusters within a region for spaces buckets. We can choose what region a bucket is in, but cluster seems entirely internal to DO. This means that, with some tool (mc/rclone/boto3), we need to actually download/upload to get files from edm-recipes or publishing into a new bucket.

This has some drawbacks, primarily

- speed. On my personal comp, creating a dev bucket with latest of all recipe datasets needed for pluto took about an hour. Not the end of the world, not as lightweight and easy as I had hoped
- downloads count towards our monthly read bandwidth, which is 1TB. My run right now of latest of all pluto-related datasets and latest publish folder for pluto was ~5gb. I think cpdb and GFT would be larger. So maybe not a huge issue - I don't think anyone would make more than one of these a month, and it's only a bit bulkier than running a few builds (which we already do all the time)

These are both made worse by the fact that we currently have multiple file types for each source dataset, and different builds sometimes use different file types (pluto uses pg_dump, facdb uses csv) so it's a bit tough to limit this. I suppose I could use the recipe to determine which file types are needed and only download those. This could reduce this size (and also then the time to setup) to close to 1/3 - right now it just grabs the whole datasets/{ds_id}/latest folder

Tangent on reducing read bandwidth:
-  maybe that's also something to think about a bit with our nightly_qa job - I wouldn't be surprised if we're reading 10-15 gb per day with that, which would get us (monthy) to somewhere between 1/3 and 1/2 of our limit right there. Persisting latest of each recipe dataset in a db (at time of library archival) and only grabbing from s3 when an older version is needed might be a more sustainable (and performant) long term solution. That could be part of 1 db per build environment

Anyways - would love to chat about how we see ourselves using this just as a sanity check - I've gone in circles a bit in my vision here