### PR TITLE
Ingest Migration Util GHA

### DIFF
--- a/.github/workflows/ingest_library_compare.yml
+++ b/.github/workflows/ingest_library_compare.yml
@@ -50,6 +50,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
           BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+          SOCRATA_USER: "op://Data Engineering/DCP_OpenData/username"
+          SOCRATA_PASSWORD: "op://Data Engineering/DCP_OpenData/password"
 
       - name: Finish container setup ...
         run: ./bash/docker_container_setup.sh

--- a/.github/workflows/ingest_library_run_single.yml
+++ b/.github/workflows/ingest_library_run_single.yml
@@ -52,4 +52,8 @@ jobs:
       - name: Finish container setup ...
         run: ./bash/docker_container_setup.sh
 
-      # TODO: run CLI to ingest dataset 
+      - name: Extract dataset with selected tool and upload result to database
+        env:
+          version: ${{ inputs.version && format('--version {0}', inputs.version) || '' }}
+        run: |
+          python3 -m dcpy.cli lifecycle scripts validate_ingest run_single ${{ inputs.tool }} ${{ inputs.dataset }} $version


### PR DESCRIPTION
## What
* Adding a new GHA workflow, `ingest_library_run_single` which pulls a dataset with a tool of your choice, `library` or `ingest`, and then uploads the result to the database.
* adding socrata env vars to the previous GHA workflow file

## Testing
I ran the GHA for my favorite dataset, oti building footprints using both library and ingest.

* Successful run for ingest [here](https://github.com/NYCPlanning/data-engineering/actions/runs/12358986794).
* Not so successful run for library [here](https://github.com/NYCPlanning/data-engineering/actions/runs/12358877398/job/34490388102). Getting a connection error here. Probably because `library` extracts it as a shapefile while `ingest` - as a geojson. But it's beyond this PR. 