### PR TITLE
build edm-recipes duckdb catalog nightly

### DIFF
--- a/.github/workflows/recipes_catalog.yml
+++ b/.github/workflows/recipes_catalog.yml
@@ -1,0 +1,35 @@
+name: Build and Push `edm-recipes` Catalog
+
+on:
+  schedule:
+  - cron: "0 5 * * *"
+  workflow_dispatch:
+
+
+jobs:
+  build_and_push:
+    name: Build and Push `edm-recipes` Catalog
+    runs-on: ubuntu-22.04
+    container:
+      image: nycplanning/dev:latest
+    env:
+      RECIPES_BUCKET: edm-recipes
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Load Secrets
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: true
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+        AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+        AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+
+    - name: Finish container setup
+      working-directory: ./
+      run: ./bash/docker_container_setup.sh
+
+    - name: Publish
+      run: python admin/ops/recipes_duckdb_catalog.py

--- a/admin/ops/recipes_duckdb_catalog.py
+++ b/admin/ops/recipes_duckdb_catalog.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import duckdb
+
+from dcpy.utils import s3, duckdb as dcpy_duckdb
+from dcpy.connectors.edm import recipes
+
+local_file = Path("./catalog.duckdb")
+
+local_file.unlink(missing_ok=True)
+conn = duckdb.connect(local_file)
+dcpy_duckdb.setup_s3_secret(conn)
+conn.sql("install spatial; load spatial;")
+
+for i, dataset in enumerate(s3.get_subfolders(recipes.BUCKET, "datasets/")):
+    print(dataset)
+    if recipes.DatasetType.parquet in recipes.get_file_types(
+        recipes.DatasetKey(id=dataset, version="latest")
+    ):
+        conn.sql(f"CREATE OR REPLACE SCHEMA {dataset}")
+        for version in recipes.get_all_versions(dataset):
+            if recipes.DatasetType.parquet in recipes.get_file_types(
+                recipes.DatasetKey(id=dataset, version=version)
+            ):
+                conn.sql(
+                    f"""
+                        CREATE VIEW {dataset}."{version}" AS 
+                        SELECT * 
+                        FROM 's3://edm-recipes/datasets/{dataset}/{version}/{dataset}.parquet';
+                    """
+                )
+
+conn.commit()
+conn.close()
+
+s3.upload_file(recipes.BUCKET, local_file, "datasets/catalog.duckdb", "private")

--- a/admin/ops/recipes_duckdb_catalog.py
+++ b/admin/ops/recipes_duckdb_catalog.py
@@ -1,9 +1,8 @@
 """
 This script, locally and in edm-recipes/datasets/catalog.duckdb, creates a snapshot
-catalog of all parquet datasets in edm-recipes/datasets by creating views.
-
-There is one schema created per dataset and one table per version, such that
-they can be queried as `{dataset}.{version}`
+catalog of all parquet datasets in edm-recipes/datasets. It does this by creating
+one view per file: There is one schema created per dataset and one table per version,
+such that they can be queried as `{dataset}.{version}`
 """
 
 from pathlib import Path

--- a/admin/ops/recipes_duckdb_catalog.py
+++ b/admin/ops/recipes_duckdb_catalog.py
@@ -1,3 +1,11 @@
+"""
+This script, locally and in edm-recipes/datasets/catalog.duckdb, creates a snapshot
+catalog of all parquet datasets in edm-recipes/datasets by creating views.
+
+There is one schema created per dataset and one table per version, such that
+they can be queried as `{dataset}.{version}`
+"""
+
 from pathlib import Path
 import duckdb
 

--- a/dcpy/utils/duckdb.py
+++ b/dcpy/utils/duckdb.py
@@ -2,9 +2,10 @@ import duckdb
 import os
 
 
