### PR TITLE
PLUTO dbt QA: update test to check version of ignored bbls

### DIFF
--- a/products/pluto/dbt_project.yml
+++ b/products/pluto/dbt_project.yml
@@ -8,3 +8,6 @@ test-paths: ["tests"]
 tests:
   +store_failures: true
   schema: "_tests"
+
+vars:
+  version: "{{ env_var('VERSION') }}"

--- a/products/pluto/seeds/_seeds.yml
+++ b/products/pluto/seeds/_seeds.yml
@@ -9,3 +9,4 @@ seeds:
     config:
       column_types:
         bbl: text
+        pluto_version: text

--- a/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
+++ b/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
@@ -54,6 +54,7 @@ not_ignored_primebbls AS (
     WHERE primebbl NOT IN (
         SELECT bbl
         FROM {{ ref('ignored_bbls_for_unit_count_test') }}
+        WHERE '{{ var('version') }}' = pluto_version
     )
 ),
 


### PR DESCRIPTION
### What
Update logic of newly implemented test for PLUTO build to only ignore "ignored" bbls in the seed file if their version is the same as of PLUTO being build. For example, a seed file with "ignored bbls" can look like this:

```csv
bbl,pluto_version
3001497501,24v3
3038627501,24v3
4155377501,24v1
```

If we are building PLUTO 24v3, we shouldn't ignore the last bbl that was added during 24v1 because the raw data for this bbl could change. With the new logic, we will only be ingoring the first 2 bbls because their version equals to the current PLUTO version.

### Why not to overwrite this file for each PLUTO build? 
Because we need a deterministic way of building any PLUTO version. If we 'ignored' some bbls during past PLUTO, we want to be able to rebuild same output for the past PLUTO.


### Receipts it works
* PLUTO build with no records to ignore (empty seed file) [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11225072798/job/31203060304#step:16:189). There are 12 failing records
* PLUTO build with 12 records to ignore where 1 record has a different version [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11241736679/job/31253925842#step:16:189). As expected, only 1 record failed.