### PR TITLE
Set up data tests in PLUTO

### DIFF
--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -6,7 +6,7 @@ on:
       image_tag:
         type: string
         required: false
-      build_name: 
+      build_name:
         type: string
         required: true
       recipe_file:
@@ -51,6 +51,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
           BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+          BUILD_ENGINE_HOST: "op://Data Engineering/EDM_DATA/server"
+          BUILD_ENGINE_USER: "op://Data Engineering/EDM_DATA/username"
+          BUILD_ENGINE_PASSWORD: "op://Data Engineering/EDM_DATA/password"
+          BUILD_ENGINE_PORT: "op://Data Engineering/EDM_DATA/port"
           EDM_DATA: "op://Data Engineering/EDM_DATA/defaultdb_url"
 
       - name: Finish container setup
@@ -67,7 +71,7 @@ jobs:
 
       - name: Set recipe env vars
         working-directory: ./
-        run: source ./bash/export_recipe_env.sh products/pluto/${{ inputs.recipe_file }}.lock.yml 
+        run: source ./bash/export_recipe_env.sh products/pluto/${{ inputs.recipe_file }}.lock.yml
 
       - name: Dataloading
         working-directory: products/pluto
@@ -90,3 +94,7 @@ jobs:
 
       - name: Export and Upload
         run: ./06_export.sh
+
+      - name: Custom QAQC
+        working-directory: products/pluto
+        run: ./pluto_build/07_custom_qaqc.sh

--- a/products/pluto/dbt_project.yml
+++ b/products/pluto/dbt_project.yml
@@ -1,0 +1,10 @@
+name: "pluto"
+
+profile: "dcp-de-postgres"
+
+model-paths: ["models"]
+test-paths: ["tests"]
+
+tests:
+  +store_failures: true
+  schema: "_tests"

--- a/products/pluto/models/_sources.yml
+++ b/products/pluto/models/_sources.yml
@@ -41,3 +41,14 @@ sources:
           - name: date_complete
 
       - name: pluto_pts
+
+  - name: build_sources
+    schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
+    tables:
+      - name: dof_pts_propmaster
+        description: |
+          Raw PTS data + prime bbl column that was added during PLUTO build.
+      - name: pluto_rpad_geo
+        description: |
+          Processed PTS data where each record is a UNIT BBL: i.e. there are multiple
+          records per a condominium.

--- a/products/pluto/models/_sources.yml
+++ b/products/pluto/models/_sources.yml
@@ -1,0 +1,43 @@
+version: 2
+
+sources:
+  - name: recipe_sources
+    schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
+    tables:
+      - name: pluto_input_research
+      - name: dcp_developments
+        description: |
+          Contains changes in units resulting from new buildings, major alterations, and demolitions.
+          This table is used for cross-checking condo unit count with PLUTO input data.
+        columns:
+          - name: bbl
+          - name: bin
+          - name: units_co
+          - name: classa_prop
+          - name: job_type
+            data_tests:
+              - accepted_values:
+                  name: source_dcp_developments_job_type_values
+                  values:
+                    [
+                      "Alteration",
+                      "Alteration (A2)",
+                      "Demolition",
+                      "New Building",
+                    ]
+          - name: job_status
+            data_tests:
+              - accepted_values:
+                  name: source_dcp_developments_job_status_values
+                  values:
+                    [
+                      "1. Filed Application",
+                      "2. Approved Application",
+                      "3. Permitted for Construction",
+                      "4. Partially Completed Construction",
+                      "5. Completed Construction",
+                      "9. Withdrawn",
+                    ]
+          - name: date_complete
+
+      - name: pluto_pts

--- a/products/pluto/models/qaqc/intermediate/_int_models.yml
+++ b/products/pluto/models/qaqc/intermediate/_int_models.yml
@@ -1,0 +1,22 @@
+version: 2
+
+models:
+  - name: qaqc_int__active_condo_bbl_unitsres_corrections
+    description: |
+      Contains condo bbls that are being corrected for res units in final PLUTO, using `pluto_input_research.csv` file
+    columns:
+      - name: bbl
+      - name: old_value
+
+  - name: qaqc_int__devdb_bbl_units_summary
+    description: |
+      This table provides total number of units per bbl, based on the most recent construction records in DevDB, excluding demolitions.
+
+    columns:
+      - name: bbl
+      - name: units_co
+        description: Total number of certificate of occupancy (CO) units
+      - name: classa_prop
+        description: Total number of Class A units (residential units)
+      - name: count_bins
+        description: Total number of BINs per BBL that had modification in DevDB. Note, this may not represent all building on a lot

