### PR TITLE
Fix QA app

### DIFF
--- a/admin/run_environment/requirements.in
+++ b/admin/run_environment/requirements.in
@@ -42,6 +42,7 @@ PyYAML>=6.0.1
 types-PyYAML>=6.0.1
 rich>=13.4.2
 ruff
+setuptools
 socrata-py==1.1.13
 sqlalchemy
 sqlalchemy-stubs

--- a/apps/qa/bash/docker_deploy.sh
+++ b/apps/qa/bash/docker_deploy.sh
@@ -37,4 +37,6 @@ ssh qa "\
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID\
         -e BUILD_ENGINE_SERVER=$BUILD_ENGINE_SERVER\
         -e GHP_TOKEN=$GHP_TOKEN\
+        -e PUBLISHING_BUCKET=edm-publishing\
+        -e RECIPES_BUCKET=edm-recipes\
         $DOCKER_IMAGE_NAME"

--- a/apps/qa/requirements.txt
+++ b/apps/qa/requirements.txt
@@ -5,6 +5,7 @@ mapclassify
 matplotlib
 numerize
 plotly
+setuptools
 streamlit
 streamlit-aggrid
 streamlit-folium


### PR DESCRIPTION
First, the QAQC app wouldn't load pages because it didn't have `PUBLISHING_BUCKET` and `RECIPES_BUCKET` env variables. 

After fixing the env bug, this bug showed up:

![image](https://github.com/user-attachments/assets/26452a29-9146-4e29-8c5b-87472a990a58)


Adding setup tools package resolves the issue. [Link](https://de-qaqc.nycplanningdigital.com/?page=PLUTO) to sample page in the QA app.
