### PR TITLE
Fix test severity to `warn` for PLUTO when running compile_python_reqs

### DIFF
--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -38,7 +38,7 @@ jobs:
       RECIPES_BUCKET: ${{ inputs.dev_bucket || 'edm-recipes' }}
       PUBLISHING_BUCKET: ${{ inputs.dev_bucket || 'edm-publishing' }}
       DEV_FLAG: ${{ inputs.dev_bucket && 'true' || 'false' }}
-      TEST_SEVERITY: ${{ contains(inputs.build_name, 'nightly_qa') && 'warn' || 'error' }}
+      TEST_SEVERITY: ${{ contains(fromJson('["nightly_qa", "compile_python_reqs"]'), inputs.build_name) && 'warn' || 'error' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
PLUTO build fails when compiling python reqs (example #1216) because of incorrect dbt test severity. This PR changes severity from `error` to `warn` for python reqs builds.

[Reference](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-matching-an-array-of-strings) for GHA syntax used in the fix.