### PR TITLE
update gha sparse checkout paths

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,7 +37,7 @@ jobs:
           sparse-checkout: |
             dcpy 
             bash
-            python
+            admin/run_environment
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/promote_to_draft.yml
+++ b/.github/workflows/promote_to_draft.yml
@@ -68,7 +68,7 @@ jobs:
           sparse-checkout: |
             dcpy 
             bash
-            python
+            admin/run_environment
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           sparse-checkout: |
             dcpy 
             bash
-            python
+            admin/run_environment
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1


### PR DESCRIPTION
Failed action [here](https://github.com/NYCPlanning/data-engineering/actions/runs/10963794895)

Missed a few references to the deprecated python folder in #1143. Looked through all ghas for other `sparse_checkout`s that would need updating

Fixed action [here](https://github.com/NYCPlanning/data-engineering/actions/runs/10963844755)