### PR TITLE
Add GHA for `ingest` "run_and_compare" CLI

### DIFF
--- a/.github/workflows/ingest_library_compare.yml
+++ b/.github/workflows/ingest_library_compare.yml
@@ -11,6 +11,20 @@ on:
       schema_name:
         description: "Schema name where to store data tables (required)"
         required: true
+      version:
+        description: "The version of the dataset (i.e. 22v2, 21C) if needed (optional)"
+        required: false
+      key_columns:
+        description: "Key columns for comparison. Ex: 'column1,column2' (optional)"
+        required: false
+      ignore_columns:
+        description: "Columns to ignore during comparison. Ex: 'column1,column2' (optional)"
+        required: false
+      columns_only_comparison:
+        description: "Compare only column names (optional)"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   dataloading:
@@ -42,4 +56,10 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Extract dataset with ingest & library and upload results to database
-        run: python3 -m dcpy.cli lifecycle scripts validate_ingest run_and_compare ${{ inputs.dataset }}
+        env:
+          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
+          key_columns: ${{ github.event.inputs.key_columns && format('--key {0}', github.event.inputs.key_columns) || '' }}
+          ignore_columns: ${{ github.event.inputs.ignore_columns && format('--ignore {0}', github.event.inputs.ignore_columns) || '' }}
+          columns_only_comparison: ${{ github.event.inputs.columns_only_comparison && '--columns-only' || '' }}
+        run: |
+          python3 -m dcpy.cli lifecycle scripts validate_ingest run_and_compare ${{ inputs.dataset }} $version $key_columns $ignore_columns $columns_only_comparison

--- a/.github/workflows/ingest_library_compare.yml
+++ b/.github/workflows/ingest_library_compare.yml
@@ -7,7 +7,6 @@ on:
       dataset:
         description: "Name of the dataset (required)"
         required: true
-        default: dcp_mappluto
       schema_name:
         description: "Schema name where to store data tables (required)"
         required: true

--- a/.github/workflows/ingest_library_compare.yml
+++ b/.github/workflows/ingest_library_compare.yml
@@ -35,7 +35,7 @@ jobs:
       run:
         shell: bash
     env:
-      BUILD_ENGINE_SCHEMA: ${{ github.schema_name }}
+      BUILD_NAME: ${{ github.schema_name }}
       RECIPES_BUCKET: edm-recipes
       PUBLISHING_BUCKET: edm-publishing
     steps:

--- a/.github/workflows/ingest_library_compare.yml
+++ b/.github/workflows/ingest_library_compare.yml
@@ -36,6 +36,7 @@ jobs:
           AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
       - name: Finish container setup ...
         run: ./bash/docker_container_setup.sh

--- a/.github/workflows/ingest_library_compare.yml
+++ b/.github/workflows/ingest_library_compare.yml
@@ -16,14 +16,14 @@ jobs:
   dataloading:
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/build-base:${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
+      image: nycplanning/build-base:latest
     defaults:
       run:
         shell: bash
     env:
       BUILD_ENGINE_SCHEMA: ${{ github.schema_name }}
-      RECIPES_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || 'edm-recipes' }}
-      PUBLISHING_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || 'edm-publishing' }}
+      RECIPES_BUCKET: edm-recipes
+      PUBLISHING_BUCKET: edm-publishing
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### What
This is a GHA ro run the `run_and_compare` ingest migration command which: pulls data from source using library & ingest, does some pre-processing steps for the "ingest" version, uploads both versions to database, and runs a comparison between the two. 

### Why to create this GHA
While migration of recipe templates is a one-time adventure and we could do all of this locally, I had an issue with a particularly big dataset. My local machine just can't handle the size and crashes. Thus the reason for creating this GHA. 

### Things to keep in mind
It requires presence of both recipe templates (in ingest & library). Most likely, this action will be run from a feature branch.

This is an example of a job:

![image](https://github.com/user-attachments/assets/7e868310-d418-4ca5-8fa8-53dad8d43ffd)

#### Successful GHA run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/12284126901/job/34279185084#step:6:723). This is the dataset I couldn't run locally by the way.