### PR TITLE
only check for s3 bucket when needed

### DIFF
--- a/admin/ops/recipes_duckdb_catalog.py
+++ b/admin/ops/recipes_duckdb_catalog.py
@@ -11,6 +11,7 @@ import duckdb
 from dcpy.utils import s3, duckdb as dcpy_duckdb
 from dcpy.connectors.edm import recipes
 
+bucket = recipes._bucket()
 local_file = Path("./catalog.duckdb")
 
 local_file.unlink(missing_ok=True)
@@ -18,7 +19,7 @@ conn = duckdb.connect(local_file)
 dcpy_duckdb.setup_s3_secret(conn)
 conn.sql("install spatial; load spatial;")
 
-for i, dataset in enumerate(s3.get_subfolders(recipes.BUCKET, "datasets/")):
+for i, dataset in enumerate(s3.get_subfolders(bucket, "datasets/")):
     print(dataset)
     if recipes.DatasetType.parquet in recipes.get_file_types(
         recipes.DatasetKey(id=dataset, version="latest")
@@ -39,4 +40,4 @@ for i, dataset in enumerate(s3.get_subfolders(recipes.BUCKET, "datasets/")):
 conn.commit()
 conn.close()
 
-s3.upload_file(recipes.BUCKET, local_file, "datasets/catalog.duckdb", "private")
+s3.upload_file(bucket, local_file, "datasets/catalog.duckdb", "private")

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -34,22 +34,23 @@ from dcpy.models.lifecycle.builds import BuildMetadata, EventLog, EventType
 from dcpy.utils import s3, git, versions, metadata, postgres
 from dcpy.utils.logging import logger
 
-assert PUBLISHING_BUCKET, (
-    "'PUBLISHING_BUCKET' must be defined to use edm.publishing connector"
-)
-BUCKET = PUBLISHING_BUCKET
 
-BASE_DO_URL = f"https://cloud.digitalocean.com/spaces/{BUCKET}"
+def _bucket() -> str:
+    assert PUBLISHING_BUCKET, (
+        "'RECIPES__bucket()' must be defined to use edm.recipes connector"
+    )
+    return PUBLISHING_BUCKET
 
 
 def exists(key: ProductKey) -> bool:
-    return s3.folder_exists(BUCKET, key.path)
+    return s3.folder_exists(_bucket(), key.path)
 
 
 def get_build_metadata(product_key: ProductKey) -> BuildMetadata:
     """Retrieve a product build metadata from s3."""
     key = f"{product_key.path}/build_metadata.json"
-    if not s3.object_exists(BUCKET, key):
+    bucket = _bucket()
+    if not s3.object_exists(bucket, key):
         if not exists(product_key):
             raise FileNotFoundError(f"Product {product_key} does not exist.")
         else:
@@ -57,7 +58,7 @@ def get_build_metadata(product_key: ProductKey) -> BuildMetadata:
                 f"Build metadata not found for product {product_key}."
             )
     obj = s3.client().get_object(
-        Bucket=BUCKET, Key=f"{product_key.path}/build_metadata.json"
+        Bucket=bucket, Key=f"{product_key.path}/build_metadata.json"
     )
     file_content = str(obj["Body"].read(), "utf-8")
     return BuildMetadata(**yaml.safe_load(file_content))
@@ -79,7 +80,7 @@ def get_latest_version(product: str) -> str | None:
 
 
 def get_published_versions(product: str, exclude_latest: bool = True) -> list[str]:
-    all_versions = s3.get_subfolders(BUCKET, f"{product}/publish/")
+    all_versions = s3.get_subfolders(_bucket(), f"{product}/publish/")
     output = (
         [v for v in all_versions if v != "latest"] if exclude_latest else all_versions
     )
