### PR TITLE
clean up CDBG

### DIFF
--- a/products/cdbg/README.md
+++ b/products/cdbg/README.md
@@ -1,0 +1,16 @@
+# Community Development Block Grant (CDBG)
+
+The Community Development Block Grant (CDBG) data product determines, for all census block groups and tracts in New York City, if activites in an area of the city qualify for funding through the CDBG program.
+
+NYC receives Community Development Block Grant funds from the U.S. Department of Housing and Urban Development (HUD). These funds may be used for projects in residential areas where over half of the population is considered low- and moderate-income. Income data is proved by HUD as the [Low- and Moderate-Income Summary Data (LMISD)](https://www.hudexchange.info/programs/cdbg/cdbg-low-moderate-income-data/).
+
+A census tract is considered residential if at least 50.0% of the total built floor area is residential. This is determined by summing ResArea and BldgArea for MapPLUTO lots in the census tract. If at least 90% of a lot's area is in the tract, the entire lot is assigned to that tract. Otherwise, the building area is assigned proportionately based on the percent of the lot's area in each census tract.
+
+## Important files
+
+[recipe](https://github.com/NYCPlanning/data-engineering/blob/main/products/cdbg/recipe.yml)
+
+## Links
+
+[CDBG Overview on DCP website](https://www.nyc.gov/site/planning/data-maps/community-development-block-grant.page)
+[CDBG on Bytes](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-cdbg.page)

--- a/products/cdbg/models/_sources.yml
+++ b/products/cdbg/models/_sources.yml
@@ -14,5 +14,4 @@ sources:
               - not_null
       - name: dcp_cb2020_wi
       - name: dcp_ct2020_wi
-      - name: dcp_censusdata_blocks
       - name: hud_lowmodincomebyblockgroup

--- a/products/cdbg/models/intermediate/_intermediate_models.yml
+++ b/products/cdbg/models/intermediate/_intermediate_models.yml
@@ -12,20 +12,17 @@ models:
   - name: total_floor_area
   - name: residential_floor_area
   - name: residential_floor_area_percentage
-  - name: total_population
   - name: potential_lowmod_population
   - name: lowmod_population
   - name: low_mod_income_population_percentage
 
 - name: int__block_groups_raw
-  description: census block group geoemtries and demographic data
+  description: census block group geoemtries
   columns:
   - name: geoid
     tests:
     - not_null
     - unique
-  - name: total_population
-    tests: [not_null]
 
 - name: int__boros
   description: residential area and low-to-moderate income data aggregated by boro
@@ -35,7 +32,6 @@ models:
   - name: total_floor_area
   - name: residential_floor_area
   - name: residential_floor_area_percentage
-  - name: total_population
   - name: lowmod_population
   - name: lowmod_population_percentage
 
@@ -91,6 +87,5 @@ models:
   - name: total_floor_area
   - name: residential_floor_area
   - name: residential_floor_area_percentage
-  - name: total_population
   - name: lowmod_population
   - name: lowmod_population_percentage

--- a/products/cdbg/models/intermediate/int__block_groups.sql
+++ b/products/cdbg/models/intermediate/int__block_groups.sql
@@ -15,7 +15,6 @@ block_groups_demographics AS (
         block_groups_population.geoid,
         block_groups_population.borough_code,
         block_groups_population.borough_name,
-        block_groups_population.total_population,
         block_groups_income.tract,
         block_groups_income.block_group,
         block_groups_income.potential_lowmod_population,
@@ -49,7 +48,6 @@ block_group_details AS (
                 THEN 0
             ELSE (block_groups_floor_area.residential_floor_area / block_groups_floor_area.total_floor_area) * 100
         END AS residential_floor_area_percentage,
-        block_groups_demographics.total_population,
         block_groups_demographics.potential_lowmod_population,
         block_groups_demographics.low_mod_income_population,
         block_groups_demographics.low_mod_income_population_percentage

--- a/products/cdbg/models/intermediate/int__block_groups_raw.sql
+++ b/products/cdbg/models/intermediate/int__block_groups_raw.sql
@@ -8,23 +8,6 @@
 
 WITH census_blocks AS (
     SELECT * FROM {{ ref("stg__census_blocks") }}
-),
-
-census_data_blocks AS (
-    SELECT * FROM {{ ref("stg__census_data_blocks") }}
-),
-
-blocks AS (
-    SELECT
-        census_blocks.block_group_geoid,
-        census_data_blocks.borough_code,
-        census_data_blocks.borough_name,
-        census_blocks.ct2020,
-        census_data_blocks.total_population,
-        census_blocks.wkb_geometry
-    FROM census_blocks
-    LEFT JOIN census_data_blocks
-        ON census_blocks.bctcb2020 = census_data_blocks.bctcb2020
 )
 
 SELECT
@@ -32,9 +15,8 @@ SELECT
     borough_code,
     borough_name,
     ct2020,
-    sum(total_population) AS total_population,
-    st_union(wkb_geometry) AS geom
-FROM blocks
+    st_union(geom) AS geom
+FROM census_blocks
 GROUP BY
     block_group_geoid,
     borough_code,

--- a/products/cdbg/models/intermediate/int__boros.sql
+++ b/products/cdbg/models/intermediate/int__boros.sql
@@ -9,6 +9,7 @@ boros AS (
         sum(total_floor_area) AS total_floor_area,
         sum(residential_floor_area) AS residential_floor_area,
         sum(total_population) AS total_population,
+        sum(potential_lowmod_population) AS potential_lowmod_population,
         sum(low_mod_income_population) AS low_mod_income_population
     FROM tracts
     GROUP BY
@@ -20,7 +21,7 @@ boro_calculation AS (
     SELECT
         *,
         (residential_floor_area / total_floor_area) * 100 AS residential_floor_area_percentage,
-        (low_mod_income_population / total_population) * 100 AS low_mod_income_population_percentage
+        (low_mod_income_population / potential_lowmod_population) * 100 AS low_mod_income_population_percentage
     FROM boros
 )
 

--- a/products/cdbg/models/intermediate/int__boros.sql
+++ b/products/cdbg/models/intermediate/int__boros.sql
@@ -8,7 +8,6 @@ boros AS (
         borough_code,
         sum(total_floor_area) AS total_floor_area,
         sum(residential_floor_area) AS residential_floor_area,
-        sum(total_population) AS total_population,
         sum(potential_lowmod_population) AS potential_lowmod_population,
         sum(low_mod_income_population) AS low_mod_income_population
     FROM tracts

--- a/products/cdbg/models/intermediate/int__tracts.sql
+++ b/products/cdbg/models/intermediate/int__tracts.sql
@@ -12,7 +12,6 @@ tracts AS (
         borough_code,
         sum(total_floor_area) AS total_floor_area,
         sum(residential_floor_area) AS residential_floor_area,
-        sum(total_population) AS total_population,
         sum(potential_lowmod_population) AS potential_lowmod_population,
         sum(low_mod_income_population) AS low_mod_income_population
     FROM block_groups

--- a/products/cdbg/models/product/_product_models.yml
+++ b/products/cdbg/models/product/_product_models.yml
@@ -46,6 +46,10 @@ models:
         data_type: integer
         tests: [not_null]
 
+      - name: potential_lowmod_population
+        data_type: integer
+        tests: [not_null]
+
       - name: low_mod_income_population_percentage
         data_type: decimal
         tests: [not_null]
@@ -86,6 +90,10 @@ models:
         tests: [not_null]
 
       - name: low_mod_income_population
+        data_type: integer
+        tests: [not_null]
+
+      - name: potential_lowmod_population
         data_type: integer
         tests: [not_null]
 
@@ -135,6 +143,10 @@ models:
         tests: [not_null]
 
       - name: low_mod_income_population
+        data_type: integer
+        tests: [not_null]
+
+      - name: potential_lowmod_population
         data_type: integer
         tests: [not_null]
 

--- a/products/cdbg/models/product/cdbg_block_groups.sql
+++ b/products/cdbg/models/product/cdbg_block_groups.sql
@@ -13,6 +13,7 @@ eligibility_calculation AS (
         round(residential_floor_area::numeric)::integer AS residential_floor_area,
         round(residential_floor_area_percentage::numeric, 2) AS residential_floor_area_percentage,
         low_mod_income_population::integer,
+        potential_lowmod_population::integer,
         round(low_mod_income_population_percentage::numeric, 2) AS low_mod_income_population_percentage,
         low_mod_income_population_percentage >= 51 AND residential_floor_area_percentage >= 50 AS eligibility_flag
     FROM block_groups

--- a/products/cdbg/models/product/cdbg_boroughs.sql
+++ b/products/cdbg/models/product/cdbg_boroughs.sql
@@ -10,6 +10,7 @@ eligibility_calculation AS (
         round(residential_floor_area::numeric)::integer AS residential_floor_area,
         round(residential_floor_area_percentage::numeric, 2) AS residential_floor_area_percentage,
         low_mod_income_population::integer,
+        potential_lowmod_population::integer,
         round(low_mod_income_population_percentage::numeric, 2) AS low_mod_income_population_percentage,
         low_mod_income_population_percentage >= 51 AND residential_floor_area_percentage >= 50 AS eligibility_flag
     FROM boros

--- a/products/cdbg/models/product/cdbg_tracts.sql
+++ b/products/cdbg/models/product/cdbg_tracts.sql
@@ -11,6 +11,7 @@ eligibility_calculation AS (
         round(residential_floor_area::numeric)::integer AS residential_floor_area,
         round(residential_floor_area_percentage::numeric, 2) AS residential_floor_area_percentage,
         low_mod_income_population::integer,
+        potential_lowmod_population::integer,
         round(low_mod_income_population_percentage::numeric, 2) AS low_mod_income_population_percentage,
         low_mod_income_population_percentage >= 51 AND residential_floor_area_percentage >= 50 AS eligibility_flag
     FROM tracts

--- a/products/cdbg/models/staging/_staging_models.yml
+++ b/products/cdbg/models/staging/_staging_models.yml
@@ -8,13 +8,6 @@ models:
           - not_null
           - unique
 
-  - name: stg__census_data_blocks
-    columns:
-      - name: bctcb2020
-        tests:
-          - not_null
-          - unique
-
   - name: stg__low_mod_by_block_group
     columns:
       - name: geoid

--- a/products/cdbg/models/staging/stg__census_blocks.sql
+++ b/products/cdbg/models/staging/stg__census_blocks.sql
@@ -1,11 +1,15 @@
 {{ config(
     materialized = 'table',
     indexes=[
-      {'columns': ['wkb_geometry'], 'type': 'gist'},
+      {'columns': ['geom'], 'type': 'gist'},
       {'columns': ['geoid']},
     ]
 ) }}
 SELECT
+    geoid,
     left(geoid, 12) AS block_group_geoid,
-    *
+    borocode::integer AS borough_code,
+    boroname AS borough_name,
+    ct2020,
+    wkb_geometry AS geom
 FROM {{ source("recipe_sources", "dcp_cb2020_wi") }}

--- a/products/cdbg/models/staging/stg__census_data_blocks.sql
+++ b/products/cdbg/models/staging/stg__census_data_blocks.sql
@@ -1,7 +1,0 @@
-SELECT
-    geoid20 AS bctcb2020,
-    borocode::integer AS borough_code,
-    geogname AS borough_name,
-    "pop1.1"::numeric AS total_population   -- noqa: RF01
-FROM {{ source("recipe_sources", "dcp_censusdata_blocks") }}
-WHERE geogtype = 'CB2020'

--- a/products/cdbg/recipe.yml
+++ b/products/cdbg/recipe.yml
@@ -6,8 +6,6 @@ inputs:
   missing_versions_strategy: find_latest
   datasets:
   - name: dcp_mappluto_clipped
-  - name: dcp_cb2020_wi # maybe not needed. including for now in case it's helpful for block groups
+  - name: dcp_cb2020_wi
   - name: dcp_ct2020_wi
-  - name: dcp_censusdata_blocks
-    version: "2020"
   - name: hud_lowmodincomebyblockgroup


### PR DESCRIPTION
related to #1348 

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-cdbg-clean).

visually compared outputs before and after changes, they're identical (other than the fixed `cdbg_borough`)

## changes

The biggest changes are to drop the use of block group census data since it isn't used anymore.

But I also found a bug in the boroughs logic where I missed dropping the use of that census data.