### PR TITLE
use inline css and modular templates for metadata PDFs

### DIFF
--- a/dcpy/lifecycle/package/generate_metadata_assets.py
+++ b/dcpy/lifecycle/package/generate_metadata_assets.py
@@ -51,6 +51,7 @@ def generate_pdf_from_html(
     stylesheet_path: Path,
 ) -> Path:
     logger.info(f"Saving DCP PDF to {output_path}")
+    # TODO style HTML before converting to PDF
     subprocess.run(
         [
             "weasyprint",
@@ -71,6 +72,7 @@ def generate_html_from_yaml(
 ) -> Path:
     metadata = Metadata.from_path(metadata_path, template_vars={"var1": "value1"})
 
+    # TODO use _render_html_template and _compose_html_document
     with open(html_template_path, "r") as f:
         template_text = f.read()
     rendered_template = Template(template_text).render({"metadata": metadata})

--- a/dcpy/test/lifecycle/package/resources/document.html
+++ b/dcpy/test/lifecycle/package/resources/document.html
@@ -1,0 +1,56 @@
+<html>
+ <head>
+ </head>
+ <body>
+  <div>
+   <h1>
+    My document heading is "Simple Heading"
+   </h1>
+   <div>
+    <h2>
+     My section heading is "Section 1"
+    </h2>
+    <ul>
+     <li>
+      First section
+     </li>
+    </ul>
+   </div>
+   <div>
+    <h2>
+     My section heading is "Section 2"
+    </h2>
+    <ul>
+     <li>
+      Second section
+     </li>
+    </ul>
+   </div>
+  </div>
+  <div>
+   <h1>
+    My document heading is "Simple Heading"
+   </h1>
+   <div>
+    <h2>
+     My section heading is "Section 1"
+    </h2>
+    <ul>
+     <li>
+      First section
+     </li>
+    </ul>
+   </div>
+   <div>
+    <h2>
+     My section heading is "Section 2"
+    </h2>
+    <ul>
+     <li>
+      Second section
+     </li>
+    </ul>
+   </div>
+  </div>
+ </body>
+</html>

--- a/dcpy/test/lifecycle/package/resources/document.jinja
+++ b/dcpy/test/lifecycle/package/resources/document.jinja
@@ -1,0 +1,12 @@
+<html>
+
+<head>
+</head>
+
+<body>
+  {% include 'simple.jinja' %}
+
+  {% include 'simple.jinja' %}
+</body>
+
+</html>

--- a/dcpy/test/lifecycle/package/resources/document_styled.html
+++ b/dcpy/test/lifecycle/package/resources/document_styled.html
@@ -1,0 +1,56 @@
+<html>
+ <head>
+ </head>
+ <body>
+  <div>
+   <h1 style="color: red;">
+    My document heading is "Simple Heading"
+   </h1>
+   <div>
+    <h2 style="color: blue;">
+     My section heading is "Section 1"
+    </h2>
+    <ul>
+     <li>
+      First section
+     </li>
+    </ul>
+   </div>
+   <div>
+    <h2 style="color: blue;">
+     My section heading is "Section 2"
+    </h2>
+    <ul>
+     <li>
+      Second section
+     </li>
+    </ul>
+   </div>
+  </div>
+  <div>
+   <h1 style="color: red;">
+    My document heading is "Simple Heading"
+   </h1>
+   <div>
+    <h2 style="color: blue;">
+     My section heading is "Section 1"
+    </h2>
+    <ul>
+     <li>
+      First section
+     </li>
+    </ul>
+   </div>
+   <div>
+    <h2 style="color: blue;">
+     My section heading is "Section 2"
+    </h2>
+    <ul>
+     <li>
+      Second section
+     </li>
+    </ul>
+   </div>
+  </div>
+ </body>
+</html>

--- a/dcpy/test/lifecycle/package/resources/simple.html
+++ b/dcpy/test/lifecycle/package/resources/simple.html
@@ -1,0 +1,25 @@
+<div>
+ <h1>
+  My document heading is "Simple Heading"
+ </h1>
+ <div>
+  <h2>
+   My section heading is "Section 1"
+  </h2>
+  <ul>
+   <li>
+    First section
+   </li>
+  </ul>
+ </div>
+ <div>
+  <h2>
+   My section heading is "Section 2"
+  </h2>
+  <ul>
+   <li>
+    Second section
+   </li>
+  </ul>
+ </div>
+</div>

--- a/dcpy/test/lifecycle/package/resources/simple.jinja
+++ b/dcpy/test/lifecycle/package/resources/simple.jinja
@@ -1,0 +1,9 @@
+<div>
+  <h1>My document heading is "{{ heading }}"</h1>
+  {% for section in sections %}
+  <div>
+    <h2>My section heading is "{{ section.heading }}"</h2>
+    <ul><li>{{ section.content }}</li></ul>
+  </div>
+  {% endfor %}
+</div>

--- a/dcpy/test/lifecycle/package/resources/simple_style.css
+++ b/dcpy/test/lifecycle/package/resources/simple_style.css
@@ -1,0 +1,6 @@
+h1 {
+  color: red;
+}
+h2 {
+  color: blue;
+}

--- a/dcpy/test/lifecycle/package/resources/simple_styled.html
+++ b/dcpy/test/lifecycle/package/resources/simple_styled.html
@@ -1,0 +1,25 @@
+<div>
+ <h1 style="color: red;">
+  My document heading is "Simple Heading"
+ </h1>
+ <div>
+  <h2 style="color: blue;">
+   My section heading is "Section 1"
+  </h2>
+  <ul>
+   <li>
+    First section
+   </li>
+  </ul>
+ </div>
+ <div>
+  <h2 style="color: blue;">
+   My section heading is "Section 2"
+  </h2>
+  <ul>
+   <li>
+    Second section
+   </li>
+  </ul>
+ </div>
+</div>

--- a/dcpy/test/lifecycle/package/test_generate_data_dictionary.py
+++ b/dcpy/test/lifecycle/package/test_generate_data_dictionary.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest import TestCase
 from dcpy.test.lifecycle.package.conftest import (
+    PACKAGE_RESOURCES_PATH,
     TEST_ASSEMBLED_PACKAGE_AND_METADATA_PATH,
     TEST_METADATA_YAML_PATH,
     TEMP_DATA_PATH,
@@ -17,6 +18,59 @@ class TestDataDictionary(TestCase):
     html_path = TEMP_DATA_PATH / "metadata.html"
     pdf_path = TEMP_DATA_PATH / "metadata.pdf"
     output_xlsx_path = TEMP_DATA_PATH / "my_data_dictionary.xlsx"
+    template_vars = {
+        "heading": "Simple Heading",
+        "sections": [
+            {"heading": "Section 1", "content": "First section"},
+            {"heading": "Section 2", "content": "Second section"},
+        ],
+    }
+
+    def test_render_html_template(self):
+        with open(PACKAGE_RESOURCES_PATH / "simple.html", "r") as f:
+            expected = f.read()
+
+        actual = generate_metadata_assets._render_html_template(
+            template_path=PACKAGE_RESOURCES_PATH / "simple.jinja",
+            template_vars=self.template_vars,
+        )
+        assert actual == expected
+
+    def test_render_html_template_document(self):
+        with open(PACKAGE_RESOURCES_PATH / "document.html", "r") as f:
+            expected = f.read()
+
+        actual = generate_metadata_assets._render_html_template(
+            template_path=PACKAGE_RESOURCES_PATH / "document.jinja",
+            template_vars=self.template_vars,
+        )
+        assert actual == expected
+
+    def test_style_html(self):
+        with open(PACKAGE_RESOURCES_PATH / "simple_styled.html", "r") as f:
+            expected = f.read()
+
+        with open(PACKAGE_RESOURCES_PATH / "simple.html", "r") as f:
+            html = f.read()
+
+        actual = generate_metadata_assets._style_html(
+            html=html,
+            stylesheet_path=PACKAGE_RESOURCES_PATH / "simple_style.css",
+        )
+        assert actual == expected
+
+    def test_style_html_document(self):
+        with open(PACKAGE_RESOURCES_PATH / "document_styled.html", "r") as f:
+            expected = f.read()
+
+        with open(PACKAGE_RESOURCES_PATH / "document.html", "r") as f:
+            html = f.read()
+
+        actual = generate_metadata_assets._style_html_document(
+            html=html,
+            stylesheet_path=PACKAGE_RESOURCES_PATH / "simple_style.css",
+        )
+        assert actual == expected
 
     def test_generate_pdf_from_yaml(self):
         html_path = generate_metadata_assets.generate_html_from_yaml(


### PR DESCRIPTION
related to #561 

These changes are the start of a new approach to generating PDFs from metadata. The approach is outlined in [this issue comment](https://github.com/NYCPlanning/data-engineering/issues/561#issuecomment-2489628120).

This adds new functions and tests, but doesn't use them yet in "production".

Wanted to get eyes on this before continuing and using it to generate full HTML/PDFs from data dictionary yaml and then readme yaml.

next steps would be:
- replace the sort of "monolithic" template [data_dictionary_template.jinja](https://github.com/NYCPlanning/data-engineering/blob/main/dcpy/lifecycle/package/resources/data_dictionary_template.jinja) with modular templates
- refine styling to align with the design in Figma

## diagram of logic to go from multiple jinja files to a single styled HTML file

```mermaid
flowchart TB
    fragment_a_j(fragment_a.jinja)
    fragment_b_j(fragment_b.jinja)
    document_j(document_template.jinja)
    fragment_a_j --{{ include }}--> document_j
    fragment_b_j --{{ include }}--> document_j

    document_h(document_template.html)
    document_j --render--> document_h

    document_sh(document.html)
    document_h --style--> document_sh
```

## screenshot of `document_styled.html` used in tests

<img width="722" alt="Screenshot 2024-11-26 at 12 38 40 PM" src="https://github.com/user-attachments/assets/b254c606-0ba9-41d1-abc1-cd3382c4cec7">
