### PR TITLE
fix non-deterministic cama row_numbers

### DIFF
--- a/products/pluto/pluto_build/sql/cama_bsmttype.sql
+++ b/products/pluto/pluto_build/sql/cama_bsmttype.sql
@@ -15,7 +15,7 @@ WITH dcpcamavals AS (
             bsmntgradient,
             ROW_NUMBER()
                 OVER (
-                    PARTITION BY LEFT(bbl, 10)
+                    PARTITION BY primebbl
                     ORDER BY bsmnt_type DESC, bsmntgradient DESC
                 )
             AS row_number

--- a/products/pluto/pluto_build/sql/cama_lottype.sql
+++ b/products/pluto/pluto_build/sql/cama_lottype.sql
@@ -11,7 +11,7 @@ WITH dcpcamavals AS (
             lottype,
             ROW_NUMBER()
                 OVER (
-                    PARTITION BY LEFT(bbl, 10)
+                    PARTITION BY primebbl
                     ORDER BY lottype
                 )
             AS row_number


### PR DESCRIPTION
closes #1012 

successful run - `qaqc_mismatch` still shows changed lottype from previous major because the new deterministic sorting does not line up with what was run in last major