@@ -87,12 +88,12 @@ def get_published_versions(product: str, exclude_latest: bool = True) -> list[st
 
 
 def get_draft_versions(product: str) -> list[str]:
-    return sorted(s3.get_subfolders(BUCKET, f"{product}/draft/"), reverse=True)
+    return sorted(s3.get_subfolders(_bucket(), f"{product}/draft/"), reverse=True)
 
 
 def get_draft_version_revisions(product: str, version: str) -> list[str]:
     return sorted(
-        s3.get_subfolders(BUCKET, f"{product}/draft/{version}/"), reverse=True
+        s3.get_subfolders(_bucket(), f"{product}/draft/{version}/"), reverse=True
     )
 
 
@@ -114,7 +115,7 @@ def get_draft_revision_label(product: str, version: str, revision_num: int) -> s
 
 
 def get_builds(product: str) -> list[str]:
-    return sorted(s3.get_subfolders(BUCKET, f"{product}/build/"), reverse=True)
+    return sorted(s3.get_subfolders(_bucket(), f"{product}/build/"), reverse=True)
 
 
 def get_previous_version(
@@ -151,7 +152,7 @@ def get_previous_version(
 
 
 def get_filenames(product_key: ProductKey) -> set[str]:
-    return s3.get_filenames(BUCKET, product_key.path)
+    return s3.get_filenames(_bucket(), product_key.path)
 
 
 def get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
@@ -195,7 +196,7 @@ def upload(
     if not output_path.is_dir():
         raise Exception("'upload' expects output_path to be a directory, not a file")
     s3.upload_folder(
-        BUCKET,
+        _bucket(),
         output_path,
         Path(build_key.path),
         acl,
@@ -220,6 +221,7 @@ def legacy_upload(
     Upload file or folder to publishing, with more flexibility around s3 subpath
     Currently used only by db-factfinder
     """
+    bucket = _bucket()
     if s3_subpath is None:
         prefix = Path(publishing_folder)
     else:
@@ -228,7 +230,7 @@ def legacy_upload(
     meta = generate_metadata()
     if output.is_dir():
         s3.upload_folder(
-            BUCKET,
+            bucket,
             output,
             key,
             acl,
@@ -239,17 +241,17 @@ def legacy_upload(
         if latest:
             ## much faster than uploading again
             s3.copy_folder(
-                BUCKET,
+                bucket,
                 str(key) + "/",
                 str(prefix / "latest"),
                 acl,
                 max_files=max_files,
             )
     else:
-        s3.upload_file(BUCKET, output, str(key), "public-read", metadata=meta)
+        s3.upload_file(bucket, output, str(key), "public-read", metadata=meta)
         if latest:
             ## much faster than uploading again
-            s3.copy_file(BUCKET, str(key), str(prefix / "latest" / output.name), acl)
+            s3.copy_file(bucket, str(key), str(prefix / "latest" / output.name), acl)
 
 
 def upload_build(
@@ -311,6 +313,7 @@ def promote_to_draft(
     max_files: int = s3.MAX_FILE_COUNT,
     draft_revision_summary: str = "",
 ) -> DraftKey:
+    bucket = _bucket()
     version = get_version(build_key)
 
     # generate version draft revision number
@@ -332,11 +335,11 @@ def promote_to_draft(
     draft_key = DraftKey(build_key.product, version, draft_revision_label)
     source = build_key.path + "/"
     target = draft_key.path + "/"
-    s3.copy_folder(BUCKET, source, target, acl, max_files=max_files)
+    s3.copy_folder(bucket, source, target, acl, max_files=max_files)
 
     # upload updated metadata file
     s3.upload_file(
-        BUCKET,
+        bucket,
         build_metadata_path,
         f"{target}{build_metadata_path.name}",
         acl,
@@ -346,7 +349,7 @@ def promote_to_draft(
         f"Promoted {build_key.product} to drafts as {version}/{draft_revision_label}"
     )
     if not keep_build:
-        s3.delete(BUCKET, source)
+        s3.delete(bucket, source)
 
     run_details = metadata.get_run_details()
     event_metadata = EventLog(
@@ -407,6 +410,7 @@ def publish(
 ) -> PublishKey:
     """Publishes a specific draft build of a data product
     By default, keeps draft output folder"""
+    bucket = _bucket()
     version = get_version(draft_key)
     new_version = validate_or_patch_version(draft_key.product, version, is_patch)
 
@@ -425,12 +429,12 @@ def publish(
     publish_key = PublishKey(draft_key.product, new_version)
     source = draft_key.path + "/"
     target = publish_key.path + "/"
-    s3.copy_folder(BUCKET, source, target, acl, max_files=max_files)
+    s3.copy_folder(bucket, source, target, acl, max_files=max_files)
 
     # upload metadata if version was patched
     if build_metadata:
         s3.upload_file(
-            BUCKET,
+            bucket,
             build_metadata_path,
             f"{target}{build_metadata_path.name}",
             acl,
@@ -450,7 +454,7 @@ def publish(
 
         if after_latest_version or latest_version is None:
             s3.copy_folder(
-                BUCKET,
+                bucket,
                 source,
                 f"{draft_key.product}/publish/latest/",
                 acl,
@@ -458,7 +462,7 @@ def publish(
             )
             if build_metadata:
                 s3.upload_file(
-                    BUCKET,
+                    bucket,
                     build_metadata_path,
                     f"{draft_key.product}/publish/latest/{build_metadata_path.name}",
                     acl,
@@ -497,13 +501,14 @@ def download_published_version(
     *,
     include_prefix_in_export: bool = True,
 ) -> None:
+    bucket = _bucket()
     output_dir = output_dir or Path(".")
     published_versions = get_published_versions(product=publish_key.product)
     assert publish_key.version in published_versions, (
-        f"{publish_key} not found in S3 bucket '{BUCKET}'. Published versions are {published_versions}"
+        f"{publish_key} not found in S3 bucket '{bucket}'. Published versions are {published_versions}"
     )
     s3.download_folder(
-        BUCKET,
+        bucket,
         f"{publish_key.path}/",
         output_dir,
         include_prefix_in_export=include_prefix_in_export,
@@ -512,21 +517,22 @@ def download_published_version(
 
 def file_exists(product_key: ProductKey, filepath: str) -> bool:
     """Returns true if given file exists within outputs for given product key"""
-    return s3.object_exists(bucket=BUCKET, key=f"{product_key.path}/{filepath}")
+    return s3.object_exists(bucket=_bucket(), key=f"{product_key.path}/{filepath}")
 
 
 def get_file(product_key: ProductKey, filepath: str) -> BytesIO:
     """Returns file as BytesIO given product key and path within output folder"""
-    return s3.get_file_as_stream(BUCKET, f"{product_key.path}/{filepath}")
+    return s3.get_file_as_stream(_bucket(), f"{product_key.path}/{filepath}")
 
 
 T = TypeVar("T")
 
 
 def _read_data_helper(path: str, filereader: Callable[[BytesIO], T], **kwargs) -> T:
-    if not s3.object_exists(BUCKET, path):
+    bucket = _bucket()
+    if not s3.object_exists(bucket, path):
         raise FileNotFoundError(f"publishing file {path} not found.")
-    with s3.get_file_as_stream(BUCKET, path) as stream:
+    with s3.get_file_as_stream(bucket, path) as stream:
         data = filereader(stream, **kwargs)
     return data
 
@@ -554,7 +560,7 @@ def read_csv_legacy(
     version -- a specific version of a product
     filepath -- the filepath of the desired csv in the output folder
     """
-    with s3.get_file_as_stream(BUCKET, f"{product}/{version}/{filepath}") as stream:
+    with s3.get_file_as_stream(_bucket(), f"{product}/{version}/{filepath}") as stream:
         df = pd.read_csv(stream, **kwargs)
     return df
 
@@ -576,7 +582,7 @@ def get_zip(product_key: ProductKey, filepath: str) -> ZipFile:
     product_key -- a key to find a specific instance of a data product
     filepath -- the filepath of the desired csv in the output folder
     """
-    stream = s3.get_file_as_stream(BUCKET, f"{product_key.path}/{filepath}")
+    stream = s3.get_file_as_stream(_bucket(), f"{product_key.path}/{filepath}")
     zip = ZipFile(stream)
     return zip
 
@@ -587,7 +593,7 @@ def download_file(
     logger.info(f"Downloading {product_key}, {filepath}")
     output_dir = output_dir or Path(".")
     output_filepath = output_dir / Path(filepath).name
-    s3.download_file(BUCKET, f"{product_key.path}/{filepath}", output_filepath)
+    s3.download_file(_bucket(), f"{product_key.path}/{filepath}", output_filepath)
     return output_filepath
 
 
@@ -602,14 +608,15 @@ def publish_add_created_date(
 ) -> dict[str, str]:
     """Publishes a specific draft build of a data product
     By default, keeps draft output folder"""
+    bucket = _bucket()
     if version is None:
-        with s3.get_file(BUCKET, f"{source}version.txt") as f:
+        with s3.get_file(bucket, f"{source}version.txt") as f:
             version = str(f.read())
     print(version)
-    old_metadata = s3.get_metadata(BUCKET, f"{source}{file_for_creation_date}")
+    old_metadata = s3.get_metadata(bucket, f"{source}{file_for_creation_date}")
     target = f"{product}/publish/{version}/"
     s3.copy_folder(
-        BUCKET,
+        bucket,
         source,
         target,
         acl,
@@ -626,7 +633,7 @@ def get_data_directory_url(product_key: ProductKey) -> str:
     if not path.endswith("/"):
         path += "/"
     endpoint = urlencode({"path": path})
-    url = urljoin(BASE_DO_URL, "?" + endpoint)
+    url = urljoin(f"https://cloud.digitalocean.com/spaces/{_bucket()}", "?" + endpoint)
 
     return url
 
@@ -636,11 +643,12 @@ def _gis_dataset_path(name: str, version: str) -> str:
 
 
 def _assert_gis_dataset_exists(name: str, version: str):
+    bucket = _bucket()
     version = version.upper()
-    if not s3.object_exists(BUCKET, _gis_dataset_path(name, version)):
+    if not s3.object_exists(bucket, _gis_dataset_path(name, version)):
         print(_gis_dataset_path(name, version))
-        print(s3.list_objects(BUCKET, _gis_dataset_path(name, version)))
-        print(s3.object_exists(BUCKET, _gis_dataset_path(name, version)))
+        print(s3.list_objects(bucket, _gis_dataset_path(name, version)))
+        print(s3.object_exists(bucket, _gis_dataset_path(name, version)))
         raise FileNotFoundError(f"GIS dataset {name} has no version {version}")
 
 
@@ -652,7 +660,7 @@ def get_latest_gis_dataset_version(dataset_name: str) -> str:
     gis_version_formats = [r"^\d{2}[A-Z]$", r"^\d{8}$"]
     subfolders = []
     matched_formats = set()
-    for f in s3.get_subfolders(BUCKET, f"datasets/{dataset_name}"):
+    for f in s3.get_subfolders(_bucket(), f"datasets/{dataset_name}"):
         for p in gis_version_formats:
             if re.match(p, f):
                 subfolders.append(f)
@@ -678,7 +686,7 @@ def download_gis_dataset(dataset_name: str, version: str, target_folder: Path):
     assert target_folder.is_dir(), f"Target folder '{target_folder}' is not a directory"
     _assert_gis_dataset_exists(dataset_name, version)
     file_path = target_folder / f"{dataset_name}.zip"  ## we assume all gis datasets are
-    s3.download_file(BUCKET, _gis_dataset_path(dataset_name, version), file_path)
+    s3.download_file(_bucket(), _gis_dataset_path(dataset_name, version), file_path)
     return file_path
 
 

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -37,7 +37,7 @@ from dcpy.utils.logging import logger
 
 def _bucket() -> str:
     assert PUBLISHING_BUCKET, (
-        "'RECIPES__bucket()' must be defined to use edm.recipes connector"
+        "'PUBLISHING_BUCKET' must be defined to use edm.recipes connector"
     )
     return PUBLISHING_BUCKET
 

--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -29,7 +29,7 @@ from dcpy.utils.logging import logger
 
 def _bucket() -> str:
     assert configuration.RECIPES_BUCKET, (
-        "'RECIPES__bucket()' must be defined to use edm.recipes connector"
+        "'RECIPES_BUCKET' must be defined to use edm.recipes connector"
     )
     return configuration.RECIPES_BUCKET
 


### PR DESCRIPTION
To not error when not using recipes/publishing connectors unless theyre used.

There's certainly a more graceful way to handle this, but this'll do for now I think

dcpy tests are failing on main - in here, only the expected 4 tests fail

[Ingest job](https://github.com/NYCPlanning/data-engineering/actions/runs/14063613871) on this branch (on dev bucket)

[Build job](https://github.com/NYCPlanning/data-engineering/actions/runs/14063638345) (should be covered by templatedb in test CI but just wanted to be sure)