### PR TITLE
PLUTO: tag tests based on PLUTO version type (major vs minor)

### DIFF
--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -38,6 +38,7 @@ jobs:
       RECIPES_BUCKET: ${{ inputs.dev_bucket || 'edm-recipes' }}
       PUBLISHING_BUCKET: ${{ inputs.dev_bucket || 'edm-publishing' }}
       DEV_FLAG: ${{ inputs.dev_bucket && 'true' || 'false' }}
+      TEST_SEVERITY: ${{ contains(inputs.build_name, 'nightly_qa') && 'warn' || 'error' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -84,6 +84,9 @@ def plan_recipe(recipe_path: Path, version: str | None = None) -> Recipe:
     recipe.vars = recipe.vars or {}
     recipe.vars["VERSION"] = recipe.version
 
+    if recipe.version_type is not None:
+        recipe.vars["VERSION_TYPE"] = recipe.version_type.value
+
     # Determine previous version
     try:
         previous_recipe = publishing.get_previous_version(

--- a/dcpy/test/lifecycle/builds/resources/recipe_w_version_type.yml
+++ b/dcpy/test/lifecycle/builds/resources/recipe_w_version_type.yml
@@ -1,0 +1,9 @@
+name: Tester
+version: 23v1
+
+product: db-test
+version_type: major
+inputs:
+  datasets:
+    - name: has_pinned_version
+      file_type: csv

--- a/dcpy/test/lifecycle/builds/test_plan.py
+++ b/dcpy/test/lifecycle/builds/test_plan.py
@@ -182,8 +182,6 @@ class TestRecipesNoDefaults(TestCase):
         plan.recipe_from_yaml(lock_file)
 
 
-@pytest.mark.usefixtures("file_setup_teardown")
-@pytest.mark.usefixtures("create_buckets")
 @patch("dcpy.connectors.edm.recipes.get_latest_version")
 class TestRecipeVars(TestCase):
     def test_version_type_var_is_absent(self, get_latest_version):
@@ -196,7 +194,8 @@ class TestRecipeVars(TestCase):
 
     def test_version_type_is_present(self, get_latest_version):
         """Test that the version_type is set correctly and matches env 'VERSION_TYPE' variable."""
-        planned = plan.plan_recipe(RECIPE_W_VERSION_TYPE)
+        version = "test_version"
+        planned = plan.plan_recipe(RECIPE_W_VERSION_TYPE, version)
         assert planned.version_type is not None  # sanity check
         assert (
             planned.version_type == planned.vars["VERSION_TYPE"]

--- a/dcpy/test/lifecycle/builds/test_plan.py
+++ b/dcpy/test/lifecycle/builds/test_plan.py
@@ -22,8 +22,7 @@ PRODUCT = "Tester"
 MOCKED_LATEST_VERSION = "v1"
 
 
-def setup():
-    # TEMP_DATA_PATH.mkdir(exist_ok=True)
+def add_required_version_var_to_env():
     os.environ[REQUIRED_VERSION_ENV_VAR] = "v123"
 
 
@@ -116,7 +115,7 @@ class TestRecipesWithDefaults(TestCase):
             assert REQUIRED_VERSION_ENV_VAR in str(e.exception)
 
     def test_provide_manual_version(self, get_latest_version):
-        setup()
+        add_required_version_var_to_env()
         version = "test_version"
         planned = plan.plan_recipe(RECIPE_PATH, version=version)
         assert planned.version == version
@@ -124,7 +123,7 @@ class TestRecipesWithDefaults(TestCase):
 
     def test_plan_recipe_defaults(self, get_latest_version):
         """Tests that defaults are set correctly when a recipe is planned."""
-        setup()
+        add_required_version_var_to_env()
         get_latest_version.return_value = MOCKED_LATEST_VERSION
         planned = plan.plan_recipe(RECIPE_PATH)
 
@@ -150,7 +149,7 @@ class TestRecipesWithNoVersion(TestCase):
 
     @patch("dcpy.connectors.edm.recipes.get_latest_version")
     def test_provide_manual_version(self, get_latest_version):
-        setup()
+        add_required_version_var_to_env()
         version = "test_version"
         planned = plan.plan_recipe(RECIPE_NO_VERSION_PATH, version=version)
         assert planned.version == version
@@ -163,7 +162,7 @@ class TestRecipesWithNoVersion(TestCase):
 class TestRecipesNoDefaults(TestCase):
     def test_plan_recipe_default_type(self, get_file_types):
         """Tests that default type is pg_dump if found when not otherwise specified."""
-        setup()
+        add_required_version_var_to_env()
         get_file_types.return_value = {
             recipes.DatasetType.pg_dump,
             recipes.DatasetType.parquet,
@@ -186,7 +185,7 @@ class TestRecipesNoDefaults(TestCase):
 class TestRecipeVars(TestCase):
     def test_version_type_var_is_absent(self, get_latest_version):
         """Ensures VERSION_TYPE is absent in recipe 'vars' attribute when version_type is None."""
-        setup()
+        add_required_version_var_to_env()
         version = "test_version"
         planned = plan.plan_recipe(RECIPE_PATH, version=version)
         assert planned.version_type is None  # sanity check

--- a/products/pluto/dbt_project.yml
+++ b/products/pluto/dbt_project.yml
@@ -11,3 +11,4 @@ tests:
 
 vars:
   version: "{{ env_var('VERSION') }}"
+  version_type: "{{ env_var('VERSION_TYPE') }}"

--- a/products/pluto/dbt_project.yml
+++ b/products/pluto/dbt_project.yml
@@ -7,6 +7,7 @@ test-paths: ["tests"]
 
 tests:
   +store_failures: true
+  +severity: "{{ env_var('TEST_SEVERITY') }}"
   schema: "_tests"
 
 vars:

--- a/products/pluto/models/_sources.yml
+++ b/products/pluto/models/_sources.yml
@@ -52,3 +52,7 @@ sources:
         description: |
           Processed PTS data where each record is a UNIT BBL: i.e. there are multiple
           records per a condominium.
+
+      - name: previous_pluto
+      - name: export_pluto
+        description: final PLUTO table

--- a/products/pluto/pluto_build/07_custom_qaqc.sh
+++ b/products/pluto/pluto_build/07_custom_qaqc.sh
@@ -19,4 +19,4 @@ echo "Build intermediate QAQC tables"
 dbt build --select qaqc --exclude tag:de_check
 
 echo "🔥 Run DE aka important tests 🔥"
-dbt test --select tag:de_check
+dbt test --select tag:de_check,tag:$VERSION_TYPE    # this will only run tests that have both tags, not just one of them

--- a/products/pluto/pluto_build/07_custom_qaqc.sh
+++ b/products/pluto/pluto_build/07_custom_qaqc.sh
@@ -16,7 +16,7 @@ echo "Build staging tables"
 dbt build --select staging --exclude tag:de_check
 
 echo "Build intermediate QAQC tables"
-dbt run --select qaqc --exclude tag:de_check  # need to use 'dbt run' because otherwise it fails if downstream test fails
+dbt build --select qaqc --exclude tag:de_check
 
 echo "🔥 Run DE aka important tests 🔥"
 dbt test --select tag:de_check

--- a/products/pluto/recipe-minor.yml
+++ b/products/pluto/recipe-minor.yml
@@ -28,3 +28,6 @@ inputs:
       # this env var is set in dcpy/builds/plan.py in a slightly hacky way for now
       version_env_var: VERSION_PREV
       import_as: previous_pluto
+
+    - name: dcp_developments # this dataset isn't actually used in PLUTO minor; this is a temp fix to address current code limitations when planning a recipe
+      version: latest

--- a/products/pluto/recipe-minor.yml
+++ b/products/pluto/recipe-minor.yml
@@ -3,6 +3,8 @@ base_recipe: recipe.yml
 version_type: minor
 version_strategy: bump_latest_release
 product: db-pluto
+vars:
+  VERSION_TYPE: minor
 inputs:
   missing_versions_strategy: copy_latest_release
   datasets:
@@ -24,5 +26,5 @@ inputs:
       version: latest
     - name: dcp_pluto
       # this env var is set in dcpy/builds/plan.py in a slightly hacky way for now
-      version_env_var: VERSION_PREV 
+      version_env_var: VERSION_PREV
       import_as: previous_pluto

--- a/products/pluto/recipe-minor.yml
+++ b/products/pluto/recipe-minor.yml
@@ -3,8 +3,6 @@ base_recipe: recipe.yml
 version_type: minor
 version_strategy: bump_latest_release
 product: db-pluto
-vars:
-  VERSION_TYPE: minor
 inputs:
   missing_versions_strategy: copy_latest_release
   datasets:

--- a/products/pluto/recipe.yml
+++ b/products/pluto/recipe.yml
@@ -2,6 +2,8 @@ name: Pluto Major
 version_strategy: bump_latest_release
 version_type: major
 product: db-pluto
+vars:
+  VERSION_TYPE: major
 inputs:
   missing_versions_strategy: find_latest
   datasets:

--- a/products/pluto/recipe.yml
+++ b/products/pluto/recipe.yml
@@ -2,8 +2,6 @@ name: Pluto Major
 version_strategy: bump_latest_release
 version_type: major
 product: db-pluto
-vars:
-  VERSION_TYPE: major
 inputs:
   missing_versions_strategy: find_latest
   datasets:

--- a/products/pluto/tests/assert_bbl_count_is_the_same.sql
+++ b/products/pluto/tests/assert_bbl_count_is_the_same.sql
@@ -1,0 +1,34 @@
+{{ 
+    config(
+        tags = ['de_check', 'minor'], 
+        meta = {
+            'description': '''
+				This test checks that final PLUTO table has same row count as previous version PLUTO. 
+                This test is expected to pass for PLUTO Minor versions only.
+			''',
+            'next_steps': '''
+				Investigate if a correct recipe file was used. If so, review stats for input datasets. 
+                This needs to be addressed prior to promoting PLUTO for GIS review.
+			'''
+        }
+    ) 
+}}
+
+WITH current_pluto AS (
+    SELECT bbl::bigint, 'current' AS source
+    FROM {{ source('build_sources', 'export_pluto') }}
+),
+previous_pluto AS (
+    SELECT bbl::decimal::bigint, 'previous' AS source
+    FROM {{ source('build_sources', 'previous_pluto') }}
+)
+
+-- query to detect differences and isolate records absent in one of the tables
+SELECT COALESCE(current_pluto.bbl, previous_pluto.bbl) AS bbl,
+       COALESCE(current_pluto.source, previous_pluto.source) AS source
+FROM current_pluto
+FULL OUTER JOIN previous_pluto
+    ON current_pluto.bbl = previous_pluto.bbl
+WHERE current_pluto.bbl IS NULL
+   OR previous_pluto.bbl IS NULL
+ORDER BY source

--- a/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
+++ b/products/pluto/tests/assert_condo_bbl_unit_count_research_required.sql
@@ -1,6 +1,6 @@
 {{ 
     config(
-        tags = ['de_check'], 
+        tags = ['de_check', 'major'], 
         meta = {
             'description': '''
 				This test identifies condo records that likely have incorrect unit counts in DOF PTS data, affecting the final PLUTO table. 


### PR DESCRIPTION
### What 

* Add `version_type` env variable to PLUTO minor and major recipe files.
* Create `major` and `minor` tags in `dbt` tests. Depending on the `version_type` value (`major` or `minor`), corresponding tests will run. If a test is tagged with both `major` and `minor`, then it will run for both PLUTO versions. 
* Create new singular test for PLUTO minor version, checking pluto total record count is the same as in previous PLUTO version. 

### GHA runs:
* PLUTO major [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11296716119/job/31422129835#step:16:183). As expected, it only ran the `assert_condo_bbl...` test (testing condo bbl unit counts), which has a `major` tag
* PLUTO minor [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11294916986/job/31416489905#step:16:184). As expected, it only ran the new test tagged as `minor`