### PR TITLE
ensure all products build in nightly qa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           echo "${{ toJSON(github.event.inputs) }}"
   template:
     needs: health_check
-    if: inputs.dataset_name == 'template'
+    if: inputs.dataset_name == 'template' || inputs.dataset_name  == 'all'
     uses: ./.github/workflows/template_build.yml
     secrets: inherit
     with:
@@ -183,7 +183,7 @@ jobs:
       dev_bucket: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || '' }}
   factfinder:
     needs: health_check
-    if: inputs.dataset_name == 'factfinder'
+    if: inputs.dataset_name == 'factfinder' || inputs.dataset_name  == 'all'
     uses: ./.github/workflows/factfinder_build.yml
     secrets: inherit
     with:


### PR DESCRIPTION
I noticed there isn't a folder `edm-publishing/db-template/build/nightly_qa/`, checked the lates runs of Night QA [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/nightly_qa.yml) and saw Template DB and Factfinder aren't built

I don't remember any reasons to exclude them. Template DB [sometimes](https://github.com/NYCPlanning/data-engineering/blob/main/.github/workflows/test_helper.yml#L121) built in PR tests, but still seems nice to have them all run in Nightly QA