### PR TITLE
GFT tweaks for 24v3 draft 1 review

### DIFF
--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -341,11 +341,13 @@ def _cli_wrapper_repeat_recipe(
     ),
 ):
     product_key: publishing.BuildKey | publishing.DraftKey | publishing.PublishKey
-
+    product_label = (
+        "db-green-fast-track" if product == "green_fast_track" else f"db-{product}"
+    )
     match product_type:
         case "build":
             product_key = publishing.BuildKey(
-                product=f"db-{product}", build=version_or_build
+                product=product_label, build=version_or_build
             )
         case "draft":
             if draft_revision_number is None:
@@ -353,18 +355,18 @@ def _cli_wrapper_repeat_recipe(
                     "For repeating builds of 'draft' type, need to provide draft revision number"
                 )
             draft_revision = publishing.get_draft_revision_label(
-                product=f"db-{product}",
+                product=product_label,
                 version=version_or_build,
                 revision_num=draft_revision_number,
             )
             product_key = publishing.DraftKey(
-                product=f"db-{product}",
+                product=product_label,
                 version=version_or_build,
                 revision=draft_revision,
             )
         case "publish":
             product_key = publishing.PublishKey(
-                product=f"db-{product}", version=version_or_build
+                product=product_label, version=version_or_build
             )
         case _:
             raise ValueError(

--- a/products/green_fast_track/models/product/source/air_quality/source__cats_permit_lots.sql
+++ b/products/green_fast_track/models/product/source/air_quality/source__cats_permit_lots.sql
@@ -3,3 +3,4 @@ SELECT
     variable_id,
     lot_geom
 FROM {{ ref("int_spatial__cats_permits") }}
+WHERE lot_geom IS NOT NULL

--- a/products/green_fast_track/models/product/source/air_quality/source__state_facility_lots.sql
+++ b/products/green_fast_track/models/product/source/air_quality/source__state_facility_lots.sql
@@ -3,3 +3,4 @@ SELECT
     variable_id,
     lot_geom
 FROM {{ ref("int_spatial__state_facility") }}
+WHERE lot_geom IS NOT NULL

--- a/products/green_fast_track/models/product/source/air_quality/source__title_v_permit_lots.sql
+++ b/products/green_fast_track/models/product/source/air_quality/source__title_v_permit_lots.sql
@@ -3,3 +3,4 @@ SELECT
     variable_id,
     lot_geom
 FROM {{ ref("int_spatial__title_v_permit") }}
+WHERE lot_geom IS NOT NULL

--- a/products/green_fast_track/models/product/source/historic_resources/source__historic_resources_adj_lots.sql
+++ b/products/green_fast_track/models/product/source/historic_resources/source__historic_resources_adj_lots.sql
@@ -3,3 +3,4 @@ SELECT
     variable_id,
     lot_geom
 FROM {{ ref("int_spatial__historic_resources_adj") }}
+WHERE lot_geom IS NOT NULL

--- a/products/green_fast_track/models/product/source/historic_resources/source__historic_resources_lots.sql
+++ b/products/green_fast_track/models/product/source/historic_resources/source__historic_resources_lots.sql
@@ -3,3 +3,4 @@ SELECT
     variable_id,
     lot_geom
 FROM {{ ref("int_spatial__historic_resources") }}
+WHERE lot_geom IS NOT NULL

--- a/products/green_fast_track/models/product/source/shadow/source__shadow_open_spaces_polys.sql
+++ b/products/green_fast_track/models/product/source/shadow/source__shadow_open_spaces_polys.sql
@@ -1,6 +1,13 @@
 SELECT
     variable_type,
     variable_id,
-    raw_geom
+    raw_geom AS geom
 FROM {{ ref("int_spatial__shadow_open_spaces") }}
-WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPolygon'
+WHERE ST_GEOMETRYTYPE(raw_geom) = 'ST_MultiPolygon' AND lot_geom IS NULL
+UNION ALL
+SELECT
+    variable_type,
+    variable_id,
+    lot_geom AS geom
+FROM {{ ref("int_spatial__shadow_open_spaces") }}
+WHERE lot_geom IS NOT NULL


### PR DESCRIPTION
Tweaks for https://github.com/NYCPlanning/data-engineering/issues/1004#issuecomment-2414555945

rebuild [here](https://github.com/NYCPlanning/data-engineering/actions/runs/11351451569/job/31572066514)

Next draft is in QA, but I think it makes sense to get this merged in the meantime and follow-up as needed.

Changes are
1. making sure that when we export both `points` and `lots` source dataset outputs that the `lots` only contain rows where the geom is not null
2. make sure that for open spaces/shadow polys, we're exporting both poly raw geoms and points that were joined to lots.