### PR TITLE
drop two obsolete datasets from arcgis online weekly pull

### DIFF
--- a/.github/workflows/ingest_arcgis_feature_server.yml
+++ b/.github/workflows/ingest_arcgis_feature_server.yml
@@ -28,8 +28,6 @@ jobs:
         dcp_waterfront_access_map_pow
         dcp_wrp_recognized_ecological_complexes
         dcp_wrp_special_natural_waterfront_areas
-        nysdec_freshwater_wetlands_checkzones
-        nysdec_freshwater_wetlands
         nysdec_lands
         nysdec_natural_heritage_communities
         nysdec_priority_lakes


### PR DESCRIPTION
closes #1369

There's an ongoing conversation on how to replace these datasets in GFT with CAPS - I'll make an issue shortly describing state of things. For building gft 25v1, I don't think this is blocking (the wetlands don't exactly change often)