-def setup_s3_secret():
-    duckdb.sql("INSTALL httpfs; LOAD httpfs;")
-    duckdb.sql(
+def setup_s3_secret(conn: duckdb.DuckDBPyConnection | None = None) -> None:
+    cmd = conn.sql if conn else duckdb.sql
+    cmd("INSTALL httpfs; LOAD httpfs;")
+    cmd(
         f"""
             CREATE SECRET IF NOT EXISTS s3_secret (
                 TYPE S3,


### PR DESCRIPTION
Have long been searching for the ideal lightweight wrapper on top of edm-recipes for a really simple and easy querying experience. This might be it!

[Action running](https://github.com/NYCPlanning/data-engineering/actions/runs/13928568842) (push trigger, dropped in rebase)

## DuckDB UI General info

@damonmcc posted about [duckdb ui](https://duckdb.org/2025/03/12/duckdb-ui.html) recently - it seems to be what I've wanted for personally querying parquet files. My best user experience so far was running duckdb queries via python api in jupyter notebook, which always feels still just a little awkward. With duckdb ui, you have
- db introspection like in dbeaver, but no need to create local db connection like with dbeaver
- easily runnable snippets like jupyter notebook

![image](https://github.com/user-attachments/assets/9e398b4e-81cb-4106-96f1-c6fbe59e0aa9)
Very nice user experience for quickly querying via s3 or local filepaths

## Setting up DuckDB UI locally

If you just run `duckdb`, you can run the following commands
```
install spatial;
load spatial;
install ui;
load ui;
CALL start_ui();
```
If you've installed ui before, you can just start the ui at startup with `duckdb -ui`

You'll also have to create a secret for interacting with s3
```
CREATE PERSISTENT SECRET IF NOT EXISTS s3_secret (
    TYPE S3,
    KEY_ID 'qwertyuiop',
    SECRET 'qwertyuiop',
    ENDPOINT 'example.digitaloceanspaces.com'
);
```

Note - without `PERSISTENT`, this command just creates a temporary secret, used in the current connection (but stored in memory) and then disposed. `PERSISTENT` outputs it to ~/.duckdb, unencrypted. Either way, nothing gets stored in the connected db though

## This PR: creating a `catalog`

With duckdb ui, you can point to a https or s3 read-only duckdb database. For a moment this had me hoping we could attach an explorable s3 bucket, essentially just a wrapper over the file system (if duckdb underneath was using s3 api). Seems like that's not the case. @damonmcc mentioned maybe worst-case, we could load whatever datasets we need into a duckdb database and save that somewhere. Which got me thinking, we don't need the data in the db file, we just need pointers to the data. So... views. Views are great file wrappers in duckdb, you basically just get to treat your file (local, on s3) as a table.

The script in this PR then does a few things
- creates a local duckdb file and connects to it
- iterates through all versions of all recipe datasets, and if parquet files are found, creates views in the local duckdb file to query them
- pushes this duckdb file to s3

Then, you can attach the recipes catalog from s3 in duckdb ui (or attach to duckdb without ui, but exploring via ui is really what I'm excited about here)
![image](https://github.com/user-attachments/assets/c47b1db7-9e70-4215-9cce-f19eece0d3d5)

And you can explore our whole catalog of recipes datasets by id and version, and easily query them without thinking about s3 paths
![image](https://github.com/user-attachments/assets/a1e48180-9caa-4a57-b6ba-8f1773c20d1a)

This PR has this file updated nightly. While it might be nice to update it in real time, then we'd actually need to worry about things like it being ACID, not having concurrent overwrites, etc -> at that point, if we really need a live catalog of our data lake, we'll need to go the iceberg route or something like that. This is really just as minimal an implementation of a read-only catalog as possible

## Use cases/where to go from here
More than anything, I'd love this because it seems like a great way to just quickly query source data when trying to answer weird, exploratory problems. There's very little overhead. So happy to brainstorm and chat but also would be very down to fairly soon get this on main just so it's there for us to play with and iterate. The file ends up being 2MB, which is a little surprising, but I think it stores schema for each of these views, so for datasets that archive every week that's a decent amount of data.

The autocomplete/intellisense type stuff could be a bit better, but I hope they'll work on that.

While geometries are recognized as such (and you can use duckdb spatial functions), there's no visualization, and geoms in table results are represented as binary unless you convert to wkt manually. 

Longer term, would love to get power users using this. I think it's a great way to make our data a little more accessible outside of this group.