### PR TITLE
github action maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,11 @@ on:
         description: "Version of dataset being built (overrides version defined in recipe)"
         type: string
         required: false
+      test_severity:
+        description: "Test severity (should post-build tests cause action to fail?)"
+        type: choice
+        required: true
+        options: [ error, warn ]
       dev_image:
         description: "Use dev image specific to this branch (if exists)"
         type: boolean
@@ -73,6 +78,10 @@ on:
       recipe_file:
         type: string
         required: true
+      test_severity:
+        type: string
+        required: false
+        default: 'error'
       dev_image:
         type: string
         default: false
@@ -240,6 +249,7 @@ jobs:
       recipe_file: ${{ inputs.recipe_file }}
       plan_command: ${{ needs.health_check.outputs.plan_command }}
       dev_bucket: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || '' }}
+      test_severity: ${{ inputs.test_severity }}
   ztl:
     needs: health_check
     if: inputs.dataset_name == 'ztl' || inputs.dataset_name  == 'all'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,33 +9,33 @@ on:
         type: choice
         required: true
         options:
-          - template
-          - cbbr
-          - cdbg
-          - checkbook
-          - colp
-          - cpdb
-          - developments
-          - facilities
-          - factfinder
-          - green_fast_track
-          - knownprojects
-          - pluto
-          - ztl
-          - all
+        - template
+        - cbbr
+        - cdbg
+        - checkbook
+        - colp
+        - cpdb
+        - developments
+        - facilities
+        - factfinder
+        - green_fast_track
+        - knownprojects
+        - pluto
+        - ztl
+        - all
       recipe_file:
         description: "Recipe filename to use"
         type: string
         options:
-          - recipe
-          - recipe-minor
+        - recipe
+        - recipe-minor
         required: true
         default: recipe
       version:
         description: "Version of dataset being built (overrides version defined in recipe)"
         type: string
         required: false
-      dev_image: 
+      dev_image:
         description: "Use dev image specific to this branch (if exists)"
         type: boolean
         required: true
@@ -46,9 +46,9 @@ on:
         required: true
         default: INFO
         options:
-          - WARNING
-          - INFO
-          - DEBUG
+        - WARNING
+        - INFO
+        - DEBUG
       build_name:
         description: "Build name (defaults to branch name)"
         type: string
@@ -58,7 +58,8 @@ on:
         type: string
         required: false
       dev_bucket:
-        description: "dev bucket to use in place of recipes/publishing. If name of bucket is 'de-dev-a' simply put 'a'"
+        description: "dev bucket to use in place of recipes/publishing. If name of bucket is
+          'de-dev-a' simply put 'a'"
         type: string
         required: false
   workflow_call:
@@ -83,11 +84,14 @@ on:
         type: string
         required: false
 
-
 env:
