### PR TITLE
Fix checkbook nightly qa 

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -273,7 +273,10 @@ def upload_build(
     logger.info(f'Uploading {output_path} to {build_key.path} with ACL "{acl}"')
     upload(output_path, build_key, acl=acl, max_files=max_files)
 
-    if build_key.build not in IGNORED_LOGGING_BUILDS:
+    if (
+        build_key.build not in IGNORED_LOGGING_BUILDS
+        and build_key.product in PRODUCTS_TO_LOG
+    ):
         version = get_version(build_key)
         run_details = metadata.get_run_details()
         event_metadata = EventLog(

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -187,10 +187,12 @@ def test_upload_build_validate_logging_logic(
     mock_log_event.reset_mock()
 
     non_ignored_build = TEST_BUILD
+    non_ignored_product = "db-template"
+    assert non_ignored_product in publishing.PRODUCTS_TO_LOG  # sanity check
     assert non_ignored_build not in publishing.IGNORED_LOGGING_BUILDS  # sanity check
     publishing.upload_build(
         data_path,
-        product=TEST_PRODUCT_NAME,
+        product=non_ignored_product,
         build=non_ignored_build,
         acl=TEST_ACL,
     )


### PR DESCRIPTION
Fix logging logic for building products that are not on the whitelist to log.

Failed nightly qa [job](https://github.com/NYCPlanning/data-engineering/actions/runs/10877876712/job/30179927619).