### PR TITLE
Make bytes->Socrata distribution a little more friendly

### DIFF
--- a/.github/workflows/distribute_socrata_dataset_s3.yml
+++ b/.github/workflows/distribute_socrata_dataset_s3.yml
@@ -1,5 +1,5 @@
-name: 🚀 Socrata - Publish a Dataset
-run-name: "🚀 Socrata - Publish a Dataset: ${{ inputs.PRODUCT_NAME }}-${{ inputs.DATASET_VERSION }}-${{ inputs.DATASET }}-${{ inputs.DESTINATION_ID }}"
+name: 📬 Socrata - Publish a Dataset
+run-name: "📬 Socrata - Publish a Dataset: ${{ inputs.PRODUCT_NAME }}-${{ inputs.DATASET_VERSION }}-${{ inputs.DATASET }}-${{ inputs.DESTINATION_ID }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/distribute_socrata_from_bytes.yml
+++ b/.github/workflows/distribute_socrata_from_bytes.yml
@@ -1,5 +1,5 @@
-name: 🚀 Distribute Socrata From Bytes
-run-name: "🚀 Distribute Socrata From Bytes: ${{ inputs.PRODUCT_NAME }}-${{ inputs.DATASET_VERSION }}-${{ inputs.DATASET }}-${{ inputs.DESTINATION_ID }}"
+name: 📬 Distribute Socrata From Bytes
+run-name: "📬 Distribute Socrata From Bytes: ${{ inputs.PRODUCT_NAME }}-${{ inputs.DATASET_VERSION }}-${{ inputs.DATASET }}-${{ inputs.DESTINATION_ID }}"
 
 on:
   workflow_dispatch:

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -57,15 +57,16 @@ Note: this is a low-risk operation when you don't tick the box to publish the da
 
 For Example
 ``` sh
-python -m dcpy.cli lifecycle scripts package_and_dist from_bytes_to_socrata 
-lion \ # Product 
-24d  \ # version 
--y \ # skip data validation (yolo) 
--e socrata  \ # filter for destination type is `socrata` 
--d "atomic_polygons, other_dataset" \ # filter for the two datasets
--t socrata_unpublished # filter for destinations tagged as `socrata_unpublished`
+python -m dcpy.cli lifecycle scripts package_and_dist from_bytes_to_socrata \
+  lion \
+  24d \
+  -y \
+  -e socrata \
+  -d atomic_polygons \
+  -d other_dataset \
+  -t socrata_unpublished
 ```
-This will return all socrata destinations for two datasets, where the destination is also tagged as `socrata_unpublished`.
+This will package and distribute to all socrata destinations for the `lion` product, version 24d (-y will skip dataset file validation) where the dataset is either `atomic_polygons` or `other_dataset`, where the destination is tagged as `socrata_unpublished`.
 
 
 ## The Socrata Publish Flow

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -50,6 +50,24 @@ python -m dcpy.cli lifecycle package validate [your package path here]
 
 Note: this is a low-risk operation when you don't tick the box to publish the dataset. 
 
+
+#### Assembling and Pushing from Bytes (local flow)
+1. Ensure you have the product-metadata repo cloned locally, and have set the `PRODUCT_METADATA_REPO_PATH` var
+2. Run the lifecycle package and dist command in scripts. This will allow you to target specific destinations for a given dataset. For each dataset specified, this command will pull relevant files from `bytes`, generate the OTI XLSX when specified in the files, then distribute the data to Socrata. This command can filter by dataset name, and destination tag. (note: the conditions are combined with AND logic)
+
+For Example
+``` sh
+python -m dcpy.cli lifecycle scripts package_and_dist from_bytes_to_socrata 
+lion \ # Product 
+24d  \ # version 
+-y \ # skip data validation (yolo) 
+-e socrata  \ # filter for destination type is `socrata` 
+-d "atomic_polygons, other_dataset" \ # filter for the two datasets
+-t socrata_unpublished # filter for destinations tagged as `socrata_unpublished`
+```
+This will return all socrata destinations for two datasets, where the destination is also tagged as `socrata_unpublished`.
+
+
 ## The Socrata Publish Flow
 In our publishing connector, the flow for distributing is as follows: 
 
