### PR TITLE
Generate XLSX's with file/destination Overrides

### DIFF
--- a/dcpy/lifecycle/package/assemble.py
+++ b/dcpy/lifecycle/package/assemble.py
@@ -6,7 +6,6 @@ import tempfile
 import typer
 
 from dcpy.lifecycle import WORKING_DIRECTORIES
-from dcpy.lifecycle.builds import metadata
 from dcpy.lifecycle.package import oti_xlsx
 from dcpy.lifecycle.package import assemble
 import dcpy.models.product.dataset.metadata_v2 as md

--- a/dcpy/lifecycle/package/oti_xlsx.py
+++ b/dcpy/lifecycle/package/oti_xlsx.py
@@ -104,7 +104,7 @@ def _format_row_slice(row_slice, is_last_row=False):
     _set_default_style(rightmost_cell, is_last_row=is_last_row, is_rightmost=True)
 
 
-def _write_column_information(xlsx_wb: openpyxl.Workbook, metadata: md_v2.Metadata):
+def _write_column_information(xlsx_wb: openpyxl.Workbook, metadata: md_v2.Dataset):
     ds_info_sheet = xlsx_wb[OTI_XLSX_TABS.column_information]
 
     header_description_row_index = 2
@@ -165,18 +165,17 @@ def _write_change_history(xlsx_wb: openpyxl.Workbook, change_log: list[list[str]
 
 def write_oti_xlsx(
     *,
-    metadata_path: Path,
+    dataset: md_v2.Dataset,
     output_path: Path | None = None,
     template_path_override: Path | None = None,
 ):
     xlsx_wb = openpyxl.load_workbook(
         filename=template_path_override or DEFAULT_TEMPLATE_PATH
     )
-    metadata = md_v2.Metadata.from_path(metadata_path)
-    _write_dataset_information(xlsx_wb, metadata)
-    _write_column_information(xlsx_wb, metadata)
+    _write_dataset_information(xlsx_wb, dataset)
+    _write_column_information(xlsx_wb, dataset)
     # TODO: this locationw will change
-    _write_change_history(xlsx_wb, metadata.attributes.custom.get("change_log", []))
+    _write_change_history(xlsx_wb, dataset.attributes.custom.get("change_log", []))
 
     out_path = output_path or Path("./data_dictionary.xlsx")
     logger.info(f"Saving OTI XLSX to {out_path}")
@@ -203,7 +202,7 @@ def _write_oti_xlsx_cli(
     ),
 ):
     write_oti_xlsx(
-        metadata_path=metadata_path,
+        dataset=md_v2.Metadata.from_path(metadata_path).dataset,
         output_path=output_path,
         template_path_override=template_path_override,
     )

--- a/dcpy/lifecycle/package/oti_xlsx.py
+++ b/dcpy/lifecycle/package/oti_xlsx.py
@@ -32,8 +32,19 @@ DISCLAIMER = """\
   use the dataset, or applications utilizing the dataset, provided by any third party.\
 """
 
+# pulling this out solely for a test case.
+_DESCRIPTION_ROW_INDEX = 15
 
-def _write_dataset_information(xlsx_wb: openpyxl.Workbook, metadata: md_v2.Metadata):
+
+def _get_dataset_description(path: Path):
+    xlsx_wb = openpyxl.load_workbook(filename=path)
+    ds_info = xlsx_wb[OTI_XLSX_TABS.dataset_info]
+
+    rows = [r for r in ds_info.rows]
+    return rows[_DESCRIPTION_ROW_INDEX][1].value
+
+
+def _write_dataset_information(xlsx_wb: openpyxl.Workbook, metadata: md_v2.Dataset):
     ds_info_sheet = xlsx_wb[OTI_XLSX_TABS.dataset_info]
 
     rows = [r for r in ds_info_sheet.rows]
@@ -60,7 +71,7 @@ def _write_dataset_information(xlsx_wb: openpyxl.Workbook, metadata: md_v2.Metad
     rows[14][1].value = metadata.attributes.publishing_frequency_details
 
     # Dataset Description. Overview of the information this dataset contains, including overall context and definitions of key terms. This field may include links to supporting datasets, agency websites, or external resources for additional context. ": 15
-    rows[15][1].value = metadata.attributes.description
+    rows[_DESCRIPTION_ROW_INDEX][1].value = metadata.attributes.description
 
     # Why is this dataset collected. Purpose behind the collection of this data, including any legal or policy requirements for this data by NYC Executive Order, Local Law, or other policy directive.": 16
     rows[16][1].value = metadata.attributes.publishing_purpose

--- a/dcpy/models/product/dataset/metadata_v2.py
+++ b/dcpy/models/product/dataset/metadata_v2.py
@@ -273,6 +273,16 @@ class Metadata(CustomizableBase, YamlWriter, TemplatedYamlReader):
             raise Exception(f"There should exist one file with id: {file_id}")
         return files[0]
 
+    def calculate_metadata(
+        self, *, file_id: str, destination_id: str | None = None
+    ) -> Dataset:
+        if destination_id:
+            return self.calculate_destination_metadata(
+                file_id=file_id, destination_id=destination_id
+            ).dataset
+        else:
+            return self.calculate_file_dataset_metadata(file_id=file_id)
+
     def calculate_file_dataset_metadata(self, *, file_id: str) -> Dataset:
         return self.dataset.override(
             self.get_file_and_overrides(file_id).dataset_overrides

--- a/dcpy/test/lifecycle/package/test_assemble_from_bytes.py
+++ b/dcpy/test/lifecycle/package/test_assemble_from_bytes.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import override
 import pytest
 import shutil
 from unittest.mock import patch, call

--- a/dcpy/test/lifecycle/package/test_generate_data_dictionary.py
+++ b/dcpy/test/lifecycle/package/test_generate_data_dictionary.py
@@ -7,6 +7,7 @@ from dcpy.test.lifecycle.package.conftest import (
 )
 
 from dcpy.lifecycle.package import generate_metadata_assets, oti_xlsx
+from dcpy.models.product.dataset import metadata_v2 as md
 
 
 @pytest.mark.usefixtures("file_setup_teardown")
@@ -32,7 +33,7 @@ class TestDataDictionary(TestCase):
 
     def test_generate_xslx(self):
         oti_xlsx.write_oti_xlsx(
-            metadata_path=self.package_path / "metadata.yml",
+            dataset=md.Metadata.from_path(self.package_path / "metadata.yml").dataset,
             output_path=self.output_xlsx_path,
         )
         assert self.output_xlsx_path.exists()

--- a/dcpy/test/resources/product_metadata/colp_single_feature_package/metadata.yml
+++ b/dcpy/test/resources/product_metadata/colp_single_feature_package/metadata.yml
@@ -5,348 +5,367 @@ attributes:
   display_name: City Owned and Leased Property (COLP)
   each_row_is_a: City Owned Property
   tags:
-  - a
-  - b
+    - a
+    - b
 
 assembly:
-- id: csv_package
-  filename: csv_package.zip
-  type: Zip
-  contents:
-  - id: primary_csv
-    filename: colp_{{ version }}.csv
-  - id: colp_readme
-    filename: colp_readme.pdf
-  - id: colp_metadata
-    filename: colp_metadata.pdf
+  - id: csv_package
+    filename: csv_package.zip
+    type: Zip
+    contents:
+      - id: primary_csv
+        filename: colp_{{ version }}.csv
+      - id: colp_readme
+        filename: colp_readme.pdf
+      - id: colp_metadata
+        filename: colp_metadata.pdf
 
 custom: {}
 
 destinations:
-- id: socrata_prod
-  type: socrata
-  files:
-  - id: colp_readme
+  - id: socrata_prod
+    type: socrata
+    files:
+      - id: colp_readme
+        custom:
+          destination_use: attachment
+      - id: primary_shapefile
+        dataset_overrides:
+          attributes:
+            description: Socrata Prod Shapefile Description Override
+        custom:
+          destination_use: dataset_file
     custom:
-      destination_use: attachment
-  - id: primary_shapefile
+      four_four: fn4k-qyk2
+  - id: socrata_unparsed
+    type: socrata
+    files:
+      - id: colp_readme.pdf
+        custom:
+          destination_use: attachment
+      - id: primary_shapefile
+        custom:
+          destination_use: dataset_file
     custom:
-      destination_use: dataset_file
-  custom:
-    four_four: fn4k-qyk2
-- id: socrata_unparsed
-  type: socrata
-  files:
-  - id: colp_readme.pdf
-    custom:
-      destination_use: attachment
-  - id: primary_shapefile
-    custom:
-      destination_use: dataset_file
-  custom:
-    four_four: fn4k-abcd
-    is_unparsed_dataset: true
-- id: bytes
-  type: bytes
-  files:
-  - id: csv_package
-    custom:
-      url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/colp_{{
-        version }}_csv.zip
-  - id: colp_readme
-    custom:
-      url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/colp_readme.pdf
+      four_four: fn4k-abcd
+      is_unparsed_dataset: true
+  - id: bytes
+    type: bytes
+    files:
+      - id: csv_package
+        custom:
+          url:
+            https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/colp_{{
+            version }}_csv.zip
+      - id: colp_readme
+        custom:
+          url: https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/data-tools/bytes/colp_readme.pdf
 
 files:
-- file:
-    id: primary_shapefile
-    filename: colp_single_feature_shp.zip
-    type: shapefile
-    custom:
-      ignore_validation:
-      - agreement
-      - dcpedited
-      - finalcom
-  dataset_overrides:
-    attributes:
-      description: description overridden at the dataset_file level
-      display_name: display_name overridden at the dataset_file level
-    overridden_columns:
-    - id: geom
-      name: geometry
-      data_type: geometry
-    - id: BBL
-      data_type: decimal
-    - id: MAPBBL
-      data_type: decimal
-- file:
-    id: primary_csv
-    filename: colp_single_feature.csv
-    type: csv
-  dataset_overrides:
-    omitted_columns:
-    - geom
-- file:
-    id: secondary_csv
-    filename: colp_single_feature_secondary.csv
-    type: csv
-  dataset_overrides:
-    omitted_columns:
-    - geom
-- file:
-    id: colp_readme
-    filename: colp_readme.pdf
-    is_metadata: true
-    type: None
-- file:
-    id: colp_metadata
-    filename: colp_metadata.pdf
-    is_metadata: true
-    type: None
+  - file:
+      id: primary_shapefile
+      filename: colp_single_feature_shp.zip
+      type: shapefile
+      custom:
+        ignore_validation:
+          - agreement
+          - dcpedited
+          - finalcom
+    dataset_overrides:
+      attributes:
+        description: description overridden at the dataset_file level
+        display_name: display_name overridden at the dataset_file level
+      overridden_columns:
+        - id: geom
+          name: geometry
+          data_type: geometry
+        - id: BBL
+          data_type: decimal
+        - id: MAPBBL
+          data_type: decimal
+  - file:
+      id: primary_csv
+      filename: colp_single_feature.csv
+      type: csv
+    dataset_overrides:
+      omitted_columns:
+        - geom
+  - file:
+      id: secondary_csv
+      filename: colp_single_feature_secondary.csv
+      type: csv
+    dataset_overrides:
+      omitted_columns:
+        - geom
+  - file:
+      id: colp_readme
+      filename: colp_readme.pdf
+      is_metadata: true
+      type: None
+  - file:
+      id: colp_metadata
+      filename: colp_metadata.pdf
+      is_metadata: true
+      type: None
 
 columns:
-- id: uid
-  name: uid
-  data_type: text
-  data_source: Department of City Planning
-  checks:
-    is_primary_key: true
-  example: cbe20732be28f6ab445289d7a67bb241
-- id: borough
-  name: BOROUGH
-  data_type: text
-  description: NYC borough - 1 (Manhattan), 2 (Bronx), 3 (Brooklyn), 4 (Queens), 5
-    (Staten Island)
-  checks:
-    non_nullable: true
-  example: None
-  values:
-  - value: '1'
-    description: Manhattan
-  - value: '2'
-    description: Bronx
-  - value: '3'
-    description: Brooklyn
-  - value: '4'
-    description: Queens
-  - value: '5'
-    description: Staten Island
-- id: tax_block
-  name: BLOCK
-  data_type: integer
-  description: The tax block in which the tax lot is located. Each tax block is unique
-    within a borough.
-  checks:
-    non_nullable: true
-  example: '1637'
-- id: tax_lot
-  name: LOT
-  data_type: integer
-  description: The number of the tax lot. Each tax lot is unique within a tax block.
-  checks:
-    non_nullable: true
-  example: '141'
-- id: bbl
-  name: BBL
-  data_type: number # Data imported incorrectly for these in the shapefile
-  checks:
-    non_nullable: true
-  example: '1016370141'
-  custom:
-    readme_data_type: double
-- id: mapbbl
-  name: MAPBBL
-  data_type: number # Data imported incorrectly for these in the shapefile
-  data_source: Department of City Planning - Geosupport
-  example: '1016370141'
-  custom:
-    readme_data_type: double
-- id: cd
-  name: CD
-  data_type: integer
-  data_source: Department of City Planning
-  example: '111'
-- id: hnum
-  name: HNUM
-  data_type: text
-  description: House number
-  example: '1955'
-- id: sname
-  name: SNAME
-  data_type: text
-  description: Name of the street
-  example: Third Avenue
-- id: address
-  name: ADDRESS
-  data_type: text
-  description: House number and street name
-  example: 1955 Third Avenue
-- id: parcelname
-  name: PARCELNAME
-  data_type: text
-  example: AGUILAR BRANCH LIBRARY
-- id: agency
-  name: AGENCY
-  data_type: text
-  example: NYPL
-- id: usecode
-  name: USECODE
-  data_type: text
-  description: The use code indicates how the lot is being used by the agency. See
-    Appendix B for a complete list of use codes and descriptions.
-  example: '218'
-- id: usetype
-  name: USETYPE
-  data_type: text
-  description: Description of how the lot is being used by the agency. See Appendix
-    B for a complete list of use codes and descriptions.
-  example: BRANCH LIBRARY
-- id: ownership
-  name: OWNERSHIP
-  data_type: text
-  description: Type of owner
-  checks:
-    non_nullable: true
-  example: None
-  values:
-  - value: C
-    description: City owned
-  - value: M
-    description: Mixed ownership
-  - value: P
-    description: Private
-  - value: O
-    description: Other/public authority (includes properties owned by federal and
-      state entities)
-- id: category
-  name: CATEGORY
-  data_type: integer
-  description: Category classifies lots as non-residential properties with a current
-    use, residential properties, or properties without a current use.
-  data_source: Department of City Planning
-  checks:
-    non_nullable: true
-  example: None
-  values:
-  - value: '1'
-    description: Non-residential properties with a current use
-  - value: '2'
-    description: Residential properties
-  - value: '3'
-    description: Properties with no current use
-- id: expandcat
-  name: EXPANDCAT
-  data_type: integer
-  description: This categorization classifies records into broad groups based on use.
-    Valid values are 1 - 9.
-  data_source: Department of City Planning
-  checks:
-    non_nullable: true
-  example: None
-  values:
-  - value: '1'
-    description: Office use
-  - value: '2'
-    description: Educational use
-  - value: '3'
-    description: Cultural & recreational use
-  - value: '4'
-    description: Public safety & criminal justice use
-  - value: '5'
-    description: Health & social service use
-  - value: '6'
-    description: Leased out to a private tenant
-  - value: '7'
-    description: Maintenance
+  - id: uid
+    name: uid
+    data_type: text
+    data_source: Department of City Planning
+    checks:
+      is_primary_key: true
+    example: cbe20732be28f6ab445289d7a67bb241
+  - id: borough
+    name: BOROUGH
+    data_type: text
+    description:
+      NYC borough - 1 (Manhattan), 2 (Bronx), 3 (Brooklyn), 4 (Queens), 5
+      (Staten Island)
+    checks:
+      non_nullable: true
+    example: None
+    values:
+      - value: "1"
+        description: Manhattan
+      - value: "2"
+        description: Bronx
+      - value: "3"
+        description: Brooklyn
+      - value: "4"
+        description: Queens
+      - value: "5"
+        description: Staten Island
+  - id: tax_block
+    name: BLOCK
+    data_type: integer
+    description:
+      The tax block in which the tax lot is located. Each tax block is unique
+      within a borough.
+    checks:
+      non_nullable: true
+    example: "1637"
+  - id: tax_lot
+    name: LOT
+    data_type: integer
+    description: The number of the tax lot. Each tax lot is unique within a tax block.
+    checks:
+      non_nullable: true
+    example: "141"
+  - id: bbl
+    name: BBL
+    data_type: number # Data imported incorrectly for these in the shapefile
+    checks:
+      non_nullable: true
+    example: "1016370141"
     custom:
-      other_details: '[''storage & infrastructure'']'
-  - value: '8'
-    description: Property with no use
-  - value: '9'
-    description: Property with a residential used
-- id: excatdesc
-  name: EXCATDESC
-  data_type: text
-  description: Descriptions for the expanded category values. See EXPANDCAT for the
-    domain values.
-  data_source: Department of City Planning
-  example: None
-- id: leased
-  name: LEASED
-  data_type: text
-  description: A value of "L" indicates that the agency's use of the property is authorized
-    through a lease. For questions about the lease or ownership status of specific
-    lots, please contact DCAS at (212) 386-0622 or RESPlanning311@dcas.nyc.gov.
-  example: None
-  values:
-  - value: L
-    description: Leased
-- id: finalcom
-  name: FINALCOM
-  data_type: text
-  description: A value of "D" indicates potential disposition by the City.
-  example: None
-  values:
-  - value: D
-    description: Potential Disposition
-- id: agreement
-  name: AGREEMENT
-  data_type: text
-  description: For City-owned properties that are leased to another entity, this field
-    indicates whether the agreement is short-term, long-term, or there are both short-
-    and long-term agreements present.
-  example: None
-  values:
-  - value: S
-    description: Short-term
-  - value: L
-    description: Long-term
-  - value: M
-    description: Mixed (there are both short- and long-term agreements on the property)
-- id: xcoord
-  name: XCOORD
-  data_type: integer
-  description: X coordinate based on the Geosupport label point for the billing BBL.
-    Coordinate system is NAD 1983 State Plane New York Long Island FIPS 3104 Feet.
-  data_source: Department of City Planning
-  example: '999900'
-- id: ycoord
-  name: YCOORD
-  data_type: integer
-  description: Y coordinate based on the Geosupport label point for the billing BBL.
-    Coordinate system is NAD 1983 State Plane New York Long Island FIPS 3104 Feet.
-  data_source: Department of City Planning
-  example: '228619'
-- id: latitude
-  name: LATITUDE
-  data_type: decimal
-  description: Latitude based on the Geosupport label point for the billing BBL. Coordinate
-    system is NAD_1983.
-  data_source: Department of City Planning
-  example: '40.794169'
-- id: longitude
-  name: LONGITUDE
-  data_type: decimal
-  description: Longitude based on the Geosupport label point for the billing BBL.
-    Coordinate system is NAD_1983.
-  data_source: Department of City Planning
-  example: '-73.943479'
-- id: dcpedited
-  name: DCPEDITED
-  data_type: text
-  description: City Planning modifies some records to correct street names or normalize
-    parcel names when programmatic cleaning is insufficient. If a field has been manually
-    modified, the original value can be found on GitHub in the modifications_applied.csv
-    available in Outputs file series.
-  data_source: Department of City Planning
-  example: None
-  values:
-  - value: Y
-    description: 'True'
-- id: geom
-  name: Geometry
-  data_type: geometry
-  description: Point geometry type
-  example: None
-  custom:
-    readme_data_type: geometry
+      readme_data_type: double
+  - id: mapbbl
+    name: MAPBBL
+    data_type: number # Data imported incorrectly for these in the shapefile
+    data_source: Department of City Planning - Geosupport
+    example: "1016370141"
+    custom:
+      readme_data_type: double
+  - id: cd
+    name: CD
+    data_type: integer
+    data_source: Department of City Planning
+    example: "111"
+  - id: hnum
+    name: HNUM
+    data_type: text
+    description: House number
+    example: "1955"
+  - id: sname
+    name: SNAME
+    data_type: text
+    description: Name of the street
+    example: Third Avenue
+  - id: address
+    name: ADDRESS
+    data_type: text
+    description: House number and street name
+    example: 1955 Third Avenue
+  - id: parcelname
+    name: PARCELNAME
+    data_type: text
+    example: AGUILAR BRANCH LIBRARY
+  - id: agency
+    name: AGENCY
+    data_type: text
+    example: NYPL
+  - id: usecode
+    name: USECODE
+    data_type: text
+    description:
+      The use code indicates how the lot is being used by the agency. See
+      Appendix B for a complete list of use codes and descriptions.
+    example: "218"
+  - id: usetype
+    name: USETYPE
+    data_type: text
+    description:
+      Description of how the lot is being used by the agency. See Appendix
+      B for a complete list of use codes and descriptions.
+    example: BRANCH LIBRARY
+  - id: ownership
+    name: OWNERSHIP
+    data_type: text
+    description: Type of owner
+    checks:
+      non_nullable: true
+    example: None
+    values:
+      - value: C
+        description: City owned
+      - value: M
+        description: Mixed ownership
+      - value: P
+        description: Private
+      - value: O
+        description:
+          Other/public authority (includes properties owned by federal and
+          state entities)
+  - id: category
+    name: CATEGORY
+    data_type: integer
+    description:
+      Category classifies lots as non-residential properties with a current
+      use, residential properties, or properties without a current use.
+    data_source: Department of City Planning
+    checks:
+      non_nullable: true
+    example: None
+    values:
+      - value: "1"
+        description: Non-residential properties with a current use
+      - value: "2"
+        description: Residential properties
+      - value: "3"
+        description: Properties with no current use
+  - id: expandcat
+    name: EXPANDCAT
+    data_type: integer
+    description:
+      This categorization classifies records into broad groups based on use.
+      Valid values are 1 - 9.
+    data_source: Department of City Planning
+    checks:
+      non_nullable: true
+    example: None
+    values:
+      - value: "1"
+        description: Office use
+      - value: "2"
+        description: Educational use
+      - value: "3"
+        description: Cultural & recreational use
+      - value: "4"
+        description: Public safety & criminal justice use
+      - value: "5"
+        description: Health & social service use
+      - value: "6"
+        description: Leased out to a private tenant
+      - value: "7"
+        description: Maintenance
+        custom:
+          other_details: "['storage & infrastructure']"
+      - value: "8"
+        description: Property with no use
+      - value: "9"
+        description: Property with a residential used
+  - id: excatdesc
+    name: EXCATDESC
+    data_type: text
+    description:
+      Descriptions for the expanded category values. See EXPANDCAT for the
+      domain values.
+    data_source: Department of City Planning
+    example: None
+  - id: leased
+    name: LEASED
+    data_type: text
+    description:
+      A value of "L" indicates that the agency's use of the property is authorized
+      through a lease. For questions about the lease or ownership status of specific
+      lots, please contact DCAS at (212) 386-0622 or RESPlanning311@dcas.nyc.gov.
+    example: None
+    values:
+      - value: L
+        description: Leased
+  - id: finalcom
+    name: FINALCOM
+    data_type: text
+    description: A value of "D" indicates potential disposition by the City.
+    example: None
+    values:
+      - value: D
+        description: Potential Disposition
+  - id: agreement
+    name: AGREEMENT
+    data_type: text
+    description:
+      For City-owned properties that are leased to another entity, this field
+      indicates whether the agreement is short-term, long-term, or there are both short-
+      and long-term agreements present.
+    example: None
+    values:
+      - value: S
+        description: Short-term
+      - value: L
+        description: Long-term
+      - value: M
+        description: Mixed (there are both short- and long-term agreements on the property)
+  - id: xcoord
+    name: XCOORD
+    data_type: integer
+    description:
+      X coordinate based on the Geosupport label point for the billing BBL.
+      Coordinate system is NAD 1983 State Plane New York Long Island FIPS 3104 Feet.
+    data_source: Department of City Planning
+    example: "999900"
+  - id: ycoord
+    name: YCOORD
+    data_type: integer
+    description:
+      Y coordinate based on the Geosupport label point for the billing BBL.
+      Coordinate system is NAD 1983 State Plane New York Long Island FIPS 3104 Feet.
+    data_source: Department of City Planning
+    example: "228619"
+  - id: latitude
+    name: LATITUDE
+    data_type: decimal
+    description:
+      Latitude based on the Geosupport label point for the billing BBL. Coordinate
+      system is NAD_1983.
+    data_source: Department of City Planning
+    example: "40.794169"
+  - id: longitude
+    name: LONGITUDE
+    data_type: decimal
+    description:
+      Longitude based on the Geosupport label point for the billing BBL.
+      Coordinate system is NAD_1983.
+    data_source: Department of City Planning
+    example: "-73.943479"
+  - id: dcpedited
+    name: DCPEDITED
+    data_type: text
+    description:
+      City Planning modifies some records to correct street names or normalize
+      parcel names when programmatic cleaning is insufficient. If a field has been manually
+      modified, the original value can be found on GitHub in the modifications_applied.csv
+      available in Outputs file series.
+    data_source: Department of City Planning
+    example: None
+    values:
+      - value: Y
+        description: "True"
+  - id: geom
+    name: Geometry
+    data_type: geometry
+    description: Point geometry type
+    example: None
+    custom:
+      readme_data_type: geometry

--- a/products/template/build_scripts/export.py
+++ b/products/template/build_scripts/export.py
@@ -3,7 +3,9 @@ import shutil
 from dcpy.lifecycle.package import generate_metadata_assets
 from dcpy.lifecycle.package import oti_xlsx
 from dcpy.connectors.edm import product_metadata, publishing
+from dcpy.models.geospatial.parquet import MetaData
 from dcpy.utils.logging import logger
+from dcpy.models.product.dataset import metadata_v2 as md
 
 from . import PRODUCT_PATH, OUTPUT_DIR, PG_CLIENT, BUILD_KEY
 
@@ -36,7 +38,7 @@ def generate_metadata():
         PRODUCT_PATH / "data_dictionary.pdf",
         generate_metadata_assets.DEFAULT_DATA_DICTIONARY_STYLESHEET_PATH,
     )
-    oti_xlsx.write_oti_xlsx(metadata_path=dataset_metadata_yml)
+    oti_xlsx.write_oti_xlsx(dataset=md.Metadata.from_path(dataset_metadata_yml).dataset)
 
 
 def export():

--- a/products/template/build_scripts/export.py
+++ b/products/template/build_scripts/export.py
@@ -3,7 +3,6 @@ import shutil
 from dcpy.lifecycle.package import generate_metadata_assets
 from dcpy.lifecycle.package import oti_xlsx
 from dcpy.connectors.edm import product_metadata, publishing
-from dcpy.models.geospatial.parquet import MetaData
 from dcpy.utils.logging import logger
 from dcpy.models.product.dataset import metadata_v2 as md
 


### PR DESCRIPTION
Certain datasets have multiple files or destinations with different attributes, for example the description. We currently only generate metadata for the base case. Ie we don't apply any overrides.

For example, a few LION datasets have a base dataset and a Water Included type. We only generate metadata for the base. This adds the ability to specify the dataset_id and file_id when generating the asset.