### PR TITLE
add default version strategy for colp, knownprojects

### DIFF
--- a/products/colp/recipe.yml
+++ b/products/colp/recipe.yml
@@ -1,5 +1,6 @@
 name: COLP
 product: db-colp
+version_strategy: first_of_month
 inputs:
   missing_versions_strategy: find_latest
   datasets:

--- a/products/knownprojects/recipe.yml
+++ b/products/knownprojects/recipe.yml
@@ -1,5 +1,6 @@
 name: Known Projects Database
 product: db-kpdb
+version_strategy: first_of_month
 vars:
   ZAP_VERSION: "20230905"
 inputs:


### PR DESCRIPTION
fixes issue [here](https://github.com/NYCPlanning/data-engineering/actions/runs/12173595422) (side note - not sure what's going wrong with issue creation failure. I feel like sporadic things like this happen, if this persists next week we can check it out)

This seemed like the least evil option. You can always provide a version manually, COLP does follow this convention even if it's not montly, and KPDB it seems we don't have a versioning scheme set up, so when we set it up we can change this

[Fixed run](https://github.com/NYCPlanning/data-engineering/actions/runs/12188260548) (past planning step)