### PR TITLE
fix CPDB projects outside of NYC

### DIFF
--- a/products/cpdb/bash/02_build.sh
+++ b/products/cpdb/bash/02_build.sh
@@ -156,4 +156,5 @@ run_sql_command "\COPY cpdb_badgeoms FROM './data/cpdb_geomsremove.csv' DELIMITE
 run_sql_file sql/attributes_badgeoms.sql	
 
 # create final table
+echo 'Creating projects tables'
 run_sql_file sql/projects.sql -v ccp_v=$ccp_v

--- a/products/cpdb/sql/attributes_badgeoms.sql
+++ b/products/cpdb/sql/attributes_badgeoms.sql
@@ -30,3 +30,54 @@ WHERE
         )
     )
     AND geom IS NOT NULL;
+
+-- Fix projects outside of NYC
+-- For now, only fixes point projects with inverted longtiude values
+-- All points in NYC are around latitude -73.9
+DROP TABLE IF EXISTS cpdb_dcpattributes_not_in_nyc_fixed;
+
+WITH point_projects_not_entirely_in_nyc AS (
+    SELECT
+        maprojid,
+        geom
+    FROM cpdb_dcpattributes
+    WHERE
+        ST_GEOMETRYTYPE(geom) = 'ST_MultiPoint'
+        AND ST_XMAX(geom) > 0
+),
+
+project_points AS (
+    SELECT
+        maprojid,
+        (ST_DUMP(geom)).geom AS single_point
+    FROM point_projects_not_entirely_in_nyc
+),
+
+fixed_points AS (
+    SELECT
+        maprojid,
+        CASE
+            WHEN ST_X(single_point) > 0
+                THEN ST_SETSRID(ST_MAKEPOINT(-ST_X(single_point), ST_Y(single_point)), 4326)
+            ELSE single_point
+        END AS single_point_fixed
+    FROM project_points
+),
+
+projects AS (
+    SELECT
+        maprojid,
+        ST_MULTI(ST_UNION(single_point_fixed)) AS geom
+    FROM fixed_points
+    GROUP BY maprojid
+)
+
+SELECT *
+INTO cpdb_dcpattributes_not_in_nyc_fixed
+FROM projects;
+
+UPDATE cpdb_dcpattributes
+SET geom = cpdb_dcpattributes_not_in_nyc_fixed.geom
+FROM cpdb_dcpattributes_not_in_nyc_fixed
+WHERE
+    cpdb_dcpattributes.maprojid = cpdb_dcpattributes_not_in_nyc_fixed.maprojid;


### PR DESCRIPTION
resolves #1410

all builds (repeat builds of 24adopt) on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/repeat_build.yml?query=branch%3Adm-cpdb-coords). latest outputs are in `edm-publishing/db-cpdb/build/dm-cpdb-coords`

I checked the new points shapefile in QGIS and all points are now in NYC.

I imagine the SQL approach here could be simpler but I wanted to fit into the "update columns" pattern and fix this ASAP so GIS can redistribute this release.