### PR TITLE
fix inconsistent s3 metadata field names

### DIFF
--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -174,11 +174,11 @@ def get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
 def generate_metadata() -> dict[str, str]:
     """Generates "standard" s3 metadata for our files"""
     metadata = {
-        "date_created": datetime.now(pytz.timezone("America/New_York")).isoformat()
+        "date-created": datetime.now(pytz.timezone("America/New_York")).isoformat()
     }
     metadata["commit"] = git.commit_hash()
     if CI:
-        metadata["run_url"] = git.action_url()
+        metadata["run-url"] = git.action_url()
     return metadata
 
 
@@ -612,9 +612,9 @@ def publish_add_created_date(
         target,
         acl,
         max_files=max_files,
-        metadata={"date_created": old_metadata.last_modified.isoformat()},
+        metadata={"date-created": old_metadata.last_modified.isoformat()},
     )
-    return {"date_created": old_metadata.last_modified.isoformat()}
+    return {"date-created": old_metadata.last_modified.isoformat()}
 
 
 def get_data_directory_url(product_key: ProductKey) -> str:

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -356,7 +356,7 @@ def get_archival_metadata(
             BUCKET,
             f"{DATASET_FOLDER}/{name}/{version}/config.json",
         )
-        date_created = s3metadata.custom.get("date_created")
+        date_created = s3metadata.custom.get("date-created")
         if date_created is None:
             timestamp = s3metadata.last_modified
         else:

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -49,14 +49,14 @@ class Metadata(BaseModel):
 
 def generate_metadata() -> dict[str, str]:
     metadata = {
-        "date_created": datetime.now(pytz.timezone("America/New_York")).isoformat()
+        "date-created": datetime.now(pytz.timezone("America/New_York")).isoformat()
     }
     try:
         metadata["commit"] = git.commit_hash()
     except Exception:
         pass
     if os.environ.get("CI"):
-        metadata["run_url"] = git.action_url()
+        metadata["run-url"] = git.action_url()
     return metadata
 
 
@@ -154,13 +154,11 @@ def get_custom_metadata(bucket: str, key: str) -> dict:
 def get_metadata(bucket: str, key: str) -> Metadata:
     """Gets custom metadata as well as three standard s3 fields"""
     response = client().head_object(Bucket=bucket, Key=key)
-    metadata = response["Metadata"]
-    cleaned_metadata = {key.replace("-", "_"): metadata[key] for key in metadata}
     return Metadata(
         last_modified=response["LastModified"],
         content_length=response["ContentLength"],
         content_type=response["ContentType"],
-        custom=cleaned_metadata,
+        custom=response["Metadata"],
     )
 
 


### PR DESCRIPTION
Resolves #1350 

When attempting to update the config of an existing version of a recipe dataset, we get a weird "signature does not match" error. This occurs on calling `put_object` when the object already exists. Googling has been entirely unhelpful - this error seems to occur when people have bad credentials. ~This makes me think that this might be something to do with Digital Ocean - I can't imagine there are that many folks using boto3 with DO, which would be a possible reason for lack of other people having this issue~ Issue was with the metadata I was attempting to push. Due to a bug in our code, when pulling metadata and then pushing again (and "merging" with standard generated metadata), there ended up being a both a "date-created" field and "date_created" field, with differing values. Resolving this resolved the issue

This logic maybe needs a little reworking in general - not great that I had to change multiple literals.

## Actions (all using dev bucket)
These were run in order
- [Run on this branch](https://github.com/NYCPlanning/data-engineering/actions/runs/12586088257) (could have been main) to initially archive all opendata datasets
- [Failing update](https://github.com/NYCPlanning/data-engineering/actions/runs/12586286671/job/35079800704) (run from main)
- [Now succeeding update](https://github.com/NYCPlanning/data-engineering/actions/runs/12587016106)