### PR TITLE
drop checkbook from nightly qa builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       dev_bucket: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || '' }}
   checkbook:
     needs: health_check
-    if: inputs.dataset_name == 'checkbook' || inputs.dataset_name  == 'all'
+    if: inputs.dataset_name == 'checkbook'
     uses: ./.github/workflows/checkbook_build.yml
     secrets: inherit
     with:


### PR DESCRIPTION
related to #1338 

reasons to drop it from nightly QA:
- it isn't a finished data product that we'd like to ensure is always buildable
- it often fails due to an intermittent/flaky DB connection during it's `build.py` script
- it's currently failing because it expects csvs from edm-recipes but Ingest only produces parquet files now