### PR TITLE
Add action to publish JSON Schemas

### DIFF
--- a/.github/workflows/product_metadata_checks.yml
+++ b/.github/workflows/product_metadata_checks.yml
@@ -1,4 +1,0 @@
-name: Product_metadata_checks
-
-on:
-  workflow_dispatch:

--- a/.github/workflows/publish_json_schemas.yml
+++ b/.github/workflows/publish_json_schemas.yml
@@ -1,4 +1,36 @@
 name: Publish Model JSON Schemas
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - dcpy/models/**
   workflow_dispatch:
+
+jobs:
+  test:
+    name: Publish JSON Schemas
+    runs-on: ubuntu-22.04
+    container:
+      image: nycplanning/dev:latest
+    env:
+      RECIPES_BUCKET: edm-recipes
+      PUBLISHING_BUCKET: edm-publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: NYCPlanning/data-engineering
+
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+          AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+
+      - name: Publish
+        run: python -m admin.ops.update_product_metadata_schemas

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -208,3 +208,24 @@ jobs:
       with:
         fail_ci_if_error: true
         verbose: true
+
+  validate_product_metadata:
+    if: contains(inputs.path_filter, 'dcpy')
+    name: Validate Product Metadata
+    runs-on: ubuntu-22.04
+    container:
+      image: nycplanning/dev:${{ inputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: NYCPlanning/product-metadata
+          path: product-metadata
+      - uses: actions/checkout@v4
+        with:
+          repository: NYCPlanning/data-engineering
+          path: data-engineering
+      - name: Validate All Metadata Files
+        run: cd data-engineering; python -m dcpy.cli lifecycle scripts product_metadata validate_repo ../product-metadata
+        env:
+          RECIPES_BUCKET: edm-recipes
+          PUBLISHING_BUCKET: edm-publishing

--- a/admin/ops/update_product_metadata_schemas.py
+++ b/admin/ops/update_product_metadata_schemas.py
@@ -1,0 +1,39 @@
+# type: ignore
+from dcpy.utils import s3
+from dcpy.models.product import metadata as product_metadata
+from dcpy.models.product.dataset import metadata_v2 as dataset_metadata
+
+import json
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+DO_SCHEMA_FOLDER = "data-engineering-devops/schemas/"
+
+schemas = [
+    {
+        "name": "org_metadata.schema.json",
+        "folder": "product/",
+        "schema": product_metadata.OrgMetadataFile.model_json_schema(),
+    },
+    {
+        "name": "product_metadata.schema.json",
+        "folder": "product/",
+        "schema": product_metadata.ProductMetadataFile.model_json_schema(),
+    },
+    {
+        "name": "dataset_metadata.schema.json",
+        "folder": "product/dataset/",
+        "schema": dataset_metadata.Metadata.model_json_schema(),
+    },
+]
+
+for schema in schemas:
+    with TemporaryDirectory() as _dir:
+        p = Path(_dir) / schema["name"]
+        open(p, "w").write(json.dumps(schema["schema"]))
+        s3.upload_file(
+            bucket="edm-publishing",
+            path=p,
+            key=DO_SCHEMA_FOLDER + schema["folder"] + schema["name"],
+            acl="public-read",
+        )


### PR DESCRIPTION
Adds CI for JSON Schemas and Product Metadata Validation.

For JSON Schemas, add the following to your VS Code settings for autocomplete and validation. Note: I can't get the globbing to work correctly for `org_metadata`, which is either a good argument to move it into the products folder, or change the name of the file from `metadata.yml` to `org.yml` (and same for product and datasets metadata). 
```
    "yaml.schemas": {
        "https://edm-publishing.nyc3.digitaloceanspaces.com/data-engineering-devops/schemas/product/product_metadata.schema.json": "/products/*/metadata.yml",
        "https://edm-publishing.nyc3.digitaloceanspaces.com/data-engineering-devops/schemas/product/dataset/dataset_metadata.schema.json": "/products/*/*/metadata.yml",
        // "https://edm-publishing.nyc3.digitaloceanspaces.com/data-engineering-devops/schemas/product/org_metadata.schema.json": "/metadata.yml",
    },
```


## Job Runs
Successful JSON Schemas push run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11133787284/job/30940620138)

Successful Metadata Validation with no errors [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11133854964/job/30940828640)
Successful Metadata Validation with introduced errors [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11133945489/job/30941119185?pr=1170) (I made a few fields newly required, which breaks every product)