### PR TITLE
use python 3.13 building docker images

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -66,6 +66,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:
@@ -87,6 +91,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
         with:


### PR DESCRIPTION
Similar fix in #1485 - need python 3.13 to successfully pin requirements of dcpy, which we do prior to building `build-base` and `build-geosupport`