### PR TITLE
fix CDBG population data types

### DIFF
--- a/products/cdbg/models/product/_product_models.yml
+++ b/products/cdbg/models/product/_product_models.yml
@@ -86,7 +86,7 @@ models:
         tests: [not_null]
 
       - name: low_mod_income_population
-        data_type: bigint
+        data_type: integer
         tests: [not_null]
 
       - name: low_mod_income_population_percentage
@@ -135,7 +135,7 @@ models:
         tests: [not_null]
 
       - name: low_mod_income_population
-        data_type: bigint
+        data_type: integer
         tests: [not_null]
 
       - name: low_mod_income_population_percentage

--- a/products/cdbg/models/product/cdbg_block_groups.sql
+++ b/products/cdbg/models/product/cdbg_block_groups.sql
@@ -12,7 +12,7 @@ eligibility_calculation AS (
         round(total_floor_area::numeric)::integer AS total_floor_area,
         round(residential_floor_area::numeric)::integer AS residential_floor_area,
         round(residential_floor_area_percentage::numeric, 2) AS residential_floor_area_percentage,
-        low_mod_income_population,
+        low_mod_income_population::integer,
         round(low_mod_income_population_percentage::numeric, 2) AS low_mod_income_population_percentage,
         low_mod_income_population_percentage >= 51 AND residential_floor_area_percentage >= 50 AS eligibility_flag
     FROM block_groups

--- a/products/cdbg/models/product/cdbg_boroughs.sql
+++ b/products/cdbg/models/product/cdbg_boroughs.sql
@@ -9,7 +9,7 @@ eligibility_calculation AS (
         round(total_floor_area::numeric)::integer AS total_floor_area,
         round(residential_floor_area::numeric)::integer AS residential_floor_area,
         round(residential_floor_area_percentage::numeric, 2) AS residential_floor_area_percentage,
-        low_mod_income_population::bigint,
+        low_mod_income_population::integer,
         round(low_mod_income_population_percentage::numeric, 2) AS low_mod_income_population_percentage,
         low_mod_income_population_percentage >= 51 AND residential_floor_area_percentage >= 50 AS eligibility_flag
     FROM boros

--- a/products/cdbg/models/product/cdbg_tracts.sql
+++ b/products/cdbg/models/product/cdbg_tracts.sql
@@ -10,7 +10,7 @@ eligibility_calculation AS (
         round(total_floor_area::numeric)::integer AS total_floor_area,
         round(residential_floor_area::numeric)::integer AS residential_floor_area,
         round(residential_floor_area_percentage::numeric, 2) AS residential_floor_area_percentage,
-        low_mod_income_population,
+        low_mod_income_population::integer,
         round(low_mod_income_population_percentage::numeric, 2) AS low_mod_income_population_percentage,
         low_mod_income_population_percentage >= 51 AND residential_floor_area_percentage >= 50 AS eligibility_flag
     FROM tracts

--- a/products/cdbg/models/staging/stg__low_mod_by_block_group.sql
+++ b/products/cdbg/models/staging/stg__low_mod_by_block_group.sql
@@ -8,7 +8,7 @@ SELECT
     "BORO" AS boro,
     "TRACT"::text AS tract,
     "BLKGRP"::text AS block_group,
-    REPLACE("LOWMODUNIV", ',', '')::integer AS potential_lowmod_population,
-    REPLACE("LOWMOD", ',', '')::integer AS low_mod_income_population,
+    REPLACE("LOWMODUNIV", ',', '')::decimal AS potential_lowmod_population,
+    REPLACE("LOWMOD", ',', '')::decimal AS low_mod_income_population,
     RTRIM("LOWMOD_PCT", '%')::numeric AS low_mod_income_population_percentage
 FROM {{ source("recipe_sources", "hud_lowmodincomebyblockgroup") }}


### PR DESCRIPTION
related to #1348 

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-cdbg-zeros)

## before

`int__tracts.low_mod_income_population_percentage` was mostly 0s because `low_mod_income_population and `potential_lowmod_population` are integers and division using integers doesn't return (the expected) decimal values

value counts from a recent build are either 0 or 100:
<img width="420" alt="Screenshot 2025-01-06 at 12 08 25 PM" src="https://github.com/user-attachments/assets/aed26179-63ab-4a5c-9e01-29a5055c021f" />

`int__block_groups.low_mod_income_population_percentage` doesn't have this issue because it isn't computed, it comes straight from `stg__low_mod_by_block_group`

## after

value counts from build on this branch make more sense:

<img width="418" alt="Screenshot 2025-01-06 at 12 22 40 PM" src="https://github.com/user-attachments/assets/01f692eb-0df7-4a98-88bd-b56bbfffddbc" />