--- a/products/pluto/models/qaqc/intermediate/qaqc_int__active_condo_bbl_unitsres_corrections.sql
+++ b/products/pluto/models/qaqc/intermediate/qaqc_int__active_condo_bbl_unitsres_corrections.sql
@@ -1,0 +1,28 @@
+{{ config(
+    materialized = 'table'
+) }}
+
+WITH historical_condo_unit_corrections AS (
+    SELECT
+        bbl,
+        old_value::numeric
+    FROM {{ source("recipe_sources", "pluto_input_research") }}
+    WHERE field = 'unitsres'
+        AND substring(bbl, 7, 2) = '75'
+),
+
+primebbl_condo_units AS (
+    SELECT
+        primebbl,
+        sum(coop_apts) AS coop_apts,
+        sum(units) AS units
+    FROM {{ ref('pluto_rpad_geo') }}
+    WHERE tl NOT LIKE '75%'
+    GROUP BY primebbl
+)
+
+SELECT l.*
+FROM historical_condo_unit_corrections AS l
+INNER JOIN primebbl_condo_units AS r
+    ON l.bbl = r.primebbl
+WHERE l.old_value = r.coop_apts

--- a/products/pluto/models/qaqc/intermediate/qaqc_int__active_condo_bbl_unitsres_corrections.sql
+++ b/products/pluto/models/qaqc/intermediate/qaqc_int__active_condo_bbl_unitsres_corrections.sql
@@ -16,7 +16,7 @@ primebbl_condo_units AS (
         primebbl,
         sum(coop_apts) AS coop_apts,
         sum(units) AS units
-    FROM {{ ref('pluto_rpad_geo') }}
+    FROM {{ source("build_sources", "pluto_rpad_geo") }}
     WHERE tl NOT LIKE '75%'
     GROUP BY primebbl
 )

--- a/products/pluto/models/qaqc/intermediate/qaqc_int__devdb_bbl_units_summary.sql
+++ b/products/pluto/models/qaqc/intermediate/qaqc_int__devdb_bbl_units_summary.sql
@@ -1,0 +1,42 @@
+{{ config(
+    materialized = 'table'
+) }}
+
+WITH completed_construction_records AS (
+    SELECT
+        bbl,
+        bin,
+        units_co,
+        CASE
+            WHEN classa_prop IS null AND job_status = '5. Completed Construction' THEN 0
+            ELSE classa_prop
+        END AS classa_prop_modified,
+        job_type,
+        job_status,
+        date_complete,
+        row_number() OVER (PARTITION BY bbl, bin ORDER BY date_complete DESC) AS order_num
+    FROM {{ ref("stg__dcp_developments") }}
+    WHERE job_status IN ('5. Completed Construction', '4. Partially Completed Construction')
+),
+
+most_recent_construction_by_bin AS (
+    SELECT
+        bbl,
+        bin,
+        units_co,
+        classa_prop_modified AS classa_prop,
+        job_type,
+        job_status,
+        date_complete
+    FROM completed_construction_records
+    WHERE order_num = 1 -- Selecting the most recent record per BIN
+)
+
+SELECT
+    bbl,
+    sum(units_co) AS units_co,
+    sum(classa_prop) AS classa_prop,
+    count(*) AS count_bins
+FROM most_recent_construction_by_bin
+WHERE job_type <> 'Demolition' -- Exclude demolished buildings as property taxes may still be paid, aligning with the DOF data
+GROUP BY bbl

