### PR TITLE
drop failing dcpy test

### DIFF
--- a/dcpy/test/library/test_ingest_script.py
+++ b/dcpy/test/library/test_ingest_script.py
@@ -23,9 +23,3 @@ def test_nypl_libraries():
     ingestor = Ingestor()
     ingestor.csv(f"{template_path}/nypl_libraries.yml", version="test")
     assert os.path.isfile(".library/datasets/nypl_libraries/test/nypl_libraries.csv")
-
-
-def test_uscourts_courts():
-    ingestor = Ingestor()
-    ingestor.csv(f"{template_path}/uscourts_courts.yml", version="test")
-    assert os.path.isfile(".library/datasets/uscourts_courts/test/uscourts_courts.csv")


### PR DESCRIPTION
failing due to change to US Courts API, not dcpy

resolves https://github.com/NYCPlanning/data-engineering/issues/1320

from chat in Teams, dropping the test is good for now. created https://github.com/NYCPlanning/data-engineering/issues/1326 for fixing the source dataset