### PR TITLE
GHA template for `ingest` compare util: fix a bug with env vars

### DIFF
--- a/.github/workflows/ingest_library_compare.yml
+++ b/.github/workflows/ingest_library_compare.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         shell: bash
     env:
-      BUILD_NAME: ${{ github.schema_name }}
+      BUILD_NAME: ${{ inputs.schema_name }}
       RECIPES_BUCKET: edm-recipes
       PUBLISHING_BUCKET: edm-publishing
     steps:
@@ -59,6 +59,6 @@ jobs:
           version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
           key_columns: ${{ github.event.inputs.key_columns && format('--key {0}', github.event.inputs.key_columns) || '' }}
           ignore_columns: ${{ github.event.inputs.ignore_columns && format('--ignore {0}', github.event.inputs.ignore_columns) || '' }}
-          columns_only_comparison: ${{ github.event.inputs.columns_only_comparison && '--columns-only' || '' }}
+          columns_only_comparison: ${{ github.event.inputs.columns_only_comparison == 'true' && '--columns-only' || '' }}
         run: |
           python3 -m dcpy.cli lifecycle scripts validate_ingest run_and_compare ${{ inputs.dataset }} $version $key_columns $ignore_columns $columns_only_comparison


### PR DESCRIPTION
Didn't catch a bug with vars in my previous [PR]( #1315 ) (the GHA would still run successfully but with wrong vars). 

Successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/12300148572/job/34327723403) (the job fails because 2 datasets don't match by data types which is okay). 

* Before fixing the bug: 
    ![image](https://github.com/user-attachments/assets/7466819d-4c9c-45b3-aafd-f654ecba3fb7)



* After fixing the bug (as expected)
    ![image](https://github.com/user-attachments/assets/d65acbb4-5d82-4328-9a81-bd610dd834e3)