--- a/products/pluto/models/qaqc/reports/_reports_models.yml
+++ b/products/pluto/models/qaqc/reports/_reports_models.yml
@@ -1,0 +1,27 @@
+version: 2
+
+models:
+  - name: qaqc_reports__dof_incorrect_condo_res_units
+    description: |
+      This report is to be shared with DOF.
+      It contains DOF records that need to be corrected for res unit count at the source, supplied with DevDB unit counts
+
+    columns:
+      - name: primebbl
+      - name: units
+        description: DOF number of total units (including non-residential) per BBL
+      - name: coop_apts
+        description: DOF number of residential units per BBL
+      - name: units_co
+        description: DevDB number of units on Certificate of Occupancy
+      - name: classa_prop
+        description: DevDB number of class A units
+      - name: dof_matches_devdb_units
+        description: Flag to indicate whether DOF res units match DevDB res units (coop_apts == classa_prop)
+      - name: diff
+        description: Difference in residential units between
+
+  - name: qaqc_reports__dof_pts_incorrect_condo_res_units
+    description: |
+      This report is to be shared with DOF. 
+      It contains raw DOF PTS data filtered for condo records in `qaqc_reports__dof_incorrect_condo_res_units``

--- a/products/pluto/models/qaqc/reports/qaqc_reports__dof_incorrect_condo_res_units.sql
+++ b/products/pluto/models/qaqc/reports/qaqc_reports__dof_incorrect_condo_res_units.sql
@@ -1,0 +1,27 @@
+WITH active_condo_unitsres_corrections AS (
+    SELECT bbl
+    FROM {{ ref('qaqc_int__active_condo_bbl_unitsres_corrections') }}
+),
+
+dof_condo_units AS (
+    SELECT
+        primebbl,
+        sum(coop_apts) AS coop_apts,
+        sum(units) AS units
+    FROM {{ ref('pluto_rpad_geo') }}
+    WHERE
+        primebbl IN (SELECT bbl FROM active_condo_unitsres_corrections)
+        AND tl NOT LIKE '75%'
+    GROUP BY primebbl
+)
+
+SELECT
+    l.*,
+    r.units_co,
+    r.classa_prop,
+    r.count_bins,
+    l.coop_apts = r.classa_prop AS dof_matches_devdb_units,
+    r.classa_prop - l.coop_apts AS diff
+FROM dof_condo_units AS l
+INNER JOIN {{ ref('qaqc_int__devdb_bbl_units_summary') }} AS r
+    ON l.primebbl = r.bbl

--- a/products/pluto/models/qaqc/reports/qaqc_reports__dof_incorrect_condo_res_units.sql
+++ b/products/pluto/models/qaqc/reports/qaqc_reports__dof_incorrect_condo_res_units.sql
@@ -8,7 +8,7 @@ dof_condo_units AS (
         primebbl,
         sum(coop_apts) AS coop_apts,
         sum(units) AS units
-    FROM {{ ref('pluto_rpad_geo') }}
+    FROM {{ source("build_sources", "pluto_rpad_geo") }}
     WHERE
         primebbl IN (SELECT bbl FROM active_condo_unitsres_corrections)
         AND tl NOT LIKE '75%'

--- a/products/pluto/models/qaqc/reports/qaqc_reports__dof_pts_incorrect_condo_res_units.sql
+++ b/products/pluto/models/qaqc/reports/qaqc_reports__dof_pts_incorrect_condo_res_units.sql
@@ -1,0 +1,18 @@
+WITH active_condo_unitsres_corrections AS (
+    SELECT bbl
+    FROM {{ ref('qaqc_int__active_condo_bbl_unitsres_corrections') }}
+),
+
+filtered_dof_pts_propmaster AS (
+    SELECT boro || tb || tl AS bbl
+    FROM {{ ref('dof_pts_propmaster') }}
+    WHERE primebbl IN (
+        SELECT bbl FROM active_condo_unitsres_corrections
+    )
+)
+
+SELECT * FROM
+    {{ source("recipe_sources", "pluto_pts") }}
+WHERE (boro || block || lot) IN (
+    SELECT bbl FROM filtered_dof_pts_propmaster
+)

--- a/products/pluto/models/qaqc/reports/qaqc_reports__dof_pts_incorrect_condo_res_units.sql
+++ b/products/pluto/models/qaqc/reports/qaqc_reports__dof_pts_incorrect_condo_res_units.sql
@@ -5,7 +5,7 @@ WITH active_condo_unitsres_corrections AS (
 
 filtered_dof_pts_propmaster AS (
     SELECT boro || tb || tl AS bbl
-    FROM {{ ref('dof_pts_propmaster') }}
+    FROM {{ source("build_sources", "dof_pts_propmaster") }}
     WHERE primebbl IN (
         SELECT bbl FROM active_condo_unitsres_corrections
     )

--- a/products/pluto/models/staging/stg__dcp_developments.sql
+++ b/products/pluto/models/staging/stg__dcp_developments.sql
@@ -1,0 +1,5 @@
+WITH final AS (
+    SELECT bbl::decimal::bigint::text, bin, units_co::numeric, classa_prop::numeric, job_type, job_status, date_complete::date
+    FROM {{ source("recipe_sources", "dcp_developments") }}
+)
+SELECT * from final

--- a/products/pluto/packages.yml
+++ b/products/pluto/packages.yml
@@ -1,0 +1,5 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.1.1
+  - package: calogica/dbt_expectations
+    version: 0.10.3

--- a/products/pluto/pluto_build/07_custom_qaqc.sh
+++ b/products/pluto/pluto_build/07_custom_qaqc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+source ./pluto_build/bash/config.sh   # assuming this script is run from pluto/ dir
+set_error_traps
+
+echo "Setup dbt"
+dbt deps
+dbt debug
+
+echo "Build seed tables"
+dbt build --select config.materialized:seed --indirect-selection=cautious --full-refresh
+
+echo "Test source tables"
+dbt test --select "source:*"
+
+echo "Build staging tables"
+dbt build --select staging
+
+echo "Build intermediate QAQC tables"
+dbt run --select qaqc   # need to use 'dbt run' because otherwise it fails if downstream test fails
+
+echo "🔥 Run DE aka important tests 🔥"
+dbt test --select tag:de_check

--- a/products/pluto/pluto_build/07_custom_qaqc.sh
+++ b/products/pluto/pluto_build/07_custom_qaqc.sh
@@ -10,13 +10,13 @@ echo "Build seed tables"
 dbt build --select config.materialized:seed --indirect-selection=cautious --full-refresh
 
 echo "Test source tables"
-dbt test --select "source:*"
+dbt test --select "source:*" --exclude tag:de_check
 
 echo "Build staging tables"
-dbt build --select staging
+dbt build --select staging --exclude tag:de_check
 
 echo "Build intermediate QAQC tables"
-dbt run --select qaqc   # need to use 'dbt run' because otherwise it fails if downstream test fails
+dbt run --select qaqc --exclude tag:de_check  # need to use 'dbt run' because otherwise it fails if downstream test fails
 
 echo "🔥 Run DE aka important tests 🔥"
 dbt test --select tag:de_check

--- a/products/pluto/profiles.yml
+++ b/products/pluto/profiles.yml
@@ -1,0 +1,11 @@
+dcp-de-postgres:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('BUILD_ENGINE_HOST') }}"
+      user: "{{ env_var('BUILD_ENGINE_USER') }}"
+      password: "{{ env_var('BUILD_ENGINE_PASSWORD') }}"
+      port: "{{ env_var('BUILD_ENGINE_PORT') | as_number }}"
+      dbname: "{{ env_var('BUILD_ENGINE_DB') }}"
+      schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"

--- a/products/pluto/recipe.yml
+++ b/products/pluto/recipe.yml
@@ -13,6 +13,7 @@ inputs:
     - name: dcp_commercialoverlay
     - name: dcp_ct2010_wi
     - name: dcp_ct2020_wi
+    - name: dcp_developments # only used for data tests
     - name: dcp_edesignation
     - name: dcp_firecompanies
     - name: dcp_healthareas
@@ -20,7 +21,7 @@ inputs:
     - name: dcp_limitedheight
     - name: dcp_pluto
       # this env var is set in dcpy/builds/plan.py in a slightly hacky way for now
-      version_env_var: VERSION_PREV 
+      version_env_var: VERSION_PREV
       import_as: previous_pluto
     - name: dcp_policeprecincts
     - name: dcp_school_districts

--- a/products/pluto/seeds/_seeds.yml
+++ b/products/pluto/seeds/_seeds.yml
@@ -6,3 +6,6 @@ seeds:
       List of manually researched bbls that have correct count of residential units in DOF PTS data,
       despite failing `assert_condo_bbl_unit_count_research_required` test. These records are ignored
       during the test.
+    config:
+      column_types:
+        bbl: text

--- a/products/pluto/seeds/_seeds.yml
+++ b/products/pluto/seeds/_seeds.yml
@@ -1,0 +1,8 @@
+version: 2
+
+seeds:
+  - name: ignored_bbls_for_unit_count_test
+    description: |
+      List of manually researched bbls that have correct count of residential units in DOF PTS data,
+      despite failing `assert_condo_bbl_unit_count_research_required` test. These records are ignored
+      during the test.

--- a/products/pluto/seeds/ignored_bbls_for_unit_count_test.csv
+++ b/products/pluto/seeds/ignored_bbls_for_unit_count_test.csv
@@ -1,0 +1,1 @@
+bbl,pluto_version

--- a/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
+++ b/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
@@ -52,7 +52,7 @@ not_ignored_primebbls AS (
     SELECT *
     FROM uncorrected_primebbl_offenders
     WHERE primebbl NOT IN (
-        SELECT bbl::decimal::bigint::text
+        SELECT bbl
         FROM {{ ref('ignored_bbls_for_unit_count_test') }}
     )
 ),

--- a/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
+++ b/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
@@ -8,15 +8,18 @@
 				The remaining logic cross-checks these BBL "offenders" with the PLUTO corrections file and the Developments database (aka DevDB) to narrow down the records needing manual review.
 			''',
             'next_steps': '''
-				Manually research failing records. If confirmed, update the corrections file with the correct unit counts and share a report with Amanda to send to DOF.
+				1. Manually research failing records. 
+                2. If confirmed, update the corrections file with the correct total and res unit number; 
+                not confirmed bbls need to be added to the `ignored_bbls_for_unit_count_test` seed file.
+                3. Re-run PLUTO build. If this check passes, share reports from `models/qaqc/reports` with Amanda to send them to DOF.
 			'''
         }
     ) 
 }}
 
--- Find condo records where multiple unit BBLs have coop_apts > 1
+-- Find records where multiple unit BBLs have coop_apts > 1
 WITH condo_prime_bbls AS (
-    SELECT DISTINCT primebbl
+    SELECT primebbl
     FROM {{ ref('pluto_rpad_geo') }}
     WHERE coop_apts > 1
     GROUP BY primebbl
@@ -35,64 +38,23 @@ primebbl_offenders AS (
     GROUP BY primebbl
 ),
 
-historical_unit_corrections AS (
-    SELECT
-        bbl,
-        old_value::numeric
-    FROM {{ source("recipe_sources", "pluto_input_research") }}
-    WHERE field = 'unitsres' AND substring(bbl, 7, 2) = '75'
-),
-
-current_unit_corrections AS (
-    SELECT l.* FROM historical_unit_corrections AS l
-    INNER JOIN primebbl_offenders AS r
-        ON l.bbl = r.primebbl AND l.old_value = r.coop_apts
-),
-
+-- Identify bbl offenders that are not actively corrected
 uncorrected_primebbl_offenders AS (
     SELECT *
     FROM primebbl_offenders
-    WHERE primebbl NOT IN (SELECT bbl FROM current_unit_corrections)
+    WHERE primebbl NOT IN (
+        SELECT bbl
+        FROM {{ ref('qaqc_int__active_condo_bbl_unitsres_corrections') }}
+    )
 ),
 
--- Filter DevDB for uncorrected offenders
-devdb_uncorrected_offenders AS (
-    SELECT
-        *,
-        row_number() OVER (PARTITION BY bbl, bin ORDER BY date_complete DESC) AS order_num,
-        CASE
-            WHEN classa_prop IS null AND job_status = '5. Completed Construction' THEN 0
-            ELSE classa_prop
-        END AS classa_prop_modified
-    FROM {{ ref("stg__dcp_developments") }}
-    WHERE
-        bbl IN
-        (SELECT DISTINCT primebbl FROM uncorrected_primebbl_offenders)
-        AND job_status IN ('5. Completed Construction', '4. Partially Completed Construction')
-),
-
-devdb_uncorrected_offender_grouped_by_latest_bin AS (
-    SELECT
-        bbl,
-        bin,
-        units_co,
-        classa_prop_modified AS classa_prop,
-        job_type,
-        job_status,
-        date_complete
-    FROM devdb_uncorrected_offenders
-    WHERE order_num = 1
-),
-
-devdb_uncorrected_offender_grouped_by_bbl AS (
-    SELECT
-        bbl,
-        sum(units_co) AS units_co,
-        sum(classa_prop) AS classa_prop,
-        count(*) AS count_bins
-    FROM devdb_uncorrected_offender_grouped_by_latest_bin
-    WHERE job_type <> 'Demolition' -- Exclude demolished buildings as property taxes may still be paid, aligning with the DOF data
-    GROUP BY bbl
+not_ignored_primebbls AS (
+    SELECT *
+    FROM uncorrected_primebbl_offenders
+    WHERE primebbl NOT IN (
+        SELECT bbl::decimal::bigint::text
+        FROM {{ ref('ignored_bbls_for_unit_count_test') }}
+    )
 ),
 
 -- Join DevDB with uncorrected offenders
@@ -104,13 +66,13 @@ offenders_joined_with_devdb AS (
         r.count_bins,
         l.coop_apts = r.classa_prop AS dof_matches_devdb_units,
         r.classa_prop - l.coop_apts AS diff
-    FROM uncorrected_primebbl_offenders AS l
-    LEFT JOIN devdb_uncorrected_offender_grouped_by_bbl AS r
+    FROM not_ignored_primebbls AS l
+    LEFT JOIN {{ ref('qaqc_int__devdb_bbl_units_summary') }} AS r
         ON l.primebbl = r.bbl
-    ORDER BY dof_matches_devdb_units
 )
 
 -- Final selection of records where the unit difference exceeds threshold
 SELECT *
 FROM offenders_joined_with_devdb
 WHERE diff >= 50 OR diff <= -50	-- 50 is an arbitrary threshold
+ORDER BY dof_matches_devdb_units

--- a/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
+++ b/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
@@ -1,0 +1,116 @@
+{{ 
+    config(
+        tags = ['de_check'], 
+        meta = {
+            'description': '''
+				This test identifies condo records that likely have incorrect unit counts in DOF PTS data, affecting the final PLUTO table. 
+				The first 2 CTEs determine prime BBLs for condos with multiple unit records where their residential unit count != 1 (expected value). 
+				The remaining logic cross-checks these BBL "offenders" with the PLUTO corrections file and the Developments database (aka DevDB) to narrow down the records needing manual review.
+			''',
+            'next_steps': '''
+				Manually research failing records. If confirmed, update the corrections file with the correct unit counts and share a report with Amanda to send to DOF.
+			'''
+        }
+    ) 
+}}
+
+-- Find condo records where multiple unit BBLs have coop_apts > 1
+WITH condo_prime_bbls AS (
+    SELECT DISTINCT primebbl
+    FROM {{ ref('pluto_rpad_geo') }}
+    WHERE coop_apts > 1
+    GROUP BY primebbl
+    HAVING count(*) > 1
+),
+
+primebbl_offenders AS (
+    SELECT
+        primebbl,
+        sum(coop_apts) AS coop_apts,
+        sum(units) AS units
+    FROM {{ ref('pluto_rpad_geo') }}
+    WHERE
+        primebbl IN (SELECT primebbl FROM condo_prime_bbls)
+        AND tl NOT LIKE '75%'
+    GROUP BY primebbl
+),
+
+historical_unit_corrections AS (
+    SELECT
+        bbl,
+        old_value::numeric
+    FROM {{ source("recipe_sources", "pluto_input_research") }}
+    WHERE field = 'unitsres' AND substring(bbl, 7, 2) = '75'
+),
+
+current_unit_corrections AS (
+    SELECT l.* FROM historical_unit_corrections AS l
+    INNER JOIN primebbl_offenders AS r
+        ON l.bbl = r.primebbl AND l.old_value = r.coop_apts
+),
+
+uncorrected_primebbl_offenders AS (
+    SELECT *
+    FROM primebbl_offenders
+    WHERE primebbl NOT IN (SELECT bbl FROM current_unit_corrections)
+),
+
+-- Filter DevDB for uncorrected offenders
+devdb_uncorrected_offenders AS (
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY bbl, bin ORDER BY date_complete DESC) AS order_num,
+        CASE
+            WHEN classa_prop IS null AND job_status = '5. Completed Construction' THEN 0
+            ELSE classa_prop
+        END AS classa_prop_modified
+    FROM {{ ref("stg__dcp_developments") }}
+    WHERE
+        bbl IN
+        (SELECT DISTINCT primebbl FROM uncorrected_primebbl_offenders)
+        AND job_status IN ('5. Completed Construction', '4. Partially Completed Construction')
+),
+
+devdb_uncorrected_offender_grouped_by_latest_bin AS (
+    SELECT
+        bbl,
+        bin,
+        units_co,
+        classa_prop_modified AS classa_prop,
+        job_type,
+        job_status,
+        date_complete
+    FROM devdb_uncorrected_offenders
+    WHERE order_num = 1
+),
+
+devdb_uncorrected_offender_grouped_by_bbl AS (
+    SELECT
+        bbl,
+        sum(units_co) AS units_co,
+        sum(classa_prop) AS classa_prop,
+        count(*) AS count_bins
+    FROM devdb_uncorrected_offender_grouped_by_latest_bin
+    WHERE job_type <> 'Demolition' -- Exclude demolished buildings as property taxes may still be paid, aligning with the DOF data
+    GROUP BY bbl
+),
+
+-- Join DevDB with uncorrected offenders
+offenders_joined_with_devdb AS (
+    SELECT
+        l.*,
+        r.units_co,
+        r.classa_prop,
+        r.count_bins,
+        l.coop_apts = r.classa_prop AS dof_matches_devdb_units,
+        r.classa_prop - l.coop_apts AS diff
+    FROM uncorrected_primebbl_offenders AS l
+    LEFT JOIN devdb_uncorrected_offender_grouped_by_bbl AS r
+        ON l.primebbl = r.bbl
+    ORDER BY dof_matches_devdb_units
+)
+
+-- Final selection of records where the unit difference exceeds threshold
+SELECT *
+FROM offenders_joined_with_devdb
+WHERE diff >= 50 OR diff <= -50	-- 50 is an arbitrary threshold

--- a/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
+++ b/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
@@ -20,7 +20,7 @@
 -- Find records where multiple unit BBLs have coop_apts > 1
 WITH condo_prime_bbls AS (
     SELECT primebbl
-    FROM {{ ref('pluto_rpad_geo') }}
+    FROM {{ source("build_sources", "pluto_rpad_geo") }}
     WHERE coop_apts > 1
     GROUP BY primebbl
     HAVING count(*) > 1
@@ -31,7 +31,7 @@ primebbl_offenders AS (
         primebbl,
         sum(coop_apts) AS coop_apts,
         sum(units) AS units
-    FROM {{ ref('pluto_rpad_geo') }}
+    FROM {{ source("build_sources", "pluto_rpad_geo") }}
     WHERE
         primebbl IN (SELECT primebbl FROM condo_prime_bbls)
         AND tl NOT LIKE '75%'


### PR DESCRIPTION
Fixes #962. See the issue for test framework details.

This PR establishes `dbt` framework for running data tests post PLUTO build, keeping in mind future migration of the entire PLUTO pipeline to `dbt`. 
I also implemented first data test that I've been working on with Amanda; this test helps us identify DOF PTS condo bbls that likely have incorrect residential unit count. 

# Data Test description

* As mentioned above this test helps us identify DOF condo records that likely have incorrect residential unit number. The test consists of 2 parts: 
    * First, we check DOF semi-raw data (`pluto_rpad_geo` table) to find prime bbls where multiple *unit* condos have res unit > 1. Why? Because each residential unit in a condo building should have exactly one condo. 
    
    For example, the following prime bbl would be flagged if it has the following records:

    | primebbl | bbl (unit bbl) | coop_units (res units) |
    |----------|----------------|------------------------|
    | 75123    | 1              | 3                      |
    | 75123    | 2              | 3                      |
    | 75123    | 3              | 1                      |

    * Second, we cross-check this prime bbl with the corrections file `pluto_input_research.csv`, the Developments database (DevdB), and a file of bbls that should be ignored during the check. 
       *   Why there is a file of bbls that should be ignored during the check? Because DevDB isn't perfect and it only contains building construction records going back to 2010ish. So for example, if a lot has 2 buildings built in 1980 and only 1 building was renovated post 2010ish, DevDB will should residential units for that 1 building.

* test logic tree: 
```mermaid
flowchart TD

