### PR TITLE
make s3 interaction opt-in for ingest

### DIFF
--- a/.github/workflows/ingest_multiple.yml
+++ b/.github/workflows/ingest_multiple.yml
@@ -102,7 +102,7 @@ jobs:
       env:
         version: ${{ inputs.version && format('--version {0}', inputs.version) || '' }}
         latest: ${{ inputs.latest == 'true' && '--latest' || '' }}
-      run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} $version $latest -s
+      run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} $version $latest --push-to-s3
 
   create_issue_on_failure:
     needs: dataloading

--- a/.github/workflows/ingest_multiple.yml
+++ b/.github/workflows/ingest_multiple.yml
@@ -102,7 +102,7 @@ jobs:
       env:
         version: ${{ inputs.version && format('--version {0}', inputs.version) || '' }}
         latest: ${{ inputs.latest == 'true' && '--latest' || '' }}
-      run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} $version $latest
+      run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} $version $latest -s
 
   create_issue_on_failure:
     needs: dataloading

--- a/.github/workflows/ingest_single.yml
+++ b/.github/workflows/ingest_single.yml
@@ -67,4 +67,4 @@ jobs:
           latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
           version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
           mode: ${{ github.event.inputs.mode && format('--mode {0}', github.event.inputs.mode) || '' }}
-        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ inputs.dataset }} $latest $version $mode -s
+        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ inputs.dataset }} $latest $version $mode --push-to-s3

--- a/.github/workflows/ingest_single.yml
+++ b/.github/workflows/ingest_single.yml
@@ -67,4 +67,4 @@ jobs:
           latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
           version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
           mode: ${{ github.event.inputs.mode && format('--mode {0}', github.event.inputs.mode) || '' }}
