### PR TITLE
More Metadata Changes

### DIFF
--- a/dcpy/configuration.py
+++ b/dcpy/configuration.py
@@ -24,3 +24,5 @@ PRODUCTS_TO_LOG = [
     "db-zoningtaxlots",
 ]
 IGNORED_LOGGING_BUILDS = ["nightly_qa", "compile_python_reqs"]
+
+PRODUCT_METADATA_REPO_PATH = env.get("PRODUCT_METADATA_REPO_PATH")

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -124,23 +124,28 @@ class Socrata:
 
             @classmethod
             def from_dataset_attributes(cls, attrs: md.DatasetAttributes):
+                if not (attrs.category and attrs.agency and attrs.publishing_frequency):
+                    raise Exception(
+                        f"Required metadata fields are missing. Found category: {attrs.category}, agency: {attrs.agency} or publishing_frequency: {attrs.publishing_frequency}"
+                    )
+
                 return cls(
                     name=attrs.display_name,
                     description=attrs.description,
-                    category=attrs.category or "",
+                    category=attrs.category,
                     attribution=attrs.attribution or "",
                     attributionLink=attrs.attributionLink or "",
                     tags=attrs.tags or [],
                     metadata={
                         "rowLabel": attrs.each_row_is_a,
                         "custom_fields": {
-                            "Dataset Information": {"Agency": attrs.agency or ""},
+                            "Dataset Information": {"Agency": attrs.agency},
                             "Update": {
                                 "Data Change Frequency": attrs.publishing_frequency,
                                 "Date Made Public": attrs.date_made_public,
                                 "Update Frequency Details": attrs.publishing_frequency_details,
                                 "Update Frequency": translate_legislative_freq_to_update_freq(
-                                    attrs.publishing_frequency or ""
+                                    attrs.publishing_frequency
                                 )
                                 or attrs.publishing_frequency,
                                 "Automation": "Yes",
@@ -148,7 +153,7 @@ class Socrata:
                         },
                     },
                     privateMetadata={
-                        # "contactEmail": "opendata@planning.nyc.gov", # what's the right email?
+                        # "contactEmail": "", # Leaving this here in case we want to add it, so we don't have to remember what the field is called
                         "custom_fields": {
                             "Legislative Compliance": {
                                 "Removed Records?": "Yes",  # refers to row removal at time of push to Socrata. Always true since we overwrite the existing dataset.

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -114,7 +114,11 @@ class Socrata:
         class DatasetMetadata(BaseModel):
             name: str
             description: str
+            category: str
+            attribution: str
+            attributionLink: str
             tags: list[str]
+            # licenseId: str
             metadata: dict[str, Any]
             privateMetadata: dict[str, Any]
 
@@ -123,20 +127,28 @@ class Socrata:
                 return cls(
                     name=attrs.display_name,
                     description=attrs.description,
+                    category="City Government",
+                    attribution="Department of City Planning (DCP)",
+                    attributionLink="https://www.nyc.gov/site/planning/data-maps/open-data.page",
+                    # licenseId="ODC_BY", # TODO: what's the right license?
                     tags=attrs.tags,
                     metadata={
                         "rowLabel": attrs.each_row_is_a,
                         "custom_fields": {
+                            "Dataset Information": {
+                                "Agency": "Department of City Planning (DCP)"
+                            },
                             "Update": {
                                 "Update Frequency": translate_legislative_freq_to_update_freq(
                                     attrs.publishing_frequency or ""
                                 )
                                 or attrs.publishing_frequency,
                                 "Automation": "Yes",
-                            }
+                            },
                         },
                     },
                     privateMetadata={
+                        # "contactEmail": "opendata@planning.nyc.gov", # what's the right email?
                         "custom_fields": {
                             "Legislative Compliance": {
                                 "Removed Records?": "Yes",  # refers to row removal at time of push to Socrata. Always true since we overwrite the existing dataset.
@@ -153,8 +165,8 @@ class Socrata:
                                     if attrs.custom.get("dataset_from_open_data_plan")
                                     else "No"
                                 ),
-                            }
-                        }
+                            },
+                        },
                     },
                 )
 

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -127,18 +127,18 @@ class Socrata:
                 return cls(
                     name=attrs.display_name,
                     description=attrs.description,
-                    category="City Government",
-                    attribution="Department of City Planning (DCP)",
-                    attributionLink="https://www.nyc.gov/site/planning/data-maps/open-data.page",
-                    # licenseId="ODC_BY", # TODO: what's the right license?
-                    tags=attrs.tags,
+                    category=attrs.category or "",
+                    attribution=attrs.attribution or "",
+                    attributionLink=attrs.attributionLink or "",
+                    tags=attrs.tags or [],
                     metadata={
                         "rowLabel": attrs.each_row_is_a,
                         "custom_fields": {
-                            "Dataset Information": {
-                                "Agency": "Department of City Planning (DCP)"
-                            },
+                            "Dataset Information": {"Agency": attrs.agency or ""},
                             "Update": {
+                                "Data Change Frequency": attrs.publishing_frequency,
+                                "Date Made Public": attrs.date_made_public,
+                                "Update Frequency Details": attrs.publishing_frequency_details,
                                 "Update Frequency": translate_legislative_freq_to_update_freq(
                                     attrs.publishing_frequency or ""
                                 )

--- a/dcpy/lifecycle/package/assemble.py
+++ b/dcpy/lifecycle/package/assemble.py
@@ -265,7 +265,7 @@ def assemble_dataset_from_bytes_cli(
         BYTES_DEST_TYPE,
         "--source-destination-id",
         "-s",
-        help="Only Assemble Metadata.",
+        help="The Destination which acts as a source for this assembly",
     ),
 ):
     dataset_name = dataset or product

--- a/dcpy/lifecycle/scripts/package_and_distribute.py
+++ b/dcpy/lifecycle/scripts/package_and_distribute.py
@@ -28,7 +28,7 @@ def from_bytes_to_tagged_socrata(
     package_paths = {}
     for ds_id, dests_to_mds in dests.items():
         out_path = assemble.assemble_dataset_from_bytes(
-            dataset_md=product_md.dataset(ds_id),
+            dataset_metadata=product_md.dataset(ds_id),
             product=product,
             version=version,
             source_destination_id="bytes",

--- a/dcpy/lifecycle/scripts/package_and_distribute.py
+++ b/dcpy/lifecycle/scripts/package_and_distribute.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import typer
 from typing import Unpack
 
+from dcpy.configuration import PRODUCT_METADATA_REPO_PATH
 from dcpy.models.product import metadata as product_metadata
 from dcpy.lifecycle.distribute import socrata as soc_dist
 from dcpy.lifecycle.package import assemble
@@ -52,9 +53,14 @@ app = typer.Typer()
 
 @app.command("from_bytes_to_tagged_socrata")
 def from_bytes_to_tagged_socrata_cli(
-    org_metadata_path: Path,
     product: str,
     version: str,
+    org_metadata_path: Path = typer.Option(
+        PRODUCT_METADATA_REPO_PATH,
+        "-o",
+        "--metadata-path",
+        help="Path to metadata repo. Optionally, set in your env.",
+    ),
     destination_tag: str = typer.Option(
         None,
         "-t",

--- a/dcpy/lifecycle/scripts/package_and_distribute.py
+++ b/dcpy/lifecycle/scripts/package_and_distribute.py
@@ -9,28 +9,28 @@ from dcpy.utils.logging import logger
 
 
 def from_bytes_to_tagged_socrata(
-    product_metadata_path: Path,
+    org_metadata_path: Path,
+    product: str,
     version: str,
     destination_tag: str,
-    source_destination_id: str = "bytes",
     **publish_kwargs: Unpack[soc_dist.PublishKwargs],
 ):
     """Package tagged datsets from bytes, and distribute to Socrata."""
-    product = product_metadata.ProductMetadata.from_path(
-        root_path=product_metadata_path,
+    org_md = product_metadata.OrgMetadata.from_path(
+        path=org_metadata_path,
         template_vars={"version": version},
     )
-    dests = product.get_tagged_destinations(destination_tag)
+    product_md = org_md.product(product)
+    dests = product_md.get_tagged_destinations(destination_tag)
 
-    logger.info(f"Packaging {product.metadata.id}. Datasets: {list(dests.keys())}")
+    logger.info(f"Packaging {product_md.metadata.id}. Datasets: {list(dests.keys())}")
     package_paths = {}
     for ds_id, dests_to_mds in dests.items():
-        dataset_metadata = list(dests_to_mds.values())[0]
         out_path = assemble.assemble_dataset_from_bytes(
-            dataset_metadata,
-            product=product.metadata.id,
+            dataset_md=product_md.dataset(ds_id),
+            product=product,
             version=version,
-            source_destination_id=source_destination_id,
+            source_destination_id="bytes",
             metadata_only=publish_kwargs["metadata_only"],
         )
         package_paths[ds_id] = out_path
@@ -52,7 +52,8 @@ app = typer.Typer()
 
 @app.command("from_bytes_to_tagged_socrata")
 def from_bytes_to_tagged_socrata_cli(
-    product_metadata_path: Path,
+    org_metadata_path: Path,
+    product: str,
     version: str,
     destination_tag: str = typer.Option(
         None,
@@ -86,7 +87,8 @@ def from_bytes_to_tagged_socrata_cli(
     ),
 ):
     results = from_bytes_to_tagged_socrata(
-        product_metadata_path,
+        org_metadata_path,
+        product,
         version,
         destination_tag,
         publish=publish,

--- a/dcpy/lifecycle/scripts/package_and_distribute.py
+++ b/dcpy/lifecycle/scripts/package_and_distribute.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import typer
+from typing import Unpack
 
 from dcpy.models.product import metadata as product_metadata
 from dcpy.lifecycle.distribute import socrata as soc_dist
@@ -12,9 +13,9 @@ def from_bytes_to_tagged_socrata(
     version: str,
     destination_tag: str,
     source_destination_id: str = "bytes",
-    **publish_kwargs,
+    **publish_kwargs: Unpack[soc_dist.PublishKwargs],
 ):
-    """Package from bytes, and"""
+    """Package tagged datsets from bytes, and distribute to Socrata."""
     product = product_metadata.ProductMetadata.from_path(
         root_path=product_metadata_path,
         template_vars={"version": version},
@@ -30,6 +31,7 @@ def from_bytes_to_tagged_socrata(
             product=product.metadata.id,
             version=version,
             source_destination_id=source_destination_id,
+            metadata_only=publish_kwargs["metadata_only"],
         )
         package_paths[ds_id] = out_path
 
@@ -78,7 +80,7 @@ def from_bytes_to_tagged_socrata_cli(
     ),
     metadata_only: bool = typer.Option(
         False,
-        "-z",
+        "-m",
         "--metadata-only",
         help="Only push metadata (including attachments).",
     ),

--- a/dcpy/models/product/dataset/metadata_v2.py
+++ b/dcpy/models/product/dataset/metadata_v2.py
@@ -138,39 +138,36 @@ class Package(CustomizableBase):
     contents: List[PackageFile]
 
 
-# DATASET
-class DatasetAttributesOverride(CustomizableBase):
-    display_name: str | None = None
-    description: str | None = None
-    each_row_is_a: str | None = None
+class DatasetOrgProductAttributesOverride(CustomizableBase):
+    """Fields that might be set as a default at the Product/Org level."""
 
-    contains_address: bool | None = None
+    agency: str | None = None
+    attribution: str | None = None
+    attributionLink: str | None = None
+    category: str | None = None
+    contact_email: str | None = None
+    contains_address: bool | None = (
+        None  # `contains_address` refers specifically to addresses containing house, numbers + street names. (ie. not just streets, polys, etc.)
+    )
     date_made_public: str | None = None
-    publishing_purpose: str | None = None
     potential_uses: str | None = None
+    projection: str | None = None
     publishing_frequency: str | None = None  # TODO: picklist values
     publishing_frequency_details: str | None = None
-    projection: str | None = None  # TODO: does projection belong here?
+    publishing_purpose: str | None = None
+    tags: List[str] | None = []
 
-    tags: List[str] | None = None
+
+class DatasetAttributesOverride(DatasetOrgProductAttributesOverride):
+    description: str | None = None
+    display_name: str | None = None
+    each_row_is_a: str | None = None
 
 
-class DatasetAttributes(CustomizableBase):
+class DatasetAttributes(DatasetOrgProductAttributesOverride):
     display_name: str
     description: str = ""
     each_row_is_a: str
-
-    # `contains_address` refers specifically to addresses containing house
-    # numbers + street names. (ie. not just streets, polys, etc.)
-    contains_address: bool | None = None
-    date_made_public: str | None = None
-    publishing_purpose: str | None = None
-    potential_uses: str | None = None
-    publishing_frequency: str | None = None  # TODO: picklist values
-    publishing_frequency_details: str | None = None
-    projection: str | None = None  # TODO: does projection belong here?
-
-    tags: List[str] = []
 
     def override(self, overrides: DatasetAttributesOverride) -> DatasetAttributes:
         return DatasetAttributes(**merge(self.model_dump(), overrides.model_dump()))

--- a/dcpy/models/product/dataset/metadata_v2.py
+++ b/dcpy/models/product/dataset/metadata_v2.py
@@ -267,6 +267,9 @@ class Metadata(CustomizableBase, YamlWriter, TemplatedYamlReader):
             raise Exception(f"There should exist one destination with id: {id}")
         return dests[0]
 
+    def get_file_ids(self):
+        return {f.file.id for f in self.files}
+
     def get_file_and_overrides(self, file_id: str) -> FileAndOverrides:
         files = [f for f in self.files if f.file.id == file_id]
         if len(files) != 1:

--- a/dcpy/test/lifecycle/package/test_assemble_from_bytes.py
+++ b/dcpy/test/lifecycle/package/test_assemble_from_bytes.py
@@ -108,7 +108,7 @@ def test_plan_errors_for_socrata():
 
 @patch("dcpy.lifecycle.package.assemble.unzip_into_package")
 @patch("urllib.request.urlretrieve")
-def test_pull_destination_files_mocked(mock_urlretrieve, mock_unpackage, tmp_path):
+def test_pull_destination_files(mock_urlretrieve, mock_unpackage, tmp_path):
     assemble.pull_destination_files(
         tmp_path, make_metadata(), BYTES_DEST_WITH_INDIVIDUAL_FILES, unpackage_zips=True
     )
@@ -134,6 +134,26 @@ def test_pull_destination_files_mocked(mock_urlretrieve, mock_unpackage, tmp_pat
     assert (
         1 == mock_unpackage.call_count
     ), "`unpackage` should have been invoked on the zipfile."
+
+
+@patch("urllib.request.urlretrieve")
+def test_pull_destination_files_md_only(mock_urlretrieve, tmp_path):
+    assemble.pull_destination_files(
+        tmp_path,
+        make_metadata(),
+        BYTES_DEST_WITH_INDIVIDUAL_FILES,
+        metadata_only=True,
+    )
+
+    expected_calls = [
+        call(
+            "https://s-media.nyc.gov/agencies/dcp/assets/files/my_data_dict.pdf",
+            tmp_path / Path("attachments/data_dict.pdf"),
+        ),
+    ]
+
+    assert len(expected_calls) == mock_urlretrieve.call_count
+    mock_urlretrieve.assert_has_calls(expected_calls)
 
 
 @pytest.fixture

--- a/dcpy/test/lifecycle/package/test_assemble_from_bytes.py
+++ b/dcpy/test/lifecycle/package/test_assemble_from_bytes.py
@@ -182,7 +182,7 @@ def test_assemble_from_bytes(pull_destination_files_mock, tmp_path, colp_package
         )
 
     assemble.assemble_dataset_from_bytes(
-        metadata,
+        dataset_metadata=metadata,
         source_destination_id="socrata",
         out_path=tmp_path,
         product="colp",

--- a/dcpy/test/models/product/test_metadata.py
+++ b/dcpy/test/models/product/test_metadata.py
@@ -15,20 +15,21 @@ def lion_md_path(test_metadata_repo: Path):
     return test_metadata_repo / "products" / "lion"
 
 
-lion_product_level_pub_freq = "monthly"
-pseudo_lots_pub_freq = "bimonthly"
+lion_product_level_pub_freq = "lion_product_freq"
+pseudo_lots_pub_freq = "pseudo_lots-freq"
+agency = "DCP"
 template_vars = {
     "version": "24c",
     "lion_prod_level_pub_freq": lion_product_level_pub_freq,
     "pseudo_lots_pub_freq": pseudo_lots_pub_freq,
+    "agency": agency,
 }
 PRODUCT_WITH_ERRORS = "mock_product_with_errors"
 
 
-def test_dataset_md_overrides(lion_md_path: Path):
-    lion_md = md.ProductMetadata.from_path(
-        root_path=lion_md_path, template_vars=template_vars
-    )
+def test_org_md_overrides(test_metadata_repo: Path):
+    org_md = md.OrgMetadata.from_path(test_metadata_repo, template_vars=template_vars)
+    lion_md = org_md.product("lion")
     pseudo_lots_with_defaults = lion_md.dataset("pseudo_lots")
 
     # Display name is both a product and dataset field. However, the product.display_name
@@ -36,22 +37,21 @@ def test_dataset_md_overrides(lion_md_path: Path):
     assert (
         pseudo_lots_with_defaults.attributes.display_name
         != lion_md.metadata.attributes.display_name
-    ), "Product-level attrbite `display_name` should not be overridden."
+    ), "Product-level attribute `display_name` should not be overridden."
 
     assert (
         pseudo_lots_with_defaults.attributes.publishing_frequency
         == pseudo_lots_pub_freq
-    ), "Pseudo lots pub-freq should not be effected by the defaults."
-
-    assert (
-        pseudo_lots_with_defaults.attributes.publishing_frequency
-        == pseudo_lots_pub_freq
-    ), "Pseudo lots pub-freq should not be effected by the defaults."
+    ), "Pseudo lots pub-freq should not be affected by the product defaults."
 
     assert (
         pseudo_lots_with_defaults.attributes.publishing_purpose
         == lion_md.metadata.dataset_defaults.publishing_purpose
     ), "The missing field `publishing_purpose` should use the product-level default"
+
+    assert (
+        pseudo_lots_with_defaults.attributes.agency == agency
+    ), "The field `agency` should use the org-level default"
 
 
 def test_get_tagged_destinations(lion_md_path: Path):

--- a/dcpy/test/models/product/test_metadata.py
+++ b/dcpy/test/models/product/test_metadata.py
@@ -50,7 +50,7 @@ def test_dataset_md_overrides(lion_md_path: Path):
 
     assert (
         pseudo_lots_with_defaults.attributes.publishing_purpose
-        == lion_md.metadata.attributes.publishing_purpose
+        == lion_md.metadata.dataset_defaults.publishing_purpose
     ), "The missing field `publishing_purpose` should use the product-level default"
 
 

--- a/dcpy/test/resources/product_metadata/assembled_package_and_metadata/metadata.yml
+++ b/dcpy/test/resources/product_metadata/assembled_package_and_metadata/metadata.yml
@@ -1,6 +1,9 @@
 id: test
 
 attributes:
+  agency: DCP
+  category: City Gov
+  publishing_frequency: often
   description: attrs_description
   display_name: attrs_display_name
   each_row_is_a: attrs_each_row_is_a

--- a/dcpy/test/resources/test_product_metadata_repo/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo/metadata.yml
@@ -1,5 +1,5 @@
 attributes:
-  agency: DCP
+  agency: "{{ agency }}"
   category: City Government
   attribution: DCP
   attributionLink: https://www.nyc.gov/site/planning/data-maps/open-data.page

--- a/dcpy/test/resources/test_product_metadata_repo/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo/metadata.yml
@@ -1,3 +1,10 @@
+attributes:
+  agency: DCP
+  category: City Government
+  attribution: DCP
+  attributionLink: https://www.nyc.gov/site/planning/data-maps/open-data.page
+  contact_email: opendata@planning.nyc.gov
+
 products:
   - lion
   - transit_zones

--- a/dcpy/test/resources/test_product_metadata_repo/products/lion/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo/products/lion/metadata.yml
@@ -2,7 +2,9 @@ id: lion
 
 attributes:
   display_name: LION Product Display Name
-  description: The lion dataset blah blah
+  description: The entire lion product
+
+dataset_defaults:
   publishing_frequency: "{{ lion_prod_level_pub_freq }}"
   publishing_purpose: "legal compliance."
 

--- a/dcpy/test/resources/test_product_metadata_repo_with_snippets/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo_with_snippets/metadata.yml
@@ -1,2 +1,5 @@
+attributes:
+  agency: DCP
+
 products:
   - test_product

--- a/dcpy/test/resources/test_product_metadata_repo_with_snippets/products/test_product/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo_with_snippets/products/test_product/metadata.yml
@@ -3,8 +3,6 @@ id: test_product
 attributes:
   display_name: Test Product
   description: Product description {{ sample_text }}
-  publishing_frequency: yearly
-  publishing_purpose: "legal compliance."
 
 datasets:
   - test_dataset


### PR DESCRIPTION
This ties up a bunch of lose ends:
- and adds quality of life improvements for the CLI
- changes CLI to point at the entire product metadata repo, rather than individual dataset md files
- implements Org-Level defaults
- Implements those defaults in the Socrata publish connector
- Implements metadata-only package_from_bytes+deployment. 

Commits are very atomic and tidy (the only leakage is in the last commit). Rationale for changes is included in the commit message for each commit.

Product Metadata Repo PR with related changes [here](https://github.com/NYCPlanning/product-metadata/pull/20)
Note: the `Tests / test / Validate Product Metadata` will fail (both here and in the product metadata repo) until we merge both of these. So they should go together.