### PR TITLE
update numbldgs to new four-four

### DIFF
--- a/products/pluto/pluto_build/python/numbldgs.py
+++ b/products/pluto/pluto_build/python/numbldgs.py
@@ -23,7 +23,7 @@ def get_bbl(inputs):
 
 
 def get_bins(uid):
-    # https://data.cityofnewyork.us/Housing-Development/Building-Footprints/nqwf-w8eh
+    # https://data.cityofnewyork.us/Housing-Development/Building-Footprints/5zhs-2jue
     url = f"https://data.cityofnewyork.us/resource/{uid}.csv"
     headers = {"X-App-Token": os.environ["API_TOKEN"]}
     params = {"$select": "bin", "$limit": 50000000000000000}
@@ -32,8 +32,7 @@ def get_bins(uid):
 
 
 if __name__ == "__main__":
-    metadata = requests.get("https://data.cityofnewyork.us/api/views/nqwf-w8eh").json()
-    uid = metadata["childViews"][1]
+    uid = "5zhs-2jue"
     df = get_bins(uid)
     with Pool(processes=cpu_count()) as pool:
         it = pool.map(get_bbl, df.to_dict("records"), 100000)

--- a/products/pluto/pluto_build/templates/pluto_input_numbldgs.yml
+++ b/products/pluto/pluto_build/templates/pluto_input_numbldgs.yml
@@ -5,8 +5,8 @@ dataset:
     url:
       path: s3://edm-recipes/tmp/pluto_input_numbldgs.csv
     options:
-      - "AUTODETECT_TYPE=NO"
-      - "EMPTY_STRING_AS_NULL=YES"
+    - "AUTODETECT_TYPE=NO"
+    - "EMPTY_STRING_AS_NULL=YES"
     geometry:
       SRS: null
       type: NONE
@@ -16,8 +16,8 @@ dataset:
       SRS: null
       type: NONE
     options:
-      - "OVERWRITE=YES"
-      - "PRECISION=NO"
+    - "OVERWRITE=YES"
+    - "PRECISION=NO"
     fields: []
     sql: |
       SELECT bbl, count(*) as count
@@ -30,5 +30,5 @@ dataset:
       ### Number of Buildings
       Please check the following url to check the `building_p` csv url
       it needs to match up with the url in the python script
-    url: https://data.cityofnewyork.us/Housing-Development/Building-Footprints/nqwf-w8eh
+    url: https://data.cityofnewyork.us/Housing-Development/Building-Footprints/5zhs-2jue
     dependents: []


### PR DESCRIPTION
closes #1403.

In #1379 we updated the four-four for `doitt_buildingfootprints` because the old page was deprecated and OTI migrated to a new page. That old dataset, somewhat obscured, is also the actual source of `pluto_input_numbldgs`, which gets geocoded and minorly processed before being archived.

Longer term - we should probably have it pull from our archived `doitt_buildingfootprints` - something that we could use for other recipe datasets too where we
- archive `doitt_buildingfootprints` -> gets version from socrata
- above triggers archive of `doitt_buildingfootprints_geocoded`, which gets latest of above and pins version to the same version

We have other workflows where we do similar things - DevDB inputs off the top of my head. But for now, just want to fix this issue.