### PR TITLE
Get facdb 25v1 passing... again

### DIFF
--- a/products/facilities/recipe.yml
+++ b/products/facilities/recipe.yml
@@ -11,26 +11,17 @@ inputs:
   - name: dcp_mappluto_wi
     file_type: pg_dump
   - name: dcp_boroboundaries_wi
-    file_type: pg_dump
   - name: dcp_ct2010
-    file_type: pg_dump
   - name: dcp_ct2020
-    file_type: pg_dump
   - name: dcp_councildistricts
-    file_type: pg_dump
   - name: dcp_cdboundaries
-    file_type: pg_dump
   - name: dcp_nta2010
-    file_type: pg_dump
   - name: dcp_nta2020
-    file_type: pg_dump
   - name: dcp_policeprecincts
-    file_type: pg_dump
   - name: doitt_zipcodeboundaries
     file_type: pg_dump
   - name: doitt_buildingfootprints
   - name: dcp_school_districts
-    file_type: pg_dump
   # facility sources
   # many datasets are pinned to csv although they have been migrated to ingest
   # because they have not been updated on socrata since before migration


### PR DESCRIPTION
Because bytes quarterly update datasets had been hard-coded to filetype pgdump, there were 404s when trying to pull them after the 25a update yesterday (first time they were archived by ingest)

[successful run](https://github.com/NYCPlanning/data-engineering/actions/runs/13568330146)

I looked at the QA app and results seem okay... EXCEPT we have way fewer records than last time coming from dca_operatingbusinesses. I assume I bungled something in a different PR, will address separately