check_name["condominium has multiple units with coop_units > 1?"]
corrected["Has res unit total been manually corrected?"]
in_ignore_file["Is in the 'ignore' csv file?"]
devdb["Is res unit total aligns with DevDB?"]
over_50["Is res unit count diff >= 50?"]
fix{"Manually research bbl. Needs correction?"}
add_to_corrections["Add to corrections & report to DOF"]
add_to_ignore_file["Add to 'ignore' csv file"]

ignore{"Ignore ✅"}

check_name --> |Yes| corrected
check_name --> |No| ignore

corrected --> |Yes| ignore
corrected --> |No| in_ignore_file

in_ignore_file --> |Yes| ignore
in_ignore_file --> |No| devdb

devdb --> |Yes| ignore
devdb --> |No| over_50

over_50 --> |Yes| fix
over_50 --> |No| ignore

fix --> |Yes| add_to_corrections
fix --> |No| add_to_ignore_file
```

* `dbt` lineage graph:

    <img width="1332" alt="image" src="https://github.com/user-attachments/assets/967f0d46-8432-4e9f-8bc1-6b7eb3b8eeb2">


# Commits
1. Initiate `dbt` project inside of PLUTO directory

2. Add DevDB dataset to PLUTO recipes. We need DevDB for the data test

5. Create a custom `dbt` test for residential units in `tests/assert_condo_bbl_unit_count_research_required.sql` file. In `dbt`, you can create your own custom, "singular" test which is pretty much a sql query stored in a `tests` directory. This is slightly different from macros that we've created before in a way that it's not reusable for different tables. 
    * Test description and our next steps in the case of failure are documented in the config object of the test file. At the moment, `dbt` doesn't have `description` property for tests, but it should be available with `dbt` next release (they recently implemented this feature [here](https://github.com/dbt-labs/dbt-core/issues/9005)).
    * This test is refactored in commit 4, so it may not be necessary to check out this commit; I kept it just in case.

6. Refactor the test by creating intermediate tables. The reasons to do so are: 1) make the test more readable and 2) use these intermediate tables for creating reports to send to DOF. 
    * I created `models/qaqc/` directory that is intended for test/qaqc intermediate tables that are NOT a part of the build and for qaqc reports. As we migrate PLUTO build, we can use the reports subdirectory for QAQC app tables. I also added yaml files to describe various tables in the qaqc dir. This directory contains some of the refactored tables used in the test.
    * Simplify the test itself given the refactored tables.
    * Add a seed file that will contain condo bbls that should be ignored during the test. This seed file is manually filled out during manual research step.


7. Run `dbt` test as a separate step in PLUTO build GHA.   


# Test Documentation in `dbt`

* As I previously mentioned, `dbt` is in process of implementing `description` property for tests: i.e. we will be able to document generic and singular tests in a yaml file. And then the test descriptions will be parsed to `dbt` docs pages here:
    <img width="1338" alt="image" src="https://github.com/user-attachments/assets/90eae220-00a4-4f8b-98df-ae1b60c4b692">

    <img width="1400" alt="image" src="https://github.com/user-attachments/assets/d44e23e3-f446-4a10-9e32-dae8aed28ccb">


* For now, we can document tests in a test's `config.meta` property which can be a dict with any key-value pairs. This property is available for both generic and singular tests.

* Where test results and test properties can be accessed? In `dbt`-generated artifacts: `manifest.json` & `run_results.json` 