-        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ inputs.dataset }} $latest $version $mode
+        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ inputs.dataset }} $latest $version $mode -s

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -68,7 +68,7 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Ingest
-        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} --latest -s
+        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} --latest --push-to-s3
 
   build_ztl:
     needs: [dataloading]

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -68,7 +68,7 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Ingest
-        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} --latest
+        run: python3 -m dcpy.cli lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} --latest -s
 
   build_ztl:
     needs: [dataloading]

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -20,7 +20,7 @@ def _cli_wrapper_run(
     latest: bool = typer.Option(
         False, "-l", "--latest", help="Push to latest folder in s3"
     ),
-    skip_archival: bool = typer.Option(False, "--skip-archival", "-s"),
+    push_to_s3: bool = typer.Option(False, "--s3", "-s"),
     csv: bool = typer.Option(
         False, "-c", "--csv", help="Output csv locally as well as parquet"
     ),
@@ -42,7 +42,7 @@ def _cli_wrapper_run(
         version,
         mode=mode,
         latest=latest,
-        skip_archival=skip_archival,
+        push_to_s3=push_to_s3,
         output_csv=csv,
         local_file_path=local_file_path,
         template_dir=template_dir,

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -20,7 +20,7 @@ def _cli_wrapper_run(
     latest: bool = typer.Option(
         False, "-l", "--latest", help="Push to latest folder in s3"
     ),
-    push_to_s3: bool = typer.Option(False, "--s3", "-s"),
+    push_to_s3: bool = typer.Option(False, "--push-to-s3", "-s"),
     csv: bool = typer.Option(
         False, "-c", "--csv", help="Output csv locally as well as parquet"
     ),

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -24,7 +24,7 @@ def ingest(
     ingest_output_dir: Path = INGEST_OUTPUT_DIR,
     mode: str | None = None,
     latest: bool = False,
-    skip_archival: bool = False,
+    push_to_s3: bool = False,
     output_csv: bool = False,
     template_dir: Path | None = TEMPLATE_DIR,
     local_file_path: Path | None = None,
@@ -62,7 +62,7 @@ def ingest(
     )
     file_path = dataset_staging_dir / config.archival.raw_filename
 
-    if not skip_archival:
+    if push_to_s3:
         # archive to edm-recipes/raw_datasets
         recipes.archive_dataset(config, file_path, raw=True)
 
@@ -88,10 +88,10 @@ def ingest(
     shutil.copy(dataset_staging_dir / CONFIG_FILENAME, dataset_output_dir)
     shutil.copy(dataset_staging_dir / config.filename, dataset_output_dir)
 
-    action = validate.validate_against_existing_versions(
-        config.dataset, dataset_staging_dir / config.filename
-    )
-    if not skip_archival:
+    if push_to_s3:
+        action = validate.validate_against_existing_versions(
+            config.dataset, dataset_staging_dir / config.filename
+        )
         match action:
             case validate.ArchiveAction.push:
                 recipes.archive_dataset(

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -64,7 +64,8 @@ def ingest(
 
     if push_to_s3:
         # archive to edm-recipes/raw_datasets
-        recipes.archive_dataset(config, file_path, raw=True)
+        assert config.archival.acl, "'acl' must be defined to push to s3"
+        recipes.archive_dataset(config, file_path, acl=config.archival.acl, raw=True)
 
     init_parquet = "init.parquet"
     transform.to_parquet(
@@ -89,13 +90,17 @@ def ingest(
     shutil.copy(dataset_staging_dir / config.filename, dataset_output_dir)
 
     if push_to_s3:
+        assert config.archival.acl
         action = validate.validate_against_existing_versions(
             config.dataset, dataset_staging_dir / config.filename
         )
         match action:
             case validate.ArchiveAction.push:
                 recipes.archive_dataset(
-                    config, dataset_staging_dir / config.filename, latest=latest
+                    config,
+                    dataset_staging_dir / config.filename,
+                    acl=config.archival.acl,
+                    latest=latest,
                 )
             case validate.ArchiveAction.update_freshness:
                 recipes.update_freshness(

--- a/dcpy/lifecycle/scripts/ingest_with_library_fallback.py
+++ b/dcpy/lifecycle/scripts/ingest_with_library_fallback.py
@@ -16,7 +16,7 @@ def run(
     latest: bool = typer.Option(
         False, "-l", "--latest", help="Push to latest folder in s3"
     ),
-    push_to_s3: bool = typer.Option(False, "--s3", "-s"),
+    push_to_s3: bool = typer.Option(False, "--push-to-s3", "-s"),
     csv: bool = typer.Option(
         False, "-c", "--csv", help="Output csv locally as well as parquet"
     ),

--- a/dcpy/lifecycle/scripts/ingest_with_library_fallback.py
+++ b/dcpy/lifecycle/scripts/ingest_with_library_fallback.py
@@ -16,7 +16,7 @@ def run(
     latest: bool = typer.Option(
         False, "-l", "--latest", help="Push to latest folder in s3"
     ),
-    skip_archival: bool = typer.Option(False, "--skip-archival", "-s"),
+    push_to_s3: bool = typer.Option(False, "--s3", "-s"),
     csv: bool = typer.Option(
         False, "-c", "--csv", help="Output csv locally as well as parquet"
     ),
@@ -30,7 +30,7 @@ def run(
             version,
             mode=mode,
             latest=latest,
-            skip_archival=skip_archival,
+            push_to_s3=push_to_s3,
             output_csv=csv,
         )
     else:
@@ -40,7 +40,7 @@ def run(
             name=dataset_id,
             version=version,
             latest=latest,
-            push=not skip_archival,
+            push=push_to_s3,
             # defaults - needed since typer defaults are odd when called in python rather than cli
             output_formats=["pgdump", "parquet", "csv"],
             path=None,  # type: ignore

--- a/dcpy/lifecycle/scripts/validate_ingest.py
+++ b/dcpy/lifecycle/scripts/validate_ingest.py
@@ -123,7 +123,7 @@ def ingest(
         version=version,
         dataset_staging_dir=dataset_staging_dir,
         ingest_output_dir=ingest_output_dir,
-        skip_archival=True,
+        push_to_s3=False,
     )
 
     ## copy so that it's in the "library" file system for easy import

--- a/dcpy/models/lifecycle/ingest.py
+++ b/dcpy/models/lifecycle/ingest.py
@@ -93,7 +93,7 @@ class ArchivalMetadata(SortedSerializedBase):
     archival_timestamp: datetime
     check_timestamps: list[datetime] = []
     raw_filename: str
-    acl: recipes.ValidAclValues
+    acl: recipes.ValidAclValues | None = None
 
 
 class Ingestion(SortedSerializedBase):
@@ -114,7 +114,7 @@ class Template(BaseModel, extra="forbid"):
     """Definition of a dataset for ingestion/processing/archiving in edm-recipes"""
 
     id: str
-    acl: recipes.ValidAclValues
+    acl: recipes.ValidAclValues | None = None
 
     attributes: DatasetAttributes
     ingestion: Ingestion

--- a/dcpy/test/lifecycle/ingest/test_run.py
+++ b/dcpy/test/lifecycle/ingest/test_run.py
@@ -22,6 +22,7 @@ def run_basic(mock_request_get, create_buckets, tmp_path):
     return run_ingest(
         dataset_id=DATASET,
         version=FAKE_VERSION,
+        push_to_s3=True,
         dataset_staging_dir=tmp_path,
         template_dir=TEMPLATE_DIR,
     )
@@ -46,7 +47,12 @@ def test_run_output_exists(run_basic):
 
 @mock.patch("requests.get", side_effect=mock_request_get)
 def test_run_default_folder(mock_request_get, create_buckets):
-    run_ingest(dataset_id=DATASET, version=FAKE_VERSION, template_dir=TEMPLATE_DIR)
+    run_ingest(
+        dataset_id=DATASET,
+        version=FAKE_VERSION,
+        push_to_s3=True,
+        template_dir=TEMPLATE_DIR,
+    )
     assert s3.object_exists(RECIPES_BUCKET, S3_PATH)
     assert (INGEST_STAGING_DIR / DATASET).exists()
     shutil.rmtree(INGEST_STAGING_DIR)
@@ -58,7 +64,7 @@ def test_skip_archival(mock_request_get, create_buckets, tmp_path):
         dataset_id=DATASET,
         version=FAKE_VERSION,
         dataset_staging_dir=tmp_path,
-        skip_archival=True,
+        push_to_s3=False,
         template_dir=TEMPLATE_DIR,
     )
     assert not s3.object_exists(RECIPES_BUCKET, S3_PATH)
@@ -70,6 +76,7 @@ def test_run_update_freshness(mock_request_get, create_buckets, tmp_path):
         dataset_id=DATASET,
         version=FAKE_VERSION,
         dataset_staging_dir=tmp_path,
+        push_to_s3=True,
         template_dir=TEMPLATE_DIR,
     )
     config = recipes.get_config(DATASET, FAKE_VERSION)
@@ -78,6 +85,7 @@ def test_run_update_freshness(mock_request_get, create_buckets, tmp_path):
         dataset_id=DATASET,
         version=FAKE_VERSION,
         dataset_staging_dir=tmp_path,
+        push_to_s3=True,
         latest=True,
         template_dir=TEMPLATE_DIR,
     )
@@ -99,6 +107,7 @@ def test_run_update_freshness_fails_if_data_diff(
         dataset_id=DATASET,
         version=FAKE_VERSION,
         dataset_staging_dir=tmp_path,
+        push_to_s3=True,
         template_dir=TEMPLATE_DIR,
     )
 
@@ -113,6 +122,7 @@ def test_run_update_freshness_fails_if_data_diff(
                 dataset_id=DATASET,
                 version=FAKE_VERSION,
                 dataset_staging_dir=tmp_path,
+                push_to_s3=True,
                 template_dir=TEMPLATE_DIR,
             )
 

--- a/dcpy/test/lifecycle/ingest/test_validate.py
+++ b/dcpy/test/lifecycle/ingest/test_validate.py
@@ -59,7 +59,7 @@ class TestValidateAgainstExistingVersions:
 
     def test_existing(self, create_buckets):
         ds = BASIC_CONFIG.dataset
-        recipes.archive_dataset(BASIC_CONFIG, TEST_OUTPUT)
+        recipes.archive_dataset(BASIC_CONFIG, TEST_OUTPUT, acl="private")
         assert recipes.exists(ds)
         assert (
             validate.validate_against_existing_versions(ds, TEST_OUTPUT)
@@ -68,7 +68,7 @@ class TestValidateAgainstExistingVersions:
 
     def test_existing_data_diffs(self, create_buckets):
         ds = BASIC_CONFIG.dataset
-        recipes.archive_dataset(BASIC_CONFIG, TEST_OUTPUT)
+        recipes.archive_dataset(BASIC_CONFIG, TEST_OUTPUT, acl="private")
         assert recipes.exists(ds)
         with pytest.raises(FileExistsError):
             validate.validate_against_existing_versions(


### PR DESCRIPTION
originally meant to address #1516, but after starting to implement, think that will be easier post connector stuff after allsince that will simplify interactions between ingest and recipes just a little bit

Instead, just addresses smaller points in todos in #1438
 - default to not interact with s3 and only validate dataframe against s3 if flag is present
 - make acl values optional for this reason (only need acl if we're pushing to a server, otherwise it's just clutter for users)