### PR TITLE
Feb Distribution Fixups

### DIFF
--- a/.github/workflows/distribute_socrata_from_bytes.yml
+++ b/.github/workflows/distribute_socrata_from_bytes.yml
@@ -42,6 +42,10 @@ on:
         description: "Ignore Validation Errors? (Will still perform validation, but will just log the outputs to the console)"
         type: boolean
         default: false
+      MD_REPO_BRANCH:
+        description: "(Override) Product-Metadata branch/commit/ref"
+        type: string
+        default: "main"
 jobs:
   publish:
     runs-on: ubuntu-22.04
@@ -62,6 +66,8 @@ jobs:
         with:
           repository: NYCPlanning/product-metadata
           path: product-metadata
+          ref: ${{ inputs.MD_REPO_BRANCH }}
+
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1

--- a/dcpy/lifecycle/scripts/package_and_distribute.py
+++ b/dcpy/lifecycle/scripts/package_and_distribute.py
@@ -33,6 +33,8 @@ def package_and_distribute(
     product_md = org_md.product(product)
     dataset_md = product_md.dataset(dataset)
     destinations = product_md.query_destinations(**destination_filters)[dataset]
+    assert destinations, "No Destinations found! Check your destination filters"
+
     logger.info(f"Target destinations are {list(destinations.keys())}")
     package_path = package.ASSEMBLY_DIR / product / version / dataset
 

--- a/dcpy/models/product/metadata.py
+++ b/dcpy/models/product/metadata.py
@@ -79,8 +79,10 @@ class ProductMetadata(SortedSerializedBase, extra="forbid"):
         )
         if ds_md.id != dataset_id:
             raise Exception(
-                ("There is a mismatch between the dataset id listed at the"
-                f" dataset level ({ds_md.id}) vs the product-level ({dataset_id})")
+                (
+                    "There is a mismatch between the dataset id listed at the"
+                    f" dataset level ({ds_md.id}) vs the product-level ({dataset_id})"
+                )
             )
 
         ds_md.attributes = ds_md.attributes.apply_defaults(
@@ -201,7 +203,7 @@ class OrgMetadata(SortedSerializedBase, extra="forbid"):
         )
 
     def product(self, name: str) -> ProductMetadata:
-        if not name in self.metadata.products:
+        if name not in self.metadata.products:
             raise Exception(f"{self.PRODUCT_NOT_LISTED_ERROR}: {name}")
 
         return ProductMetadata.from_path(

--- a/dcpy/test/models/product/test_metadata.py
+++ b/dcpy/test/models/product/test_metadata.py
@@ -28,6 +28,32 @@ template_vars = {
 PRODUCT_WITH_ERRORS = "mock_product_with_errors"
 
 
+def test_missing_product(test_metadata_repo: Path):
+    NONEXISTENT_PRODUCT = "asdfasdfsadf"
+    org_md = md.OrgMetadata.from_path(test_metadata_repo, template_vars=template_vars)
+
+    with pytest.raises(Exception) as e:
+        org_md.product(NONEXISTENT_PRODUCT)
+
+    assert str(e.value).startswith(md.OrgMetadata.PRODUCT_NOT_LISTED_ERROR)
+    assert NONEXISTENT_PRODUCT in str(e.value), (
+        "The error message should mention the missing product"
+    )
+
+
+def test_missing_dataset(test_metadata_repo: Path):
+    NONEXISTENT_DATASET = "asdfasdfsadf"
+    org_md = md.OrgMetadata.from_path(test_metadata_repo, template_vars=template_vars)
+
+    with pytest.raises(Exception) as e:
+        org_md.product("lion").dataset(NONEXISTENT_DATASET)
+
+    assert str(e.value).startswith(md.ProductMetadata.DATASET_NOT_LISTED_ERROR)
+    assert NONEXISTENT_DATASET in str(e.value), (
+        "The error message should mention the missing product"
+    )
+
+
 def test_org_md_overrides(test_metadata_repo: Path):
     org_md = md.OrgMetadata.from_path(test_metadata_repo, template_vars=template_vars)
     lion_md = org_md.product("lion")

--- a/dcpy/test/resources/test_product_metadata_repo/products/mock_product_with_errors/dataset_with_reference_errors/metadata.yml
+++ b/dcpy/test/resources/test_product_metadata_repo/products/mock_product_with_errors/dataset_with_reference_errors/metadata.yml
@@ -1,4 +1,4 @@
-id: mock_product_with_errors
+id: dataset_with_reference_errors
 
 attributes:
   description: Has column reference errors


### PR DESCRIPTION
Two things from this last round of making drafts for GIS:
1. Add better error messages when our dataset ids don't line up, or when metadata is retrieved for nonexistant products/datasets. I ran into this while making a revision for the `neighborhood_names` product/dataset
*Long term note: Not sure it makes to define these ids in multiple places. But so long as we do, some enforcement is a necessary thing.

2. Enables specifying a different branch of the product-metadata repo in the Socrata deploy GHA. This is to enable pushing when you don't have dcpy set up locally to push. Sample run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/13314048564/job/37183577385) pushing from a branch called `ar-feb-fixes` in the pmd repo.

Related PR in the MD repo [here](https://github.com/NYCPlanning/product-metadata/pull/40). Note: a few tests on this branch will fail until this related PR is merged.

