### PR TITLE
fix failing gft dbt source test

### DIFF
--- a/products/green_fast_track/models/_sources.yml
+++ b/products/green_fast_track/models/_sources.yml
@@ -471,7 +471,6 @@ sources:
         columns:
           - name: pwl_id
             tests:
-              - unique
               - not_null
           - name: name
             tests:
@@ -479,6 +478,9 @@ sources:
           - name: wkb_geometry
             tests:
               - not_null
+        tests:
+          - dbt_utils.unique_combination_of_columns:
+              combination_of_columns: [ pwl_id, name ]
 
       - name: nysdec_priority_estuaries
         columns:


### PR DESCRIPTION
gft build is our only failing build on nightly qa, and I don't know when if ever NYSDEC is going to fix (or respond) about the one little data issue (two lakes near binghamton NY having the same pwl_id) which doesn't actually impact the build itself. So I wanted to resolve it.

A couple thoughts on options fixing this
1. just set to warn, and add a "todo"
2. above, but also test the staging table. Long term, there's an argument for testing staging tables rather than source tables as general practice - given the scope of staging tables, it sort of makes sense that we'd want to impose these tests when the tables have been staged and are "transformation-ready". In this case, the data issue is with lakes outside of NYC - after clipping to NYC boundary, pwl_id would actually be unique. So the action of staging gives us some amount of opportunity to handle any known/expected potential issues with source data. Also, any true requirements of the source data are maybe better handled at time of ingestion rather than build time
3. implemented here, don't do unique column but unique combo of columns. this keeps in line with our current setup of testing source and not staging tables, and this test aligns with how we actually set the unique key for the variable in the staging table (concatenate pwl_id and name). But still don't love this here - the fact that it's testing the unique key of the staging table sort of assumes knowledge of what happens downstream and that's a little odd. But seemed like the simplest way to resolve for now

Very curious on folks' thoughts