### PR TITLE
Use socratapy api for column updates, informative logging for column mismatches

### DIFF
--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -9,7 +9,6 @@ quite informative.
 """
 
 from __future__ import annotations
-import copy
 from dataclasses import dataclass
 import json
 from pathlib import Path

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -656,7 +656,7 @@ def push_dataset(
                 # Upating column Metadata is tricky, and there's still some work to be done
                 logger.error(
                     "Error Updating Column Metadata! However, the Dataset File was uploaded "
-                    f"and the revision can still be applied manually, here: {rev.page_url}\n"
+                    f"and the revision can still be applied manually, here:\n    {rev.page_url}\n"
                     f"Error:\n{textwrap.indent(str(e), '    ')}"
                 )
                 return f"Error publishing {metadata.attributes.display_name} - destination: {dataset_destination_id}: {str(e)}"

--- a/dcpy/connectors/socrata/publish.py
+++ b/dcpy/connectors/socrata/publish.py
@@ -655,7 +655,7 @@ def push_dataset(
             except Exception as e:
                 # Upating column Metadata is tricky, and there's still some work to be done
                 logger.error(
-                    "Error Updating Column Metadata! However, the Dataset File was uploaded"
+                    "Error Updating Column Metadata! However, the Dataset File was uploaded "
                     f"and the revision can still be applied manually, here: {rev.page_url}\n"
                     f"Error:\n{textwrap.indent(str(e), '    ')}"
                 )

--- a/dcpy/lifecycle/distribute/_cli.py
+++ b/dcpy/lifecycle/distribute/_cli.py
@@ -31,11 +31,10 @@ def _dist_from_local(
     ),
 ):
     md = m.Metadata.from_path(metadata_path or (package_path / "metadata.yml"))
-    result = distribute.to_dataset_destination(
+    distribute.to_dataset_destination(
         metadata=md,
         dataset_destination_id=dataset_destination_id,
         publish=publish,
         dataset_package_path=package_path,
         metadata_only=metadata_only,
     )
-    print(result)


### PR DESCRIPTION
Alright - this ended up going in circles quite a bit, and in the end is barely making any code changes.

Mainly
1. just because I did this when I was exploring changing transformations and determining these things a tad more programatically, moved to using socratapy's api for managing column metadata (simple refactor)
2. a more helpful error message when mapping doesn't line up

Since the thought is that if we have this rare case where mapping doesn't line up (which we don't expect operationally but has happened during the current effort of getting automation going), we get a simple error message, resolve it via UI, and then the issue is fixed moving forwards.

Went through the exercise of making sure that solving this in the UI once fixes the issue moving forward. Here's a "simple" [revision](https://data.cityofnewyork.us/dataset/dcp_test/5n4u-q8gi/revisions/4) of a dataset where everything lines up as expected

<img width="992" alt="image" src="https://github.com/user-attachments/assets/220fa10a-b4c4-45ec-9c4a-dbaad8b61e0e" />

Then, we have a revision where there are column changes (this was applied after this screenshot)
<img width="1158" alt="image" src="https://github.com/user-attachments/assets/a7b86fc0-c800-4f1a-b70a-7acf506cd51e" />

Once this is applied, we send that same file in a [new revision](https://data.cityofnewyork.us/City-Government/dcp_test/5n4u-q8gi/revisions/28), and mappings are applied correctly
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/fd4d096d-77ef-46c8-ba02-ec225182c8be" />

And it does this without modifying the actual column metadata. 
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/53e85391-db17-4a79-9b01-4c8cf012b245" />
In this case, it's a little weird. I've made the dataset column names not line up with the dataset metadata. So column mappings are sort of their own distinct little weird entity defined for the socrata dataset. But that can be fixed by pushing a new revision where we'll have to specify the column mappings manually again ([here](https://data.cityofnewyork.us/City-Government/dcp_test/5n4u-q8gi/revisions/27))