### PR TITLE
Product Logging: Add sql scripts used for creating views in db

### DIFF
--- a/dcpy/migrations/create_latest_version_status.sql
+++ b/dcpy/migrations/create_latest_version_status.sql
@@ -1,0 +1,40 @@
+/*
+View: latest_version_status
+ 
+This view selects the latest event for each product version 
+from the event_logging table, excluding 'db-template'. 
+It ranks events by priority ('publish', 'promote_to_draft', 'build') 
+and timestamp, returning the top-ranked event.
+*/
+
+CREATE VIEW product_data.latest_version_status AS (
+    WITH exclude_template AS (
+        SELECT * 
+        FROM product_data.event_logging 
+        WHERE product <> 'db-template'
+    ),
+    ranked_events AS (
+        SELECT *,
+            ROW_NUMBER() OVER (
+                PARTITION BY product, version
+                ORDER BY 
+                    CASE 
+                        WHEN event IN ('publish', 'promote_to_draft') THEN 1
+                        WHEN event = 'build' THEN 2
+                    END, 
+                    timestamp DESC
+            ) AS rank
+        FROM exclude_template
+    )
+    SELECT 
+        product,
+        version,
+        event,
+        path,
+        old_path,
+        runner_type,
+        runner,
+        timestamp
+    FROM ranked_events
+    WHERE rank = 1
+);

--- a/dcpy/migrations/create_product_version_lifecycle.sql
+++ b/dcpy/migrations/create_product_version_lifecycle.sql
@@ -1,0 +1,51 @@
+/*
+View: product_version_lifecycle
+
+This query aggregates information from the event logging table per product + version.
+It returns only product versions that have both publish and draft events,
+including the count of published and draft records, the earliest draft 
+timestamp, the latest publish timestamp, and the difference in days 
+between the two timestamps.
+ */
+
+CREATE VIEW product_data.product_version_lifecycle AS (
+    WITH latest_publish AS (
+        SELECT 
+            product, 
+            version, 
+            COUNT(*) AS publish_count, 
+            MAX(timestamp) AS latest_publish_timestamp
+        FROM product_data.event_logging
+        WHERE product <> 'db-template' 
+        AND event = 'publish'
+        GROUP BY 
+            product, 
+            version
+    ),
+    earliest_draft AS (
+        SELECT 
+            product, 
+            version, 
+            COUNT(*) AS draft_count, 
+            MIN(timestamp) AS earliest_draft_timestamp
+        FROM product_data.event_logging
+        WHERE product <> 'db-template'
+        AND event = 'promote_to_draft'
+        GROUP BY 
+            product, 
+            version
+    )
+    SELECT 
+        published.product, 
+        published.version, 
+        published.publish_count, 
+        draft.draft_count, 
+        draft.earliest_draft_timestamp,
+        published.latest_publish_timestamp, 
+        DATE_PART('day', published.latest_publish_timestamp - draft.earliest_draft_timestamp) AS total_days
+    FROM latest_publish AS published
+    INNER JOIN earliest_draft AS draft
+        ON published.product = draft.product 
+        AND published.version = draft.version
+    )
+);


### PR DESCRIPTION
I created a couple of views built on top of the logging table. Adding the scripts used for the views. 

What these views look like: 

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/90886743-529b-497a-ac72-e1aaeb8c7800">

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/a7b1dd74-7fb4-471d-8dcc-300cba5af7e2">