-  tag: ${{ (inputs.dev_image == 'true' || inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
   build_name: ${{ inputs.build_name || github.head_ref || github.ref_name }}
-  version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
+  version: ${{ inputs.version && format('--version {0}', inputs.version) || '' }}
+  tag: >-
+    ${{
+      (inputs.dev_image == 'true' || inputs.dev_image == true)
+      && format('dev-{0}', github.head_ref || github.ref_name) || 'latest'
+    }}
 
 jobs:
   health_check:
@@ -98,11 +102,11 @@ jobs:
       tag: ${{ env.tag }}
       build_name: ${{ env.build_name }}
     steps:
-      - name: Check inputs
-        run: |
-          echo "running with image tag ${{ (inputs.dev_image == 'true'|| inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}"
-          echo "Workflow inputs are:"
-          echo "${{ toJSON(github.event.inputs) }}"
+    - name: Check inputs
+      run: |
+        echo "running with image tag ${{ (inputs.dev_image == 'true'|| inputs.dev_image == true) && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}"
+        echo "Workflow inputs are:"
+        echo "${{ toJSON(github.event.inputs) }}"
   template:
     needs: health_check
     if: inputs.dataset_name == 'template'

--- a/.github/workflows/colp_build.yml
+++ b/.github/workflows/colp_build.yml
@@ -34,19 +34,6 @@ jobs:
       RECIPES_BUCKET: ${{ inputs.dev_bucket || 'edm-recipes' }}
       PUBLISHING_BUCKET: ${{ inputs.dev_bucket || 'edm-publishing' }}
       DEV_FLAG: ${{ inputs.dev_bucket && 'true' || 'false' }}
-    services:
-      postgis:
-        image: postgis/postgis:15-3.3-alpine
-        env:
-          POSTGRES_DB: dbcolp
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly_qa.yml
+++ b/.github/workflows/nightly_qa.yml
@@ -30,6 +30,7 @@ jobs:
       recipe_file: recipe
       dev_image: ${{ inputs.dev_image || 'false' }}
       build_name: ${{ inputs.build_name || 'nightly_qa' }}
+      test_severity: warn
 
   create_issue_on_failure:
     needs: [test, build]

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -38,64 +38,67 @@ jobs:
       RECIPES_BUCKET: ${{ inputs.dev_bucket || 'edm-recipes' }}
       PUBLISHING_BUCKET: ${{ inputs.dev_bucket || 'edm-publishing' }}
       DEV_FLAG: ${{ inputs.dev_bucket && 'true' || 'false' }}
-      TEST_SEVERITY: ${{ contains(fromJson('["nightly_qa", "compile_python_reqs"]'), inputs.build_name) && 'warn' || 'error' }}
+      TEST_SEVERITY: ${{ contains(fromJson('["nightly_qa", "compile_python_reqs"]'),
+        inputs.build_name) && 'warn' || 'error' }}
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - name: Load Secrets
-        uses: 1password/load-secrets-action@v1
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
-          AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
-          AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
-          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
-          BUILD_ENGINE_HOST: "op://Data Engineering/EDM_DATA/server"
-          BUILD_ENGINE_USER: "op://Data Engineering/EDM_DATA/username"
-          BUILD_ENGINE_PASSWORD: "op://Data Engineering/EDM_DATA/password"
-          BUILD_ENGINE_PORT: "op://Data Engineering/EDM_DATA/port"
-          EDM_DATA: "op://Data Engineering/EDM_DATA/defaultdb_url"
+    - name: Load Secrets
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: true
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+        AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+        AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+        BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+        BUILD_ENGINE_HOST: "op://Data Engineering/EDM_DATA/server"
+        BUILD_ENGINE_USER: "op://Data Engineering/EDM_DATA/username"
+        BUILD_ENGINE_PASSWORD: "op://Data Engineering/EDM_DATA/password"
+        BUILD_ENGINE_PORT: "op://Data Engineering/EDM_DATA/port"
+        EDM_DATA: "op://Data Engineering/EDM_DATA/defaultdb_url"
 
-      - name: Finish container setup
-        working-directory: ./
-        run: ./bash/docker_container_setup.sh
+    - name: Finish container setup
+      working-directory: ./
+      run: ./bash/docker_container_setup.sh
 
-      - name: Set build environment variables
-        working-directory: ./
-        run: ./bash/build_env_setup.sh
+    - name: Set build environment variables
+      working-directory: ./
+      run: ./bash/build_env_setup.sh
 
-      - name: Plan build
-        working-directory: products/pluto
-        run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
+    - name: Plan build
+      working-directory: products/pluto
+      run: python3 -m dcpy.lifecycle.builds.plan ${{ inputs.plan_command }}
 
-      - name: Set recipe env vars
-        working-directory: ./
-        run: source ./bash/export_recipe_env.sh products/pluto/${{ inputs.recipe_file }}.lock.yml
+    - name: Set recipe env vars
+      working-directory: ./
+      run: source ./bash/export_recipe_env.sh products/pluto/${{ inputs.recipe_file
+        }}.lock.yml
 
-      - name: Dataloading
-        working-directory: products/pluto
-        run: python -m dcpy.lifecycle.builds.load load --recipe-path ${{ inputs.recipe_file }}.lock.yml
+    - name: Dataloading
+      working-directory: products/pluto
+      run: python -m dcpy.lifecycle.builds.load load --recipe-path ${{ inputs.recipe_file
+        }}.lock.yml
 
-      - name: Load Local Data
-        run: ./01_load_local_csvs.sh
+    - name: Load Local Data
+      run: ./01_load_local_csvs.sh
 
-      - name: building ...
-        run: ./02_build.sh
+    - name: building ...
+      run: ./02_build.sh
 
-      - name: apply corrections
-        run: ./03_corrections.sh
+    - name: apply corrections
+      run: ./03_corrections.sh
 
-      - name: Archive
-        run: ./04_archive.sh
+    - name: Archive
+      run: ./04_archive.sh
 
-      - name: QAQC
-        run: ./05_qaqc.sh
+    - name: QAQC
+      run: ./05_qaqc.sh
 
-      - name: Export and Upload
-        run: ./06_export.sh
+    - name: Export and Upload
+      run: ./06_export.sh
 
-      - name: Custom QAQC
-        working-directory: products/pluto
-        run: ./pluto_build/07_custom_qaqc.sh
+    - name: Custom QAQC
+      working-directory: products/pluto
+      run: ./pluto_build/07_custom_qaqc.sh

--- a/.github/workflows/pluto_build.yml
+++ b/.github/workflows/pluto_build.yml
@@ -21,6 +21,9 @@ on:
       dev_bucket:
         type: string
         required: false
+      test_severity:
+        type: string
+        default: 'error'
 
 jobs:
   build:
@@ -38,8 +41,7 @@ jobs:
       RECIPES_BUCKET: ${{ inputs.dev_bucket || 'edm-recipes' }}
       PUBLISHING_BUCKET: ${{ inputs.dev_bucket || 'edm-publishing' }}
       DEV_FLAG: ${{ inputs.dev_bucket && 'true' || 'false' }}
-      TEST_SEVERITY: ${{ contains(fromJson('["nightly_qa", "compile_python_reqs"]'),
-        inputs.build_name) && 'warn' || 'error' }}
+      TEST_SEVERITY: ${{ inputs.test_severity }}
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,4 +218,5 @@ jobs:
       dataset_name: all
       build_note: check newly compiled python requirements
       recipe_file: recipe
+      test_severity: warn
       dev_image: true

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -210,7 +210,6 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
       with:
-        fail_ci_if_error: true
         verbose: true
 
   validate_product_metadata:


### PR DESCRIPTION
By commit is easier - some autoformatting in commit 1

Main motivation was pluto build failures seen in #1508 - there are times when we don't want these "take-action" failures to actually fail, since we regularly run builds that aren't "production" and don't need to meet the same stringent requirements.

Also
- remove unused postgis service for colp build (seems like just detritis)
- change ci failure for codecov

## Testing test_severity logic

- [Run w/ 'warn'](https://github.com/NYCPlanning/data-engineering/actions/runs/13773396224/job/38517029360) (should pass)
- [Run w/ 'error'](https://github.com/NYCPlanning/data-engineering/actions/runs/13773852992/job/38518537088) (should fail)