### PR TITLE
don't apply codecov status to ci check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,0 @@
-coverage:
-  status:
-    project: off
-    patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off

--- a/dcpy/utils/duckdb.py
+++ b/dcpy/utils/duckdb.py
@@ -3,6 +3,7 @@ import os
 
 
 def setup_s3_secret(conn: duckdb.DuckDBPyConnection | None = None) -> None:
+    print("this line isn't tested!")
     cmd = conn.sql if conn else duckdb.sql
     cmd("INSTALL httpfs; LOAD httpfs;")
     cmd(


### PR DESCRIPTION
Need to remove dummy commit, but needed to demonstrate.

I think this looks how I'd actually like it - we still get codecov commenting its report, but CI isn't failed