### PR TITLE
add timestamp to logging utils

### DIFF
--- a/dcpy/utils/logging.py
+++ b/dcpy/utils/logging.py
@@ -16,7 +16,9 @@ class LoggingHandler(logging.StreamHandler):
 logging.root.setLevel(logging.INFO)
 
 handler = LoggingHandler()
-formatter = logging.Formatter(logging.BASIC_FORMAT)
+formatter = logging.Formatter(
+    fmt="%(asctime)s %(levelname)s:%(name)s:%(message)s", datefmt="%H:%M:%S"
+)
 handler.setFormatter(formatter)
 
 logger = logging.getLogger("dcpy")


### PR DESCRIPTION
This just seemed nice. 

Running a build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14040350354) to demonstrate

```
16:21:20 INFO:dcpy:Pulling nysdec_freshwater_wetlands_checkzones to destination: postgres
16:21:20 INFO:dcpy:🛠 nysdec_freshwater_wetlands_checkzones.sql doesn't exists in cache, downloading datasets/nysdec_freshwater_wetlands_checkzones/20220927/nysdec_freshwater_wetlands_checkzones.sql
  Downloading nysdec_freshwater_wetlands_checkzones.sql ━━━━━━━━━━━ 100% 0:00:00
16:21:22 INFO:dcpy:Pulled nysdec_freshwater_wetlands_checkzones to .lifecycle/builds/load/nysdec_freshwater_wetlands_checkzones/20220927/nysdec_freshwater_wetlands_checkzones.sql.
16:21:22 INFO:dcpy:Inserting id='nysdec_freshwater_wetlands_checkzones' version='20220927' file_type=<DatasetType.pg_dump: 'pg_dump'> into postgres
```

If people have other thoughts about logging, happy to chat in this PR too