### PR TITLE
fix CPDB filenames

### DIFF
--- a/products/cpdb/bash/04_analysis.sh
+++ b/products/cpdb/bash/04_analysis.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 source bash/config.sh
 
-# Tables of projects in geographies of interest
-python3 -m python.projects_in_geographies
-
 # Summary table by managing and sponsor agency
 echo 'Creating summary tables by managing and sponsor agency'
 run_sql_file sql/analysis/projects_dollars_mapped_categorized_managing.sql

--- a/products/cpdb/bash/05_export.sh
+++ b/products/cpdb/bash/05_export.sh
@@ -6,6 +6,9 @@ set_error_traps
 run_sql_file sql/_create_export.sql
 python3 python/checkbook_spending_by_year.py
 
+# Create and export tables of projects in geographies of interest
+python3 -m python.projects_in_geographies
+
 mkdir -p output && (
     cd output
     
@@ -26,7 +29,8 @@ mkdir -p output && (
     shp_export cpdb_projects_pts MULTIPOINT &
     shp_export cpdb_projects_poly MULTIPOLYGON &
     
-    cp -r ../projects_in_geographies ./
+    mv ../projects_in_geographies.zip ../projects_in_geographies/
+    mv ../projects_in_geographies ./
 
     echo $VERSION > version.txt
     wait 

--- a/products/cpdb/python/admin_geographies.py
+++ b/products/cpdb/python/admin_geographies.py
@@ -25,7 +25,7 @@ class CityCouncilDistricts(AdminGeographies):
     cpdb_geography_type: str = "council"
 
     def generate_geography(self, geography_number: int) -> AdminGeography:
-        table_name = "city_council_district_" + str(geography_number).rjust(2, "0")
+        table_name = "city_council_district_" + str(geography_number)
         geography_id = str(geography_number)
         geography_name = "City Council District " + str(geography_number)
 
@@ -48,7 +48,7 @@ class BoroughCommunityDistricts(AdminGeographies):
 
     def generate_geography(self, geography_number: int) -> AdminGeography:
         table_suffix = (
-            self.borough_name.replace(" ", "_") + "_cd" + str(geography_number)
+            self.borough_name.replace(" ", "_") + "_cd" + str(geography_number).zfill(2)
         ).lower()
         table_name = "community_district_" + table_suffix
 

--- a/products/cpdb/python/projects_in_geographies.py
+++ b/products/cpdb/python/projects_in_geographies.py
@@ -62,3 +62,11 @@ if __name__ == "__main__":
             geography.geography_name,
         )
         export_table(geography.table_name)
+
+    # zip folder with all csv files
+    print(f"Zipping folder\n\t{OUTPUT_DIR}")
+    shutil.make_archive(
+        base_name=OUTPUT_DIR,
+        format="zip",
+        root_dir=OUTPUT_DIR,
+    )

--- a/products/cpdb/python/projects_in_geographies.py
+++ b/products/cpdb/python/projects_in_geographies.py
@@ -38,17 +38,15 @@ def create_table(
         conn.execute(text(sql_rendered))
 
 
-def export_table(geography_type: str, table_name: str) -> None:
+def export_table(table_name: str) -> None:
     print(f"pd.read_sql from table {table_name} ...")
     engine = create_engine(os.environ["BUILD_ENGINE"])
     with engine.begin() as conn:
         df = pd.read_sql(text("select * from %(name)s" % {"name": table_name}), conn)
 
-    output_subfolder = OUTPUT_DIR / geography_type
-    if not output_subfolder.exists():
-        output_subfolder.mkdir(parents=True, exist_ok=True)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    output_file_path = output_subfolder / f"{table_name}.csv"
+    output_file_path = OUTPUT_DIR / f"{table_name}.csv"
     print(f"sql_to_csv from {table_name} to {output_file_path} ...")
     df.to_csv(output_file_path, index=False)
 
@@ -63,4 +61,4 @@ if __name__ == "__main__":
             geography.geography_id,
             geography.geography_name,
         )
-        export_table(geography.geography_type, geography.table_name)
+        export_table(geography.table_name)


### PR DESCRIPTION
related to https://github.com/NYCPlanning/ae-cp-map/issues/44
follow-up to https://github.com/NYCPlanning/data-engineering/pull/1095

I mixed up which files needed zero-padding.

Will return to refactor this code for simplicity/readability (e.g. repetitive `str(geography_number).zfill(2))`, just wanted this change to be as obvious/atomic as possible first.

since these csvs are needed for version 24prelim, repeat builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/repeat_build.yml?query=branch%3Adm-cpdb-csvs)