### PR TITLE
Ingest QOL tweaks

### DIFF
--- a/dcpy/lifecycle/_cli.py
+++ b/dcpy/lifecycle/_cli.py
@@ -1,6 +1,6 @@
 import typer
 
-from dcpy.lifecycle.ingest import run as ingest
+from dcpy.lifecycle.ingest import _cli_wrapper_run as run_ingest
 from dcpy.lifecycle.package._cli import app as package_app
 from dcpy.lifecycle.distribute import _cli as distribute_cli
 from dcpy.lifecycle.scripts import _cli as scripts_cli
@@ -11,4 +11,4 @@ app.add_typer(distribute_cli.app, name="distribute")
 app.add_typer(scripts_cli.app, name="scripts")
 
 # while there's only one ingest command, add it directly
-app.command(name="ingest")(ingest._cli_wrapper_run)
+app.command(name="ingest")(run_ingest)

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -23,6 +23,12 @@ def _cli_wrapper_run(
     csv: bool = typer.Option(
         False, "-c", "--csv", help="Output csv locally as well as parquet"
     ),
+    local_file_path: Path = typer.Option(
+        None,
+        "--local-file-path",
+        "-p",
+        help="Use local file path as source, overriding source in template",
+    ),
 ):
     ingest(
         dataset_id,
@@ -31,4 +37,5 @@ def _cli_wrapper_run(
         latest=latest,
         skip_archival=skip_archival,
         output_csv=csv,
+        local_file_path=local_file_path,
     )

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import typer
+
+from .run import ingest
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command("ingest")
+def _cli_wrapper_run(
+    dataset_id: str = typer.Argument(),
+    version: str = typer.Option(
+        None,
+        "-v",
+        "--version",
+        help="Version of dataset being archived",
+    ),
+    mode: str = typer.Option(None, "-m", "--mode", help="Preprocessing mode"),
+    latest: bool = typer.Option(
+        False, "-l", "--latest", help="Push to latest folder in s3"
+    ),
+    skip_archival: bool = typer.Option(False, "--skip-archival", "-s"),
+    csv: bool = typer.Option(
+        False, "-c", "--csv", help="Output csv locally as well as parquet"
+    ),
+):
+    ingest(
+        dataset_id,
+        version,
+        mode=mode,
+        latest=latest,
+        skip_archival=skip_archival,
+        output_csv=csv,
+    )

--- a/dcpy/lifecycle/ingest/configure.py
+++ b/dcpy/lifecycle/ingest/configure.py
@@ -146,6 +146,7 @@ def get_config(
     *,
     mode: str | None = None,
     template_dir: Path = TEMPLATE_DIR,
+    local_file_path: Path | None = None,
 ) -> Config:
     """Generate config object for dataset and optional version"""
     run_details = metadata.get_run_details()
@@ -154,6 +155,11 @@ def get_config(
     filename = get_filename(template.ingestion.source, template.id)
     version = version or get_version(template.ingestion.source, run_details.timestamp)
     template = read_template(dataset_id, version=version, template_dir=template_dir)
+
+    if local_file_path:
+        template.ingestion.source = LocalFileSource(
+            type="local_file", path=local_file_path
+        )
 
     processing_steps = determine_processing_steps(
         template.ingestion.processing_steps,

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -1,15 +1,15 @@
 import json
 from pathlib import Path
-import typer
 
 from dcpy.models.lifecycle.ingest import Config
 from dcpy.connectors.edm import recipes
 from . import configure, extract, transform, validate
 
+
 TMP_DIR = Path("tmp")
 
 
-def run(
+def ingest(
     dataset_id: str,
     version: str | None = None,
     *,
@@ -84,34 +84,3 @@ def run(
             case _:
                 pass
     return config
-
-
-app = typer.Typer(add_completion=False)
-
-
-@app.command("run")
-def _cli_wrapper_run(
-    dataset_id: str = typer.Argument(),
-    version: str = typer.Option(
-        None,
-        "-v",
-        "--version",
-        help="Version of dataset being archived",
-    ),
-    mode: str = typer.Option(None, "-m", "--mode", help="Preprocessing mode"),
-    latest: bool = typer.Option(
-        False, "-l", "--latest", help="Push to latest folder in s3"
-    ),
-    skip_archival: bool = typer.Option(False, "--skip-archival", "-s"),
-    csv: bool = typer.Option(
-        False, "-c", "--csv", help="Output csv locally as well as parquet"
-    ),
-):
-    run(
-        dataset_id,
-        version,
-        mode=mode,
-        latest=latest,
-        skip_archival=skip_archival,
-        output_csv=csv,
-    )

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -3,10 +3,11 @@ from pathlib import Path
 
 from dcpy.models.lifecycle.ingest import Config
 from dcpy.connectors.edm import recipes
+from dcpy.lifecycle import BASE_PATH
 from . import configure, extract, transform, validate
 
-
-TMP_DIR = Path("tmp")
+INGEST_DIR = BASE_PATH / "ingest"
+STAGING_DIR = INGEST_DIR / "staging"
 
 
 def ingest(
@@ -25,13 +26,11 @@ def ingest(
     )
     transform.validate_processing_steps(config.id, config.ingestion.processing_steps)
 
-    if not staging_dir:
-        staging_dir = (
-            TMP_DIR / dataset_id / config.archival.archival_timestamp.isoformat()
-        )
-        staging_dir.mkdir(parents=True)
-    else:
-        staging_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir = (
+        staging_dir
+        or STAGING_DIR / dataset_id / config.archival.archival_timestamp.isoformat()
+    )
+    staging_dir.mkdir(parents=True, exist_ok=True)
 
     # download dataset
     extract.download_file_from_source(

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 import shutil
-
 from dcpy.models.lifecycle.ingest import Config
 from dcpy.connectors.edm import recipes
 from dcpy.lifecycle import BASE_PATH
@@ -45,6 +44,9 @@ def ingest(
     with open(staging_dir / "config.json", "w") as f:
         json.dump(config.model_dump(mode="json"), f, indent=4)
 
+    with open(staging_dir / CONFIG_FILENAME, "w") as f:
+        json.dump(config.model_dump(mode="json"), f, indent=4)
+
     # download dataset
     extract.download_file_from_source(
         config.ingestion.source,
@@ -56,7 +58,7 @@ def ingest(
 
     if not skip_archival:
         # archive to edm-recipes/raw_datasets
-        recipes.archive_raw_dataset(config, file_path)
+        recipes.archive_dataset(config, file_path, raw=True)
 
     init_parquet = "init.parquet"
     transform.to_parquet(

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -23,9 +23,14 @@ def ingest(
     skip_archival: bool = False,
     output_csv: bool = False,
     template_dir: Path = configure.TEMPLATE_DIR,
+    local_file_path: Path | None = None,
 ) -> Config:
     config = configure.get_config(
-        dataset_id, version=version, mode=mode, template_dir=template_dir
+        dataset_id,
+        version=version,
+        mode=mode,
+        template_dir=template_dir,
+        local_file_path=local_file_path,
     )
     transform.validate_processing_steps(config.id, config.ingestion.processing_steps)
 

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -7,8 +7,8 @@ from dcpy.lifecycle import BASE_PATH
 from . import configure, extract, transform, validate
 
 INGEST_DIR = BASE_PATH / "ingest"
-STAGING_DIR = INGEST_DIR / "staging"
-OUTPUT_DIR = INGEST_DIR / "datasets"
+INGEST_STAGING_DIR = INGEST_DIR / "staging"
+INGEST_OUTPUT_DIR = INGEST_DIR / "datasets"
 CONFIG_FILENAME = "config.json"
 
 
@@ -35,14 +35,13 @@ def ingest(
 
     if not staging_dir:
         staging_dir = (
-            STAGING_DIR / dataset_id / config.archival.archival_timestamp.isoformat()
+            INGEST_STAGING_DIR
+            / dataset_id
+            / config.archival.archival_timestamp.isoformat()
         )
         staging_dir.mkdir(parents=True)
     else:
         staging_dir.mkdir(parents=True, exist_ok=True)
-
-    with open(staging_dir / "config.json", "w") as f:
-        json.dump(config.model_dump(mode="json"), f, indent=4)
 
     with open(staging_dir / CONFIG_FILENAME, "w") as f:
         json.dump(config.model_dump(mode="json"), f, indent=4)
@@ -77,7 +76,7 @@ def ingest(
         output_csv=output_csv,
     )
 
-    output_dir = OUTPUT_DIR / dataset_id / config.version
+    output_dir = INGEST_OUTPUT_DIR / dataset_id / config.version
     output_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(staging_dir / CONFIG_FILENAME, output_dir)
     shutil.copy(staging_dir / config.filename, output_dir)

--- a/dcpy/lifecycle/scripts/ingest_with_library_fallback.py
+++ b/dcpy/lifecycle/scripts/ingest_with_library_fallback.py
@@ -1,6 +1,6 @@
 import typer
 
-from dcpy.lifecycle.ingest import configure, run as run_ingest
+from dcpy.lifecycle.ingest import configure, ingest
 
 
 def run(
@@ -21,7 +21,7 @@ def run(
     ),
 ):
     if (configure.TEMPLATE_DIR / f"{dataset_id}.yml").exists():
-        run_ingest.run(
+        ingest(
             dataset_id,
             version,
             mode=mode,

--- a/dcpy/lifecycle/scripts/validate_ingest.py
+++ b/dcpy/lifecycle/scripts/validate_ingest.py
@@ -12,7 +12,7 @@ from dcpy.models.base import SortedSerializedBase, YamlWriter
 from dcpy.models.lifecycle.ingest import DatasetAttributes
 from dcpy.data import compare
 from dcpy.connectors.edm import recipes
-from dcpy.lifecycle.ingest.run import TMP_DIR, run as run_ingest
+from dcpy.lifecycle.ingest.run import TMP_DIR, ingest as run_ingest
 from dcpy.lifecycle.builds import metadata as build_metadata
 
 DATABASE = "sandbox"

--- a/dcpy/lifecycle/scripts/validate_ingest.py
+++ b/dcpy/lifecycle/scripts/validate_ingest.py
@@ -12,7 +12,7 @@ from dcpy.models.base import SortedSerializedBase, YamlWriter
 from dcpy.models.lifecycle.ingest import DatasetAttributes
 from dcpy.data import compare
 from dcpy.connectors.edm import recipes
-from dcpy.lifecycle.ingest.run import INGEST_STAGING_DIR, ingest as run_ingest
+from dcpy.lifecycle.ingest.run import INGEST_DIR, ingest as run_ingest
 from dcpy.lifecycle.builds import metadata as build_metadata
 
 DATABASE = "sandbox"
@@ -108,18 +108,29 @@ def library_archive(
 def ingest(
     dataset: str,
     version: str | None = None,
-    ingest_staging_dir: Path = INGEST_STAGING_DIR,
 ) -> None:
-    ingest_dir = ingest_staging_dir / "migrate_from_library"
-    if ingest_dir.is_dir():
-        shutil.rmtree(ingest_dir)
-    run_ingest(dataset, version=version, staging_dir=ingest_dir, skip_archival=True)
+    ## separate from "standard" ingest folders
+    ingest_dir = INGEST_DIR / "migrate_from_library"
+    ## where ingest will do processing
+    dataset_staging_dir = ingest_dir / "staging"
+    ## where ingest will dump outputs
+    ingest_output_dir = ingest_dir / "datasets"
+    if dataset_staging_dir.is_dir():
+        shutil.rmtree(dataset_staging_dir)
 
-    ingest_output_path = ingest_dir / f"{dataset}.parquet"
+    config = run_ingest(
+        dataset,
+        version=version,
+        dataset_staging_dir=dataset_staging_dir,
+        ingest_output_dir=ingest_output_dir,
+        skip_archival=True,
+    )
+
+    ## copy so that it's in the "library" file system for easy import
+    output_path = ingest_output_dir / dataset / config.version / f"{dataset}.parquet"
     ingest_path = LIBRARY_PATH / dataset / "ingest" / f"{dataset}.parquet"
-
     ingest_path.parent.mkdir(exist_ok=True, parents=True)
-    shutil.copy(ingest_output_path, ingest_path)
+    shutil.copy(output_path, ingest_path)
 
 
 def load_recipe(

--- a/dcpy/lifecycle/scripts/validate_ingest.py
+++ b/dcpy/lifecycle/scripts/validate_ingest.py
@@ -12,7 +12,7 @@ from dcpy.models.base import SortedSerializedBase, YamlWriter
 from dcpy.models.lifecycle.ingest import DatasetAttributes
 from dcpy.data import compare
 from dcpy.connectors.edm import recipes
-from dcpy.lifecycle.ingest.run import TMP_DIR, ingest as run_ingest
+from dcpy.lifecycle.ingest.run import STAGING_DIR, ingest as run_ingest
 from dcpy.lifecycle.builds import metadata as build_metadata
 
 DATABASE = "sandbox"
@@ -108,7 +108,7 @@ def library_archive(
 def ingest(
     dataset: str,
     version: str | None = None,
-    ingest_parent_dir: Path = TMP_DIR,
+    ingest_parent_dir: Path = STAGING_DIR,
 ) -> None:
     ingest_dir = ingest_parent_dir / dataset / "staging"
     if ingest_dir.is_dir():

--- a/dcpy/lifecycle/scripts/validate_ingest.py
+++ b/dcpy/lifecycle/scripts/validate_ingest.py
@@ -12,7 +12,7 @@ from dcpy.models.base import SortedSerializedBase, YamlWriter
 from dcpy.models.lifecycle.ingest import DatasetAttributes
 from dcpy.data import compare
 from dcpy.connectors.edm import recipes
-from dcpy.lifecycle.ingest.run import STAGING_DIR, ingest as run_ingest
+from dcpy.lifecycle.ingest.run import INGEST_STAGING_DIR, ingest as run_ingest
 from dcpy.lifecycle.builds import metadata as build_metadata
 
 DATABASE = "sandbox"
@@ -108,9 +108,9 @@ def library_archive(
 def ingest(
     dataset: str,
     version: str | None = None,
-    ingest_parent_dir: Path = STAGING_DIR,
+    ingest_staging_dir: Path = INGEST_STAGING_DIR,
 ) -> None:
-    ingest_dir = ingest_parent_dir / dataset / "staging"
+    ingest_dir = ingest_staging_dir / "migrate_from_library"
     if ingest_dir.is_dir():
         shutil.rmtree(ingest_dir)
     run_ingest(dataset, version=version, staging_dir=ingest_dir, skip_archival=True)

--- a/dcpy/test/connectors/edm/test_recipes.py
+++ b/dcpy/test/connectors/edm/test_recipes.py
@@ -89,7 +89,7 @@ class TestArchiveDataset:
     def test_archive_raw_dataset(self, create_buckets, create_temp_filesystem: Path):
         tmp_file = create_temp_filesystem / self.raw_file_name
         tmp_file.touch()
-        recipes.archive_raw_dataset(self.config, tmp_file)
+        recipes.archive_dataset(self.config, tmp_file, raw=True)
         assert s3.folder_exists(
             RECIPES_BUCKET, recipes.s3_raw_folder_path(self.config.raw_dataset_key)
         )

--- a/dcpy/test/lifecycle/ingest/test_configure.py
+++ b/dcpy/test/lifecycle/ingest/test_configure.py
@@ -155,3 +155,15 @@ class TestGetConfig:
                 mode="fake_mode",
                 template_dir=TEMPLATE_DIR,
             )
+
+    def test_file_path_override(self):
+        file_path = Path("dir/fake_file_path")
+        config = configure.get_config(
+            "dcp_addresspoints",
+            version="24c",
+            template_dir=TEMPLATE_DIR,
+            local_file_path=file_path,
+        )
+        assert config.ingestion.source == LocalFileSource(
+            type="local_file", path=file_path
+        )

--- a/dcpy/test/lifecycle/ingest/test_run.py
+++ b/dcpy/test/lifecycle/ingest/test_run.py
@@ -22,7 +22,7 @@ def run_basic(mock_request_get, create_buckets, tmp_path):
     return run_ingest(
         dataset_id=DATASET,
         version=FAKE_VERSION,
-        staging_dir=tmp_path,
+        dataset_staging_dir=tmp_path,
         template_dir=TEMPLATE_DIR,
     )
 
@@ -57,7 +57,7 @@ def test_skip_archival(mock_request_get, create_buckets, tmp_path):
     run_ingest(
         dataset_id=DATASET,
         version=FAKE_VERSION,
-        staging_dir=tmp_path,
+        dataset_staging_dir=tmp_path,
         skip_archival=True,
         template_dir=TEMPLATE_DIR,
     )
@@ -69,7 +69,7 @@ def test_run_update_freshness(mock_request_get, create_buckets, tmp_path):
     run_ingest(
         dataset_id=DATASET,
         version=FAKE_VERSION,
-        staging_dir=tmp_path,
+        dataset_staging_dir=tmp_path,
         template_dir=TEMPLATE_DIR,
     )
     config = recipes.get_config(DATASET, FAKE_VERSION)
@@ -77,7 +77,7 @@ def test_run_update_freshness(mock_request_get, create_buckets, tmp_path):
     run_ingest(
         dataset_id=DATASET,
         version=FAKE_VERSION,
-        staging_dir=tmp_path,
+        dataset_staging_dir=tmp_path,
         latest=True,
         template_dir=TEMPLATE_DIR,
     )
@@ -98,7 +98,7 @@ def test_run_update_freshness_fails_if_data_diff(
     run_ingest(
         dataset_id=DATASET,
         version=FAKE_VERSION,
-        staging_dir=tmp_path,
+        dataset_staging_dir=tmp_path,
         template_dir=TEMPLATE_DIR,
     )
 
@@ -112,6 +112,6 @@ def test_run_update_freshness_fails_if_data_diff(
             run_ingest(
                 dataset_id=DATASET,
                 version=FAKE_VERSION,
-                staging_dir=tmp_path,
+                dataset_staging_dir=tmp_path,
                 template_dir=TEMPLATE_DIR,
             )

--- a/dcpy/test/lifecycle/ingest/test_run.py
+++ b/dcpy/test/lifecycle/ingest/test_run.py
@@ -6,7 +6,7 @@ import shutil
 from dcpy.configuration import RECIPES_BUCKET
 from dcpy.utils import s3
 from dcpy.connectors.edm import recipes
-from dcpy.lifecycle.ingest.run import ingest as run_ingest, STAGING_DIR
+from dcpy.lifecycle.ingest.run import ingest as run_ingest, INGEST_STAGING_DIR
 
 from dcpy.test.conftest import mock_request_get
 from .shared import FAKE_VERSION, TEMPLATE_DIR
@@ -48,8 +48,8 @@ def test_run_output_exists(run_basic):
 def test_run_default_folder(mock_request_get, create_buckets):
     run_ingest(dataset_id=DATASET, version=FAKE_VERSION, template_dir=TEMPLATE_DIR)
     assert s3.object_exists(RECIPES_BUCKET, S3_PATH)
-    assert (STAGING_DIR / DATASET).exists()
-    shutil.rmtree(STAGING_DIR)
+    assert (INGEST_STAGING_DIR / DATASET).exists()
+    shutil.rmtree(INGEST_STAGING_DIR)
 
 
 @mock.patch("requests.get", side_effect=mock_request_get)

--- a/dcpy/test/lifecycle/ingest/test_run.py
+++ b/dcpy/test/lifecycle/ingest/test_run.py
@@ -6,7 +6,7 @@ import shutil
 from dcpy.configuration import RECIPES_BUCKET
 from dcpy.utils import s3
 from dcpy.connectors.edm import recipes
-from dcpy.lifecycle.ingest.run import run as run_ingest, TMP_DIR
+from dcpy.lifecycle.ingest.run import ingest as run_ingest, TMP_DIR
 
 from dcpy.test.conftest import mock_request_get
 from .shared import FAKE_VERSION, TEMPLATE_DIR


### PR DESCRIPTION
All coming up as part of #1334 and the associated datasets moving over to ingest.

1. originally moved too much logic to __init__.py, now mainly just moves cli target and `ingest` function (the function that runs the whole ingest process) to __init__ so that it's easily accessible
2. make use of the `.lifecycle` dir for "staging" the process
3. make use of the `.lifecycle` dir to create a local file system reminiscent of `edm-recipes/datasets` where the outputs are moved to. Just seemed to be nice for troubleshooting (slash running without a connection to s3)
4. ability to provide the path to a source dataset file when running via cli. Just overrides whatever source is found in the template
5. just make one "archive_dataset". @alexrichey based on our pairing yesterday though, maybe I'll scrap this - you could argue we want a different connector class for "raw" datasets and our parquet datasets, since we interact with them in fairly different ways