### PR TITLE
drop renaming of geom for colp

### DIFF
--- a/dcpy/lifecycle/ingest/templates/dcp_colp.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_colp.yml
@@ -13,8 +13,7 @@ ingestion:
   target_crs: EPSG:4326
   source:
     type: file_download
-    url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/colp_{{
-      version }}_csv.zip
+    url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/colp_{{ version }}_csv.zip
   file_format:
     type: csv
     unzipped_filename: colp_{{ version }}.csv

--- a/dcpy/lifecycle/ingest/templates/dcp_colp.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_colp.yml
@@ -13,7 +13,8 @@ ingestion:
   target_crs: EPSG:4326
   source:
     type: file_download
-    url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/colp_{{ version }}_csv.zip
+    url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/colp_{{
+      version }}_csv.zip
   file_format:
     type: csv
     unzipped_filename: colp_{{ version }}.csv
@@ -21,6 +22,8 @@ ingestion:
       geom_column: GEOM
       crs: EPSG:2263
       format: wkb
+    dtype:
+      USECODE: str
   processing_steps:
   - name: clean_column_names
     args: { "lower": True }

--- a/dcpy/lifecycle/ingest/templates/dcp_colp.yml
+++ b/dcpy/lifecycle/ingest/templates/dcp_colp.yml
@@ -24,9 +24,6 @@ ingestion:
   processing_steps:
   - name: clean_column_names
     args: { "lower": True }
-  - name: rename_columns
-    args:
-      map: { "geom": "wkb_geometry" }
   - name: coerce_column_types
     args:
       column_types:
@@ -94,5 +91,5 @@ columns:
   data_type: decimal
 - id: dcpedited
   data_type: text
-- id: wkb_geometry
+- id: geom
   data_type: geometry


### PR DESCRIPTION
[Nightly qa failure](https://github.com/NYCPlanning/data-engineering/actions/runs/13714168747) didn't create an issue for some reason

Ingest-archived colp has a schema change. Looks like an oversight by me - it's mentioned as migrated in https://github.com/NYCPlanning/data-engineering/issues/1290, but there's no report for it.

Since we haven't used the latest archived colp I want to overwrite it with a version that will run successfully in our pipelines

Archived [here](https://github.com/NYCPlanning/data-engineering/actions/runs/13726154624)






