@@ -75,6 +93,9 @@ INFO:dcpy:            here https://data.cityofnewyork.us/d/b7pm-uzu7/revisions/3
 Follow the provided link. Here you can review the modified data and metadata. Hit `Update` in the top right to apply the revision. 
 ![template_db_socrata](https://github.com/NYCPlanning/data-engineering/assets/11164730/b0c24251-00e3-4be1-99a6-6cf015240cc6)
 
+Before publishing, 
+- check the row count
+- review the "Metadata Changes" (hit the Details dropdown). Make sure that everything looks fine. (e.g. you haven't removed fields, or completely removed an attachment, etc.)
 
 ## Generating Metadata
 
@@ -120,3 +141,12 @@ In this case, make sure you're logged in, and then:
     - Delete the old attachment(s)
     - Upload the new attachemt(s)
 
+
+
+
+#### POTENTIAL ISSUES
+
+##### I've pushed to socrata, but when I visit the revision page, the `Update` button is greyed out. 
+Hover over the `Update` button, and it should point you towards the cause. Usually it's a metadata problem. 
+
+*If it's a metadata problem, but nothing seems wrong (ie nothing is bright red in the metadata modal)* Usually you can fix this by adding a space and removing it, or some similar non-change. Hit `Save`, and likely you'll be able to update.

--- a/dcpy/lifecycle/distribute/README.md
+++ b/dcpy/lifecycle/distribute/README.md
@@ -3,10 +3,10 @@
 ## Terms
 - `Dataset`: Abstractly, a single table of data and metadata about it.
 - `Product`: A suite of datasets. E.g. LION, which contains multiple `datasets`, such as "2010 Census Blocks" or "Community Districts (water areas Included)"
-- `Dataset File`: Actual file export for a dataset, e.g. a csv, or a shapefile. Note: there may be slight variations between `dataset files` for the same `dataset`. e.g. columns in the shapefile for PLUTO will have slightly different columns than the csv. 
+- `Dataset File`: Actual file export for a dataset, e.g. a csv, or a shapefile. Note: there may be slight variations between `dataset files` for the same `dataset`. e.g. columns in the shapefile for PLUTO will have slightly different columns than the csv.
 - `Attachment`: README's, data dictionaries, etc.
-- `Dataset Package`: Instance of a `Dataset`, meaning metadata, attachments, and dataset files. 
-- `Product Package`: Versioned collection of Dataset Packages. 
+- `Dataset Package`: Instance of a `Dataset`, meaning metadata, attachments, and dataset files.
+- `Product Package`: Versioned collection of Dataset Packages.
 
 ## How to distribute to Socrata
 Socrata datasets consist of, effectively, one table. In the past, a single Socrata dataset could contain multiple shapefile layers, but that's no longer the case. So for us:
@@ -27,7 +27,7 @@ To push from S3, the Dataset Package must exist in `edm-publishing` in the `prod
 ```
 edm-publishing / product_dataset / {product_name} / package / {version} / {dataset_name} / [package files here]
 ```
-Note: In many cases the product has only one dataset, e.g. Facilities. In that case, the convention is to just use the same product_name and dataset_name. E.g 
+Note: In many cases the product has only one dataset, e.g. Facilities. In that case, the convention is to just use the same product_name and dataset_name. E.g
 ```
 edm-publishing / product_dataset / facilities / package / 24v2 / facilities / [package files here]
 ```
@@ -37,7 +37,7 @@ python -m dcpy.cli lifecycle distribute socrata from_s3 [args]
 ```
 The --help flag will list required args.
 
-Note that unless you explicitly specify `--publish`, only a draft will be created on Socrata, and you'll need to manually apply it via the socrata GUI. The output of the command will tell you the revision number, which you can find via search on Socrata. There you can review data changes, metadata changes, etc, before actually publishing. 
+Note that unless you explicitly specify `--publish`, only a draft will be created on Socrata, and you'll need to manually apply it via the socrata GUI. The output of the command will tell you the revision number, which you can find via search on Socrata. There you can review data changes, metadata changes, etc, before actually publishing.
 
 ##### Quick Tip
 If package validation fails, you can validate locally by running the validation commands locally:
@@ -48,7 +48,7 @@ python -m dcpy.cli lifecycle package validate [your package path here]
 #### Pushing from S3 via Github Action:
 [Relevant Action](https://github.com/NYCPlanning/data-engineering/actions/workflows/socrata_publish_dataset.yml). The same options as above apply. You'll need to supply the product name, the dataset name, and the version.
 
-Note: this is a low-risk operation when you don't tick the box to publish the dataset. 
+Note: this is a low-risk operation when you don't tick the box to publish the dataset.
 
 
 #### Assembling and Pushing from Bytes (local flow)
@@ -70,12 +70,12 @@ This will package and distribute to all socrata destinations for the `lion` prod
 
 
 ## The Socrata Publish Flow
-In our publishing connector, the flow for distributing is as follows: 
+In our publishing connector, the flow for distributing is as follows:
 
-1. create a new revision for the dataset, and discard other open revisions. 
-2. upload attachments, and update dataset-level metadata. (e.g. the dataset description or tags) 
-3. Upload the dataset itself. Currently only shapefiles are supported. 
-4. _Attempt_ to update column metadata for the uploaded dataset. This step is placed last because it's the most finicky at the moment, as it entails reconciling our uploaded columns, Socrata's existing columns, and our metadata. However, should this step fail, you can still go manually apply the revision in the Socrata GUI. 
+1. create a new revision for the dataset, and discard other open revisions.
+2. upload attachments, and update dataset-level metadata. (e.g. the dataset description or tags)
+3. Upload the dataset itself. Currently only shapefiles are supported.
+4. _Attempt_ to update column metadata for the uploaded dataset. This step is placed last because it's the most finicky at the moment, as it entails reconciling our uploaded columns, Socrata's existing columns, and our metadata. However, should this step fail, you can still go manually apply the revision in the Socrata GUI.
 
 ## Applying Revisions in Socrata
 
@@ -91,10 +91,10 @@ INFO:dcpy:Finished syncing product to Socrata, but did not publish. Find revisio
 INFO:dcpy:            here https://data.cityofnewyork.us/d/b7pm-uzu7/revisions/32
 ```
 
-Follow the provided link. Here you can review the modified data and metadata. Hit `Update` in the top right to apply the revision. 
+Follow the provided link. Here you can review the modified data and metadata. Hit `Update` in the top right to apply the revision.
 ![template_db_socrata](https://github.com/NYCPlanning/data-engineering/assets/11164730/b0c24251-00e3-4be1-99a6-6cf015240cc6)
 
-Before publishing, 
+Before publishing,
 - check the row count
 - review the "Metadata Changes" (hit the Details dropdown). Make sure that everything looks fine. (e.g. you haven't removed fields, or completely removed an attachment, etc.)
 
@@ -147,7 +147,7 @@ In this case, make sure you're logged in, and then:
 
 #### POTENTIAL ISSUES
 
-##### I've pushed to socrata, but when I visit the revision page, the `Update` button is greyed out. 
-Hover over the `Update` button, and it should point you towards the cause. Usually it's a metadata problem. 
+##### I've pushed to socrata, but when I visit the revision page, the `Update` button is greyed out.
+Hover over the `Update` button, and it should point you towards the cause. Usually it's a metadata problem.
 
 *If it's a metadata problem, but nothing seems wrong (ie nothing is bright red in the metadata modal)* Usually you can fix this by adding a space and removing it, or some similar non-change. Hit `Save`, and likely you'll be able to update.

--- a/dcpy/lifecycle/package/xlsx_writer.py
+++ b/dcpy/lifecycle/package/xlsx_writer.py
@@ -19,7 +19,7 @@ from . import abstract_doc
 
 # TODO: Move template to Product Metadata Repo. Rename to be non-OTI specific
 DEFAULT_TEMPLATE_PATH = RESOURCES_PATH / "oti_data_dictionary_template.xlsx"
-EXCEL_DATA_DICT_METADATA_FILE_TYPE = "excel_data_dictionary"
+EXCEL_DATA_DICT_METADATA_FILE_TYPE = "oti_data_dictionary"
 DEFAULT_FONT = "Arial"
 
 

--- a/dcpy/lifecycle/scripts/package_and_distribute.py
+++ b/dcpy/lifecycle/scripts/package_and_distribute.py
@@ -69,11 +69,11 @@ def from_bytes_to_tagged_socrata_cli(
     product: str,
     version: str,
     # Filters
-    datasets: str = typer.Option(
+    datasets: list[str] = typer.Option(
         None,
         "-d",
         "--datasets",
-        help="comma delimited list of dataset names to filter for.",
+        help="list of dataset names to include.",
     ),
     destination_tag: str = typer.Option(
         None,
@@ -125,15 +125,11 @@ def from_bytes_to_tagged_socrata_cli(
         help="Only push metadata (including attachments).",
     ),
 ):
-    datasets_set: set[str] = set()
-    if datasets:  # TODO: can typer do this natively?
-        datasets_set = {d.strip() for d in datasets.split(",")}
-
     results = package_and_dist_from_bytes(
         org_metadata_path,
         product,
         version,
-        datasets=datasets_set,
+        datasets=set(datasets or []),
         destination_id=destination_id,
         destination_type=destination_type,
         destination_tag=destination_tag,

--- a/dcpy/test/resources/test_product_metadata_repo/products/lion/pseudo_lots/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo/products/lion/pseudo_lots/metadata.yml
@@ -16,3 +16,8 @@ attributes:
     - building identification number
     - addresses
     - cscl
+
+destinations:
+  - id: socrata
+    type: socrata
+    tags: [prod_tag, pseudo_lots_tag]

--- a/dcpy/test/resources/test_product_metadata_repo/products/lion/school_districts/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo/products/lion/school_districts/metadata.yml
@@ -19,3 +19,8 @@ destinations:
   - id: socrata
     type: socrata
     tags: [prod_tag]
+  - id: socrata_2
+    type: socrata
+    tags: [school_districts_tag]
+  - id: other
+    type: bytes


### PR DESCRIPTION
These are the changes we were using last week to distribute datasets. This improves the CLI to distribute from Bytes, fixes a bug around data dictionary generation, and makes a few quick additions to the README. (Documentation in general needs to be re-evaluated, but this was mostly for the purposes of facilitating the mobbing session last week)

Commits are atomic, and the details are included in the commit description.