### PR TITLE
Ar fix failing nightly

### DIFF
--- a/products/colp/sql/qc_geospatial_check.sql
+++ b/products/colp/sql/qc_geospatial_check.sql
@@ -12,9 +12,9 @@ from (
                               'projects_not_within_NYC' as field
 	from (SELECT a.uid, a.HNUM, a.sname, a.address, a.PARCELNAME, a.AGENCY, a.latitude, a.longitude, a.data_library_version as v
           FROM dcp_colp a, 
-               (SELECT ST_Union(wkb_geometry) geom
+               (SELECT ST_Union(geom) geom
                FROM dcp_boroboundaries_wi) combined 
-          WHERE NOT ST_WITHIN(ST_GeomFromEWKT(a.wkb_geometry), combined.geom)) tmp
+          WHERE NOT ST_WITHIN(ST_GeomFromEWKT(a.geom), combined.geom)) tmp
     )t
 );
 

--- a/products/colp/sql/qc_geospatial_check.sql
+++ b/products/colp/sql/qc_geospatial_check.sql
@@ -14,7 +14,7 @@ from (
           FROM dcp_colp a, 
                (SELECT ST_Union(wkb_geometry) geom
                FROM dcp_boroboundaries_wi) combined 
-          WHERE NOT ST_WITHIN(ST_GeomFromEWKT(a.geom), combined.geom)) tmp
+          WHERE NOT ST_WITHIN(a.geom, combined.geom)) tmp
     )t
 );
 

--- a/products/colp/sql/qc_geospatial_check.sql
+++ b/products/colp/sql/qc_geospatial_check.sql
@@ -12,7 +12,7 @@ from (
                               'projects_not_within_NYC' as field
 	from (SELECT a.uid, a.HNUM, a.sname, a.address, a.PARCELNAME, a.AGENCY, a.latitude, a.longitude, a.data_library_version as v
           FROM dcp_colp a, 
-               (SELECT ST_Union(geom) geom
+               (SELECT ST_Union(wkb_geometry) geom
                FROM dcp_boroboundaries_wi) combined 
           WHERE NOT ST_WITHIN(ST_GeomFromEWKT(a.geom), combined.geom)) tmp
     )t

--- a/products/pluto/pluto_build/sql/preprocessing.sql
+++ b/products/pluto/pluto_build/sql/preprocessing.sql
@@ -9,8 +9,6 @@ ALTER TABLE dcp_cb2010_wi RENAME wkb_geometry TO geom;
 ALTER TABLE dcp_ct2020_wi RENAME wkb_geometry TO geom;
 ALTER TABLE dcp_cb2020_wi RENAME wkb_geometry TO geom;
 ALTER TABLE dcp_edesignation RENAME wkb_geometry TO geom;
-ALTER TABLE dcp_colp DROP COLUMN geom;
-ALTER TABLE dcp_colp RENAME wkb_geometry TO geom;
 ALTER TABLE lpc_historic_districts RENAME wkb_geometry TO geom;
 ALTER TABLE lpc_landmarks RENAME wkb_geometry TO geom;
 ALTER TABLE dcp_cdboundaries_wi RENAME wkb_geometry TO geom;


### PR DESCRIPTION
the processing steps to ingest COLP were changed to remove a `wkb_geometry` field, and leave the duplicated `geom` field. This cleans out references in two products that were failing nightly QA