### PR TITLE
fix nysdec schema changes, autoformat yml

### DIFF
--- a/products/green_fast_track/bash/export.sh
+++ b/products/green_fast_track/bash/export.sh
@@ -18,6 +18,9 @@ mkdir -p output && (
     echo "Copy metadata files"
     cp ../source_data_versions.csv .
     cp ../build_metadata.json .
+
+    echo "Generate int_flags__all csv"
+    csv_export int_flags__all all_flags
     
     echo "Generate FileGeodatabase ${fgdb_filename}"
     echo "FGDB export green_fast_track_bbls ..."

--- a/products/green_fast_track/dbt_project.yml
+++ b/products/green_fast_track/dbt_project.yml
@@ -2,8 +2,8 @@ name: "green_fast_track"
 
 profile: "dcp-de-postgres"
 
-model-paths: ["models"]
-macro-paths: ["macros"]
+model-paths: [ "models" ]
+macro-paths: [ "macros" ]
 
 seeds:
   +quote_columns: true

--- a/products/green_fast_track/models/_sources.yml
+++ b/products/green_fast_track/models/_sources.yml
@@ -1,534 +1,535 @@
 version: 2
 
 sources:
-  - name: recipe_sources
-    schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
-    tables:
-      - name: panynj_jfk_65db
-        columns:
-          - name: wkb_geometry
-            tests:
-              - unique
-              - not_null
-      - name: panynj_lga_65db
-        columns:
-          - name: wkb_geometry
-            tests:
-              - unique
-              - not_null
+- name: recipe_sources
+  schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
+  tables:
+  - name: panynj_jfk_65db
+    columns:
+    - name: wkb_geometry
+      tests:
+      - unique
+      - not_null
+  - name: panynj_lga_65db
+    columns:
+    - name: wkb_geometry
+      tests:
+      - unique
+      - not_null
 
-      - name: dcm_arterial_highways
-        columns:
-          - name: name
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - unique
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: dcm_arterial_highways_compound_key
-              combination_of_columns:
-                - name
-                - wkb_geometry
+  - name: dcm_arterial_highways
+    columns:
+    - name: name
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - unique
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: dcm_arterial_highways_compound_key
+        combination_of_columns:
+        - name
+        - wkb_geometry
 
-      - name: dcp_air_quality_vent_towers
-        columns:
-          - name: bbl
-          - name: name
-            tests:
-              - unique
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - unique
-              - not_null
+  - name: dcp_air_quality_vent_towers
+    columns:
+    - name: bbl
+    - name: name
+      tests:
+      - unique
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - unique
+      - not_null
 
-      - name: dcp_edesignation_csv
-        columns:
-          - name: bbl
-            tests:
-              - not_null
-          - name: enumber
-            tests:
-              - not_null
-          - name: hazmat_code
-            tests:
-              - not_null
-              - accepted_values:
-                  values: ['true', 'false']
-          - name: air_code
-            tests:
-              - not_null
-              - accepted_values:
-                  values: ['true', 'false']
-          - name: noise_code
-            tests:
-              - not_null
-              - accepted_values:
-                  values: ['true', 'false']
-          - name: ceqr_num
+  - name: dcp_edesignation_csv
+    columns:
+    - name: bbl
+      tests:
+      - not_null
+    - name: enumber
+      tests:
+      - not_null
+    - name: hazmat_code
+      tests:
+      - not_null
+      - accepted_values:
+          values: [ 'true', 'false' ]
+    - name: air_code
+      tests:
+      - not_null
+      - accepted_values:
+          values: [ 'true', 'false' ]
+    - name: noise_code
+      tests:
+      - not_null
+      - accepted_values:
+          values: [ 'true', 'false' ]
+    - name: ceqr_num
 
-      - name: dcp_lion
-        columns:
-          - name: street
-            tests:
-              - not_null
-          - name: row_type
-            tests:
-              - not_null
-          - name: shape
-            tests:
-              - not_null
+  - name: dcp_lion
+    columns:
+    - name: street
+      tests:
+      - not_null
+    - name: row_type
+      tests:
+      - not_null
+    - name: shape
+      tests:
+      - not_null
 
-      - name: dcp_cscl_commonplace
-        columns:
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: dcp_cscl_commonplace
+    columns:
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: dcp_cscl_complex
-        columns:
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: dcp_cscl_complex
+    columns:
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: dcp_mappluto_wi
-        columns:
-          - name: bbl
-            tests:
-              - unique
-              - not_null
-          - name: zonedist1
-          - name: zonedist2
-          - name: zonedist3
-          - name: zonedist4
-          - name: spdist1
-          - name: spdist2
-          - name: spdist3
-          - name: wkb_geometry
-            tests:
-              - not_null
-              - is_epsg_2263:
-                  config:
-                    severity: warn
+  - name: dcp_mappluto_wi
+    columns:
+    - name: bbl
+      tests:
+      - unique
+      - not_null
+    - name: zonedist1
+    - name: zonedist2
+    - name: zonedist3
+    - name: zonedist4
+    - name: spdist1
+    - name: spdist2
+    - name: spdist3
+    - name: wkb_geometry
+      tests:
+      - not_null
+      - is_epsg_2263:
+          config:
+            severity: warn
 
-      - name: lpc_historic_district_areas
-        columns:
-          - name: area_name
-            tests:
-              - unique
-              - not_null
-          - name: lp_number
-            tests:
-              - unique
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: lpc_historic_district_areas
+    columns:
+    - name: area_name
+      tests:
+      - unique
+      - not_null
+    - name: lp_number
+      tests:
+      - unique
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: lpc_landmarks
-        columns:
-          - name: bbl
-          - name: last_actio
-          - name: lm_name
-          - name: lm_type
-          - name: most_curre
-          - name: status
-          - name: wkb_geometry
+  - name: lpc_landmarks
+    columns:
+    - name: bbl
+    - name: last_actio
+    - name: lm_name
+    - name: lm_type
+    - name: most_curre
+    - name: status
+    - name: wkb_geometry
 
-      - name: lpc_scenic_landmarks
-        columns:
-          - name: wkb_geometry
-          - name: scen_lm_na
+  - name: lpc_scenic_landmarks
+    columns:
+    - name: wkb_geometry
+    - name: scen_lm_na
 
-      - name: nysdec_title_v_facility_permits
-        columns:
-          - name: permit_id
-            tests:
-              - unique
-              - not_null
-          - name: facility_name
-            tests:
-              - dbt_utils.at_least_one
-          - name: geom
-            tests:
-              - not_null
+  - name: nysdec_title_v_facility_permits
+    columns:
+    - name: permit_id
+      tests:
+      - unique
+      - not_null
+    - name: facility_name
+      tests:
+      - dbt_utils.at_least_one
+    - name: geom
+      tests:
+      - not_null
 
-      - name: nysdec_state_facility_permits
-        columns:
-          - name: permit_id
-            tests:
-              - unique
-              - not_null
-          - name: facility_name
-            tests:
-              - dbt_utils.at_least_one
-          - name: geom
-            tests:
-              - not_null
+  - name: nysdec_state_facility_permits
+    columns:
+    - name: permit_id
+      tests:
+      - unique
+      - not_null
+    - name: facility_name
+      tests:
+      - dbt_utils.at_least_one
+    - name: geom
+      tests:
+      - not_null
 
-      - name: nysshpo_historic_buildings_polygons
-        columns:
-          - name: usnnum
-            tests:
-              - not_null
-          - name: usnname
-          - name: eligibilitydesc
-            tests:
-              - accepted_values:
-                  values:
-                    [
-                      "Eligible",
-                      "Listed",
-                      "Not Eligible",
-                      "Not Eligible - Demolished",
-                      "Undetermined",
-                    ]
-          - name: wkb_geometry
-            tests:
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: nysshpo_historic_buildings_polygons_compound_key
-              combination_of_columns:
-                - usnnum
-                - usnname
+  - name: nysshpo_historic_buildings_polygons
+    columns:
+    - name: usnnum
+      tests:
+      - not_null
+    - name: usnname
+    - name: eligibilitydesc
+      tests:
+      - accepted_values:
+          values:
+            [
+              "Eligible",
+              "Listed",
+              "Not Eligible",
+              "Not Eligible - Demolished",
+              "Undetermined"
+            ]
+    - name: wkb_geometry
+      tests:
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: nysshpo_historic_buildings_polygons_compound_key
+        combination_of_columns:
+        - usnnum
+        - usnname
 
-      - name: nysshpo_historic_buildings_points
-        columns:
-          - name: usnnum
-            tests:
-              - not_null
-          - name: usnname
-          - name: eligibilitydesc
-            tests:
-              - accepted_values:
-                  values:
-                    [
-                      "Eligible",
-                      "Listed",
-                      "Not Eligible",
-                      "Not Eligible - Demolished",
-                      "Undetermined",
-                    ]
-          - name: wkb_geometry
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: nysshpo_historic_buildings_points_compound_key
-              combination_of_columns:
-                - usnnum
-                - usnname
+  - name: nysshpo_historic_buildings_points
+    columns:
+    - name: usnnum
+      tests:
+      - not_null
+    - name: usnname
+    - name: eligibilitydesc
+      tests:
+      - accepted_values:
+          values:
+            [
+              "Eligible",
+              "Listed",
+              "Not Eligible",
+              "Not Eligible - Demolished",
+              "Undetermined"
+            ]
+    - name: wkb_geometry
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: nysshpo_historic_buildings_points_compound_key
+        combination_of_columns:
+        - usnnum
+        - usnname
 
-      - name: nysshpo_archaeological_buffer_areas
-        columns:
-          - name: wkb_geometry
-            tests:
-              - not_null
-              - is_epsg_2263
+  - name: nysshpo_archaeological_buffer_areas
+    columns:
+    - name: wkb_geometry
+      tests:
+      - not_null
+      - is_epsg_2263
 
-      - name: nysparks_historicplaces
-        columns:
-          - name: wkb_geometry
-            tests:
-              - not_null
-          - name: historicname
-            tests:
-              - not_null
-          - name: countyname
-          - name: nrnum
-            tests:
-              - not_null
+  - name: nysparks_historicplaces
+    columns:
+    - name: wkb_geometry
+      tests:
+      - not_null
+    - name: historicname
+      tests:
+      - not_null
+    - name: countyname
+    - name: nrnum
+      tests:
+      - not_null
 
-      - name: dep_cats_permits
-        columns:
-          - name: applicationid
-            tests:
-              - unique
-              - not_null
-          - name: status
-            tests:
-              - not_null
-          - name: geom
-            tests:
-              - not_null
+  - name: dep_cats_permits
+    columns:
+    - name: applicationid
+      tests:
+      - unique
+      - not_null
+    - name: status
+      tests:
+      - not_null
+    - name: geom
+      tests:
+      - not_null
 
-      - name: dcp_boroboundaries_wi
+  - name: dcp_boroboundaries_wi
 
-      - name: dpr_schoolyard_to_playgrounds
-        columns:
-          - name: gispropnum
-            tests:
-              - not_null
-          - name: location
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: dpr_schoolyard_to_playgrounds_compound_key
-              combination_of_columns:
-                - gispropnum
-                - location
-              config:
-                severity: warn
+  - name: dpr_schoolyard_to_playgrounds
+    columns:
+    - name: gispropnum
+      tests:
+      - not_null
+    - name: location
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: dpr_schoolyard_to_playgrounds_compound_key
+        combination_of_columns:
+        - gispropnum
+        - location
+        config:
+          severity: warn
 
-      - name: dpr_parksproperties
-        columns:
-          - name: gispropnum
-            tests:
-              - not_null
-          - name: name311
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
-          - name: typecategory
-            description: this column is tested to ensure each typecategory in dpr_property exists as typecategory in nyc_parks_properties_categories
-            tests:
-              - relationships:
-                  to: ref('nyc_parks_properties_categories')
-                  field: typecategory
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: dpr_parksproperties_compound_key
-              combination_of_columns:
-                - gispropnum
-                - name311
-                - wkb_geometry
-              config:
-                severity: warn
+  - name: dpr_parksproperties
+    columns:
+    - name: gispropnum
+      tests:
+      - not_null
+    - name: name311
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
+    - name: typecategory
+      description: this column is tested to ensure each typecategory in dpr_property exists as
+        typecategory in nyc_parks_properties_categories
+      tests:
+      - relationships:
+          to: ref('nyc_parks_properties_categories')
+          field: typecategory
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: dpr_parksproperties_compound_key
+        combination_of_columns:
+        - gispropnum
+        - name311
+        - wkb_geometry
+        config:
+          severity: warn
 
-      - name: dcp_pops
-        columns:
-          - name: pops_number
-            tests:
-              - not_null
-              - unique
-          - name: bbl
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: dcp_pops
+    columns:
+    - name: pops_number
+      tests:
+      - not_null
+      - unique
+    - name: bbl
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: dcp_waterfront_access_map_wpaa
-        columns:
-          - name: wpaa_id
-            tests:
-              - not_null
-              - unique
-          - name: name
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
-          - name: status
-            tests:
-              - not_null
+  - name: dcp_waterfront_access_map_wpaa
+    columns:
+    - name: wpaa_id
+      tests:
+      - not_null
+      - unique
+    - name: name
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
+    - name: status
+      tests:
+      - not_null
 
-      - name: dcp_waterfront_access_map_pow
-        columns:
-          - name: name
-            tests:
-              - not_null
-          - name: agency
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: dcp_waterfront_access_map_pow_compound_key
-              combination_of_columns:
-                - name
-                - agency
-                - wkb_geometry
-              config:
-                severity: warn
+  - name: dcp_waterfront_access_map_pow
+    columns:
+    - name: name
+      tests:
+      - not_null
+    - name: agency
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: dcp_waterfront_access_map_pow_compound_key
+        combination_of_columns:
+        - name
+        - agency
+        - wkb_geometry
+        config:
+          severity: warn
 
-      - name: nysparks_parks
-        columns:
-          - name: uid
-          - name: name
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: nysparks_parks_compound_key
-              combination_of_columns:
-                - uid
-                - name
-                - wkb_geometry
-              config:
-                severity: warn
+  - name: nysparks_parks
+    columns:
+    - name: uid
+    - name: name
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: nysparks_parks_compound_key
+        combination_of_columns:
+        - uid
+        - name
+        - wkb_geometry
+        config:
+          severity: warn
 
-      - name: usnps_parks
-        columns:
-          - name: gnis_id
-          - name: parkname
-            tests:
-              - not_null
-          - name: wkt
-            tests:
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: usnps_parks_compound_key
-              combination_of_columns:
-                - gnis_id
-                - parkname
-                - wkt
-              config:
-                severity: warn
+  - name: usnps_parks
+    columns:
+    - name: gnis_id
+    - name: parkname
+      tests:
+      - not_null
+    - name: wkt
+      tests:
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: usnps_parks_compound_key
+        combination_of_columns:
+        - gnis_id
+        - parkname
+        - wkt
+        config:
+          severity: warn
 
-      - name: dcp_beaches
-        columns:
-          - name: agency
-            tests:
-              - not_null
-          - name: name
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: dcp_beaches
+    columns:
+    - name: agency
+      tests:
+      - not_null
+    - name: name
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: dcp_wrp_recognized_ecological_complexes
-        columns:
-          - name: site_name
-            tests:
-              - unique
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: dcp_wrp_recognized_ecological_complexes
+    columns:
+    - name: site_name
+      tests:
+      - unique
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: dcp_wrp_special_natural_waterfront_areas
-        columns:
-          - name: name
-            tests:
-              - unique
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: dcp_wrp_special_natural_waterfront_areas
+    columns:
+    - name: name
+      tests:
+      - unique
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: dpr_forever_wild
-        columns:
-          - name: gispropnum
-            tests:
-              - not_null
-          - name: propertyna
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              name: dpr_forever_wild_uid
-              combination_of_columns:
-                - gispropnum
-                - propertyna
+  - name: dpr_forever_wild
+    columns:
+    - name: gispropnum
+      tests:
+      - not_null
+    - name: propertyna
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        name: dpr_forever_wild_uid
+        combination_of_columns:
+        - gispropnum
+        - propertyna
 
-      - name: nysdec_freshwater_wetlands_checkzones
-        columns:
-          - name: objectid
-            tests:
-              - unique
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: nysdec_freshwater_wetlands_checkzones
+    columns:
+    - name: objectid
+      tests:
+      - unique
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: nysdec_freshwater_wetlands
-        columns:
-          - name: wetid
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: nysdec_freshwater_wetlands
+    columns:
+    - name: wetid
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: nysdec_natural_heritage_communities
-        columns:
-          - name: common_name
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: nysdec_natural_heritage_communities
+    columns:
+    - name: common_name
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: nysdec_priority_lakes
-        columns:
-          - name: seg_id
-            tests:
-              - not_null
-          - name: waterbody
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              combination_of_columns: [ seg_id, waterbody ]
+  - name: nysdec_priority_lakes
+    columns:
+    - name: seg_id
+      tests:
+      - not_null
+    - name: waterbody
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
+    tests:
+    - dbt_utils.unique_combination_of_columns:
+        combination_of_columns: [ seg_id, waterbody ]
 
-      - name: nysdec_priority_estuaries
-        columns:
-          - name: seg_id
-            tests:
-              - unique
-              - not_null
-          - name: waterbody
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: nysdec_priority_estuaries
+    columns:
+    - name: seg_id
+      tests:
+      - unique
+      - not_null
+    - name: waterbody
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: nysdec_priority_streams
-        columns:
-          - name: seg_id
-            tests:
-              - not_null
-          - name: waterbody
-            tests:
-              - not_null
-          - name: wkb_geometry
-            tests:
-              - not_null
+  - name: nysdec_priority_streams
+    columns:
+    - name: seg_id
+      tests:
+      - not_null
+    - name: waterbody
+      tests:
+      - not_null
+    - name: wkb_geometry
+      tests:
+      - not_null
 
-      - name: nysdec_tidal_wetlands
-        columns:
-          - name: id
-            tests:
-              - not_null
-          - name: wkb_geometry
+  - name: nysdec_tidal_wetlands
+    columns:
+    - name: id
+      tests:
+      - not_null
+    - name: wkb_geometry
 
-      - name: usfws_nyc_wetlands
-        columns:
-          - name: wetland_type
-            tests:
-              - not_null
-          - name: geometry
-            tests:
-              - not_null
+  - name: usfws_nyc_wetlands
+    columns:
+    - name: wetland_type
+      tests:
+      - not_null
+    - name: geometry
+      tests:
+      - not_null
 
-      - name: dob_natural_resource_check_flags
-        columns:
-          - name: bbl
-            tests:
-              - not_null
-              - unique
-          - name: coastal_hazard_area_flag
-          - name: fresh_water_wetlands_flag
-          - name: tidal_coastal_wetlands_flag
+  - name: dob_natural_resource_check_flags
+    columns:
+    - name: bbl
+      tests:
+      - not_null
+      - unique
+    - name: coastal_hazard_area_flag
+    - name: fresh_water_wetlands_flag
+    - name: tidal_coastal_wetlands_flag

--- a/products/green_fast_track/models/_sources.yml
+++ b/products/green_fast_track/models/_sources.yml
@@ -469,10 +469,10 @@ sources:
 
       - name: nysdec_priority_lakes
         columns:
-          - name: pwl_id
+          - name: seg_id
             tests:
               - not_null
-          - name: name
+          - name: waterbody
             tests:
               - not_null
           - name: wkb_geometry
@@ -480,15 +480,15 @@ sources:
               - not_null
         tests:
           - dbt_utils.unique_combination_of_columns:
-              combination_of_columns: [ pwl_id, name ]
+              combination_of_columns: [ seg_id, waterbody ]
 
       - name: nysdec_priority_estuaries
         columns:
-          - name: pwl_id
+          - name: seg_id
             tests:
               - unique
               - not_null
-          - name: name
+          - name: waterbody
             tests:
               - not_null
           - name: wkb_geometry
@@ -497,10 +497,10 @@ sources:
 
       - name: nysdec_priority_streams
         columns:
-          - name: pwl_id
+          - name: seg_id
             tests:
               - not_null
-          - name: name
+          - name: waterbody
             tests:
               - not_null
           - name: wkb_geometry

--- a/products/green_fast_track/models/intermediate/flags/_flags_models.yml
+++ b/products/green_fast_track/models/intermediate/flags/_flags_models.yml
@@ -1,159 +1,155 @@
 version: 2
 
 models:
-  - name: int_flags__all
-    description: A table with all flags
-    columns:
-      - name: bbl
-        data_type: string
-        tests:
-          - not_null
-      - name: flag_id_field_name
-        data_type: string
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_distinct_values_to_equal_set:
-              name: int_flags__all__flag_id_field_name__set
-              value_set: '{{ dbt_utils.get_column_values(
-                              table=ref("variables"),
-                              column="flag_id_field_name") }}'
-      - name: variable_type
-        data_type: string
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_distinct_values_to_equal_set:
-              name: int_flags__all__variable_type__set
-              value_set: '{{ dbt_utils.get_column_values(
-                              table=ref("variables"),
-                              column="variable_type") }}'
-      - name: variable_id
-        data_type: string
-        tests:
-          - not_null
-      - name: distance
-        data_type: float
+- name: int_flags__all
+  description: A table with all flags
+  columns:
+  - name: bbl
+    data_type: string
     tests:
-      - dbt_utils.unique_combination_of_columns:
-          name: int_flags__all__compound_key
-          combination_of_columns:
-            - bbl
-            - flag_id_field_name
-            - variable_id
-
-  - name: int__zoning_districts
-    columns:
-      - name: bbl
-        data_type: string
-        tests:
-          - not_null
-      - name: zoning_district_type
-        data_type: string
-        tests:
-          - not_null
-          - relationships:
-              to: ref('zoning_district_mappings')
-              field: zoning_district_type
+    - not_null
+  - name: flag_id_field_name
+    data_type: string
     tests:
-      - dbt_utils.unique_combination_of_columns:
-          name: int__zoning_districts_compound_key
-          combination_of_columns:
-            - bbl
-            - zoning_district_type
-
-  - name: int_flags__zoning
-    columns:
-      - name: bbl
-        data_type: string
-        tests:
-          - not_null
-      - name: variable_type
-        data_type: string
-        tests:
-          - not_null
-      - name: variable_id
-        data_type: string
-        tests:
-          - not_null
+    - not_null
+    - dbt_expectations.expect_column_distinct_values_to_equal_set:
+        name: int_flags__all__flag_id_field_name__set
+        value_set: '{{ dbt_utils.get_column_values( table=ref("variables"), column="flag_id_field_name") }}'
+  - name: variable_type
+    data_type: string
     tests:
-      - dbt_utils.unique_combination_of_columns:
-          name: int_flags__zoning_compound_key
-          combination_of_columns:
-            - bbl
-            - variable_type
-            - variable_id
-
-  - name: int_flags__edesignation
-    description: Flags related to edesignation
-    columns:
-    - name: bbl
-      tests:
-        - not_null
-    - name: variable_type
-      tests:
-        - not_null
-    - name: variable_id
-      tests:
-        - not_null
-
-  - name: int_flags__dob_natural_resources
-    description: Flags from a file provided by DOB
-    columns:
-    - name: bbl
-      tests:
-        - not_null
-    - name: variable_type
-      tests:
-        - not_null
-    - name: variable_id
-      tests:
-        - not_null
-
-  - name: int_flags__spatial
-    description: |
-      A table featuring spatially joined BBLs with buffered variable types, 
-      including distances to their raw geometry
-    columns:
-      - name: bbl
-        data_type: string
-        tests:
-          - not_null
-      - name: variable_type
-        data_type: string
-        tests:
-          - not_null
-      - name: variable_id
-        data_type: string
-        tests:
-          - not_null
-      - name: distance
-        data_type: float
-        tests:
-          - not_null
+    - not_null
+    - dbt_expectations.expect_column_distinct_values_to_equal_set:
+        name: int_flags__all__variable_type__set
+        value_set: '{{ dbt_utils.get_column_values( table=ref("variables"), column="variable_type") }}'
+  - name: variable_id
+    data_type: string
     tests:
-      - dbt_utils.unique_combination_of_columns:
-          name: int_flags__spatial_compound_key
-          combination_of_columns:
-            - bbl
-            - flag_id_field_name
-            - variable_id
+    - not_null
+  - name: distance
+    data_type: float
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      name: int_flags__all__compound_key
+      combination_of_columns:
+      - bbl
+      - flag_id_field_name
+      - variable_id
 
-  - name: test_actual__flags_zoning
-    description: Particular lots, their zoning fields, and the actual GFT zoning flag results
-    columns:
-      - name: lot_label
-        tests:
-          - not_null
-      - name: bbl
-        tests:
-          - not_null
-          - unique
-      - name: zonedist1
-      - name: zonedist2
-      - name: zonedist3
-      - name: zonedist4
-      - name: Zoning Districts
+- name: int__zoning_districts
+  columns:
+  - name: bbl
+    data_type: string
     tests:
-      # test zoning flag logic
-      - dbt_utils.equality:
-          name: equality_flags_zoning
-          compare_model: ref('test_expected__flags_zoning')
+    - not_null
+  - name: zoning_district_type
+    data_type: string
+    tests:
+    - not_null
+    - relationships:
+        to: ref('zoning_district_mappings')
+        field: zoning_district_type
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      name: int__zoning_districts_compound_key
+      combination_of_columns:
+      - bbl
+      - zoning_district_type
+
+- name: int_flags__zoning
+  columns:
+  - name: bbl
+    data_type: string
+    tests:
+    - not_null
+  - name: variable_type
+    data_type: string
+    tests:
+    - not_null
+  - name: variable_id
+    data_type: string
+    tests:
+    - not_null
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      name: int_flags__zoning_compound_key
+      combination_of_columns:
+      - bbl
+      - variable_type
+      - variable_id
+
+- name: int_flags__edesignation
+  description: Flags related to edesignation
+  columns:
+  - name: bbl
+    tests:
+    - not_null
+  - name: variable_type
+    tests:
+    - not_null
+  - name: variable_id
+    tests:
+    - not_null
+
+- name: int_flags__dob_natural_resources
+  description: Flags from a file provided by DOB
+  columns:
+  - name: bbl
+    tests:
+    - not_null
+  - name: variable_type
+    tests:
+    - not_null
+  - name: variable_id
+    tests:
+    - not_null
+
+- name: int_flags__spatial
+  description: >-
+    A table featuring spatially joined BBLs with buffered variable types,  including
+    distances to their raw geometry
+  columns:
+  - name: bbl
+    data_type: string
+    tests:
+    - not_null
+  - name: variable_type
+    data_type: string
+    tests:
+    - not_null
+  - name: variable_id
+    data_type: string
+    tests:
+    - not_null
+  - name: distance
+    data_type: float
+    tests:
+    - not_null
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      name: int_flags__spatial_compound_key
+      combination_of_columns:
+      - bbl
+      - flag_id_field_name
+      - variable_id
+
+- name: test_actual__flags_zoning
+  description: Particular lots, their zoning fields, and the actual GFT zoning flag results
+  columns:
+  - name: lot_label
+    tests:
+    - not_null
+  - name: bbl
+    tests:
+    - not_null
+    - unique
+  - name: zonedist1
+  - name: zonedist2
+  - name: zonedist3
+  - name: zonedist4
+  - name: Zoning Districts
+  tests:
+  # test zoning flag logic
+  - dbt_utils.equality:
+      name: equality_flags_zoning
+      compare_model: ref('test_expected__flags_zoning')

--- a/products/green_fast_track/models/intermediate/spatial/_spatial_models.yml
+++ b/products/green_fast_track/models/intermediate/spatial/_spatial_models.yml
@@ -1,40 +1,40 @@
 version: 2
 
 models:
-  - name: int_spatial__all
-    description: Union of all spatial GFT datasets
-    columns:
-      - name: source_relation
-        tests:
-          - not_null
-      - name: variable_type
-        tests:
-          - not_null
-      - name: variable_id
-        tests:
-          - not_null
-      - name: raw_geom
-        tests:
-          - not_null
-      - name: lot_geom
-      - name: buffer_geom
-      - name: variable_geom
-        tests:
-          - not_null
-          - is_epsg_2263
+- name: int_spatial__all
+  description: Union of all spatial GFT datasets
+  columns:
+  - name: source_relation
+    tests:
+    - not_null
+  - name: variable_type
+    tests:
+    - not_null
+  - name: variable_id
+    tests:
+    - not_null
+  - name: raw_geom
+    tests:
+    - not_null
+  - name: lot_geom
+  - name: buffer_geom
+  - name: variable_geom
+    tests:
+    - not_null
+    - is_epsg_2263
 
-  - name: int_spatial__pops
-  - name: int_spatial__cats_permits
-  - name: int_spatial__industrial_lots
-  - name: int_spatial__state_facility
-  - name: int_spatial__title_v_permit
-  - name: int_spatial__vent_tower
-  - name: int_spatial__arterial_highway
-  - name: int_spatial__exposed_railway
-  - name: int_spatial__natural_resources
-  - name: int_spatial__historic_districts
-  - name: int_spatial__historic_resources
-  - name: int_spatial__historic_resources_adj
-  - name: int_spatial__shadow_open_spaces
-  - name: int_spatial__shadow_nat_resources
-  - name: int_spatial__shadow_hist_resources
+- name: int_spatial__pops
+- name: int_spatial__cats_permits
+- name: int_spatial__industrial_lots
+- name: int_spatial__state_facility
+- name: int_spatial__title_v_permit
+- name: int_spatial__vent_tower
+- name: int_spatial__arterial_highway
+- name: int_spatial__exposed_railway
+- name: int_spatial__natural_resources
+- name: int_spatial__historic_districts
+- name: int_spatial__historic_resources
+- name: int_spatial__historic_resources_adj
+- name: int_spatial__shadow_open_spaces
+- name: int_spatial__shadow_nat_resources
+- name: int_spatial__shadow_hist_resources

--- a/products/green_fast_track/models/product/_product_models.yml
+++ b/products/green_fast_track/models/product/_product_models.yml
@@ -1,182 +1,182 @@
 version: 2
 
 models:
-  - name: green_fast_track_bbls
-    description: BBLs and their CEQR Type II variable checks
-    config:
-      contract:
-        enforced: true
-    
-    # contract
-    columns:
-      - name: bbl
-        data_type: string
-        tests:
-          - not_null
-          - unique
-      # flag and flag value columns
-      - name: zoning_category
-        data_type: string
-        tests: [not_null]
-      - name: zoning_district
-        data_type: string
-
-      - name: special_coastal_risk_flag
-        data_type: string
-        tests: [not_null]
-      - name: special_coastal_risk
-        data_type: string
-
-      - name: cats_permit_flag
-        data_type: string
-        tests: [not_null]
-      - name: cats_permit
-        data_type: string
-
-      - name: industrial_lots_flag
-        data_type: string
-        tests: [not_null]
-      - name: industrial_lots
-        data_type: string
-
-      - name: state_facility_flag
-        data_type: string
-        tests: [not_null]
-      - name: state_facility
-        data_type: string
-
-      - name: title_v_permit_flag
-        data_type: string
-        tests: [not_null]
-      - name: title_v_permit
-        data_type: string
-
-      - name: vent_tower_flag
-        data_type: string
-        tests: [not_null]
-      - name: vent_tower
-        data_type: string
-        data_type: string
-
-      - name: e_des_air_quality_flag
-        data_type: string
-        tests: [not_null]
-      - name: e_des_air_quality
-        data_type: string
-
-      - name: e_des_noise_flag
-        data_type: string
-        tests: [not_null]
-      - name: e_des_noise
-        data_type: string
-
-      - name: arterial_highway_flag
-        data_type: string
-        tests: [not_null]
-      - name: arterial_highway
-        data_type: string
-
-      - name: exposed_railway_flag
-        data_type: string
-        tests: [not_null]
-      - name: exposed_railway
-        data_type: string
-
-      - name: airport_noise_flag
-        data_type: string
-        tests: [not_null]
-      - name: airport_noise
-        data_type: string
-
-      - name: e_des_hazmat_flag
-        data_type: string
-        tests: [not_null]
-      - name: e_des_hazmat
-        data_type: string
-
-      - name: natural_resources_flag
-        data_type: string
-        tests: [not_null]
-      - name: natural_resources
-        data_type: string
-
-      - name: wetland_checkzone_flag
-        data_type: string
-        tests: [not_null]
-      - name: wetland_checkzone
-        data_type: string
-
-      - name: archaeological_area_flag
-        data_type: string
-        tests: [not_null]
-      - name: archaeological_area
-        data_type: string
-
-      - name: historic_districts_flag
-        data_type: string
-        tests: [not_null]
-      - name: historic_districts
-        data_type: string
-
-      - name: historic_resources_flag
-        data_type: string
-        tests: [not_null]
-      - name: historic_resources
-        data_type: string
-
-      - name: historic_resources_adj_flag
-        data_type: string
-        tests: [not_null]
-      - name: historic_resources_adj
-        data_type: string
-
-      - name: shadow_open_spaces_flag
-        data_type: string
-        tests: [not_null]
-      - name: shadow_open_spaces
-        data_type: string
-
-      - name: shadow_nat_resources_flag
-        data_type: string
-        tests: [not_null]
-      - name: shadow_nat_resources
-        data_type: string
-
-      - name: shadow_hist_resources_flag
-        data_type: string
-        tests: [not_null]
-        data_type: string
-      - name: shadow_hist_resources
-        data_type: string
-
-      # lot geometry
-      - name: geom
-        data_type: geometry(Geometry, 2263)
-
+- name: green_fast_track_bbls
+  description: BBLs and their CEQR Type II variable checks
+  config:
+    contract:
+      enforced: true
+  
+  # contract
+  columns:
+  - name: bbl
+    data_type: string
     tests:
-      # domain knowledge
-      - dbt_expectations.expect_table_row_count_to_be_between:
-          name: logic_buffer_source_data_a
-          # expect more flags from buffered than non-buffered
-          min_value: 1
-          row_condition: "historic_resources is null and historic_resources_adj is not null"
-          config:
-            # TODO fix this
-            severity: warn
+    - not_null
+    - unique
+  # flag and flag value columns
+  - name: zoning_category
+    data_type: string
+    tests: [ not_null ]
+  - name: zoning_district
+    data_type: string
 
-      - dbt_expectations.expect_table_row_count_to_be_between:
-          name: logic_buffer_source_data_b
-          # expect more flags from larger buffer
-          min_value: 1
-          row_condition: "historic_resources_adj is null and shadow_hist_resources is not null"
+  - name: special_coastal_risk_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: special_coastal_risk
+    data_type: string
 
-  - name: test_actual__pilot_projects
-    description: Green Fast Track outputs for pilot project examples
-    tests:
-      # test the expectations of pilot projects
-      - dbt_utils.equality:
-          name: equality_green_fast_track_pilot_projects
-          compare_model: ref('test_expected__pilot_projects')
-          config:
-            # TEMP
-            severity: warn
+  - name: cats_permit_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: cats_permit
+    data_type: string
+
+  - name: industrial_lots_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: industrial_lots
+    data_type: string
+
+  - name: state_facility_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: state_facility
+    data_type: string
+
+  - name: title_v_permit_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: title_v_permit
+    data_type: string
+
+  - name: vent_tower_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: vent_tower
+    data_type: string
+    data_type: string
+
+  - name: e_des_air_quality_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: e_des_air_quality
+    data_type: string
+
+  - name: e_des_noise_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: e_des_noise
+    data_type: string
+
+  - name: arterial_highway_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: arterial_highway
+    data_type: string
+
+  - name: exposed_railway_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: exposed_railway
+    data_type: string
+
+  - name: airport_noise_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: airport_noise
+    data_type: string
+
+  - name: e_des_hazmat_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: e_des_hazmat
+    data_type: string
+
+  - name: natural_resources_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: natural_resources
+    data_type: string
+
+  - name: wetland_checkzone_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: wetland_checkzone
+    data_type: string
+
+  - name: archaeological_area_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: archaeological_area
+    data_type: string
+
+  - name: historic_districts_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: historic_districts
+    data_type: string
+
+  - name: historic_resources_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: historic_resources
+    data_type: string
+
+  - name: historic_resources_adj_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: historic_resources_adj
+    data_type: string
+
+  - name: shadow_open_spaces_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: shadow_open_spaces
+    data_type: string
+
+  - name: shadow_nat_resources_flag
+    data_type: string
+    tests: [ not_null ]
+  - name: shadow_nat_resources
+    data_type: string
+
+  - name: shadow_hist_resources_flag
+    data_type: string
+    tests: [ not_null ]
+    data_type: string
+  - name: shadow_hist_resources
+    data_type: string
+
+  # lot geometry
+  - name: geom
+    data_type: geometry(Geometry, 2263)
+
+  tests:
+    # domain knowledge
+  - dbt_expectations.expect_table_row_count_to_be_between:
+      name: logic_buffer_source_data_a
+      # expect more flags from buffered than non-buffered
+      min_value: 1
+      row_condition: "historic_resources is null and historic_resources_adj is not null"
+      config:
+        # TODO fix this
+        severity: warn
+
+  - dbt_expectations.expect_table_row_count_to_be_between:
+      name: logic_buffer_source_data_b
+      # expect more flags from larger buffer
+      min_value: 1
+      row_condition: "historic_resources_adj is null and shadow_hist_resources is not null"
+
+- name: test_actual__pilot_projects
+  description: Green Fast Track outputs for pilot project examples
+  tests:
+    # test the expectations of pilot projects
+  - dbt_utils.equality:
+      name: equality_green_fast_track_pilot_projects
+      compare_model: ref('test_expected__pilot_projects')
+      config:
+        # TEMP
+        severity: warn

--- a/products/green_fast_track/models/product/source/_source_models.yml
+++ b/products/green_fast_track/models/product/source/_source_models.yml
@@ -1,61 +1,61 @@
 version: 2
 
 models:
-  # Air Quality
-  - name: source__cats_permit_points
-  - name: source__cats_permit_lots
-  - name: source__cats_permit_buffer
+# Air Quality
+- name: source__cats_permit_points
+- name: source__cats_permit_lots
+- name: source__cats_permit_buffer
 
-  - name: source__industrial_lots
-  - name: source__industrial_lots_buffer
+- name: source__industrial_lots
+- name: source__industrial_lots_buffer
 
-  - name: source__state_facility_points
-  - name: source__state_facility_lots
-  - name: source__state_facility_buffer
+- name: source__state_facility_points
+- name: source__state_facility_lots
+- name: source__state_facility_buffer
 
-  - name: source__title_v_permit_points
-  - name: source__title_v_permit_lots
-  - name: source__title_v_permit_buffer
+- name: source__title_v_permit_points
+- name: source__title_v_permit_lots
+- name: source__title_v_permit_buffer
 
-  - name: source__vent_tower_polys
-  - name: source__vent_tower_buffer
+- name: source__vent_tower_polys
+- name: source__vent_tower_buffer
 
-  # Noise
-  - name: source__arterial_highway_lines
-  - name: source__arterial_highway_buffer
+# Noise
+- name: source__arterial_highway_lines
+- name: source__arterial_highway_buffer
 
-  - name: source__exposed_railway_lines
-  - name: source__exposed_railway_polys
-  - name: source__exposed_railway_buffer
+- name: source__exposed_railway_lines
+- name: source__exposed_railway_polys
+- name: source__exposed_railway_buffer
 
-  - name: source__airport_noise
+- name: source__airport_noise
 
-  # Natural Resources
-  - name: source__natural_resources_points
-  - name: source__natural_resources_lines
-  - name: source__natural_resources_polys
-  - name: source__wetland_checkzone
+# Natural Resources
+- name: source__natural_resources_points
+- name: source__natural_resources_lines
+- name: source__natural_resources_polys
+- name: source__wetland_checkzone
 
-  # Historic Resources
-  - name: source__archaeological_area_polys
-  - name: source__historic_districts_polys
+# Historic Resources
+- name: source__archaeological_area_polys
+- name: source__historic_districts_polys
 
-  - name: source__historic_resources_points
-  - name: source__historic_resources_lots
+- name: source__historic_resources_points
+- name: source__historic_resources_lots
 
-  - name: source__historic_resources_adj_points
-  - name: source__historic_resources_adj_lots
-  - name: source__historic_resources_adj_buffer
+- name: source__historic_resources_adj_points
+- name: source__historic_resources_adj_lots
+- name: source__historic_resources_adj_buffer
 
-  # Shadows
-  - name: source__shadow_open_spaces_points
-  - name: source__shadow_open_spaces_polys
-  - name: source__shadow_open_spaces_buffer
+# Shadows
+- name: source__shadow_open_spaces_points
+- name: source__shadow_open_spaces_polys
+- name: source__shadow_open_spaces_buffer
 
-  - name: source__shadow_nat_resources_lines
-  - name: source__shadow_nat_resources_polys
-  - name: source__shadow_nat_resources_buffer
+- name: source__shadow_nat_resources_lines
+- name: source__shadow_nat_resources_polys
+- name: source__shadow_nat_resources_buffer
 
-  - name: source__shadow_hist_resources_points
-  - name: source__shadow_hist_resources_lots
-  - name: source__shadow_hist_resources_buffer
+- name: source__shadow_hist_resources_points
+- name: source__shadow_hist_resources_lots
+- name: source__shadow_hist_resources_buffer

--- a/products/green_fast_track/models/staging/_staging_models.yml
+++ b/products/green_fast_track/models/staging/_staging_models.yml
@@ -1,38 +1,38 @@
 version: 2
 
 models:
-  - name: stg__nysdec_state_facility_permits
-  - name: stg__dcm_arterial_highways
-  - name: stg__dep_cats_permits
-  - name: stg__lpc_historic_district_areas
-  - name: stg__lpc_landmarks
-  - name: stg__lpc_scenic_landmarks
-  - name: stg__nysparks_historicplaces
-  - name: stg__nysshpo_historic_buildings
-  - name: stg__nysshpo_historic_building_districts
-  - name: stg__nysshpo_archaeological_buffer_areas
-  - name: stg__panynj_airports
-  - name: stg__exposed_railways
-  - name: stg__exposed_railyards
-  - name: stg__pluto
-  - name: stg__nysdec_title_v_facility_permits
-  - name: stg__nyc_boundary
-  - name: stg__nyc_parks_properties
-  - name: stg__pops
-  - name: stg__waterfront_access_wpaa
-  - name: stg__waterfront_access_pow
-  - name: stg__nys_parks_properties
-  - name: stg__us_parks_properties
-  - name: stg__nysdec_freshwater_wetlands_checkzones
-  - name: stg__nysdec_freshwater_wetlands
-  - name: stg__nysdec_tidal_wetlands
-  - name: stg__nysdec_priority_lakes
-  - name: stg__nysdec_priority_estuaries
-  - name: stg__nysdec_priority_streams
-  - name: stg__nysdec_natural_heritage_communities
-  - name: stg__dcp_beaches
-  - name: stg__dcp_wrp_recognized_ecological_complexes
-  - name: stg__dcp_wrp_special_natural_waterfront_areas
-  - name: stg__dpr_forever_wild
-  - name: stg__usfws_nyc_wetlands
-  - name: stg__dpr_schoolyard_to_playgrounds
+- name: stg__nysdec_state_facility_permits
+- name: stg__dcm_arterial_highways
+- name: stg__dep_cats_permits
+- name: stg__lpc_historic_district_areas
+- name: stg__lpc_landmarks
+- name: stg__lpc_scenic_landmarks
+- name: stg__nysparks_historicplaces
+- name: stg__nysshpo_historic_buildings
+- name: stg__nysshpo_historic_building_districts
+- name: stg__nysshpo_archaeological_buffer_areas
+- name: stg__panynj_airports
+- name: stg__exposed_railways
+- name: stg__exposed_railyards
+- name: stg__pluto
+- name: stg__nysdec_title_v_facility_permits
+- name: stg__nyc_boundary
+- name: stg__nyc_parks_properties
+- name: stg__pops
+- name: stg__waterfront_access_wpaa
+- name: stg__waterfront_access_pow
+- name: stg__nys_parks_properties
+- name: stg__us_parks_properties
+- name: stg__nysdec_freshwater_wetlands_checkzones
+- name: stg__nysdec_freshwater_wetlands
+- name: stg__nysdec_tidal_wetlands
+- name: stg__nysdec_priority_lakes
+- name: stg__nysdec_priority_estuaries
+- name: stg__nysdec_priority_streams
+- name: stg__nysdec_natural_heritage_communities
+- name: stg__dcp_beaches
+- name: stg__dcp_wrp_recognized_ecological_complexes
+- name: stg__dcp_wrp_special_natural_waterfront_areas
+- name: stg__dpr_forever_wild
+- name: stg__usfws_nyc_wetlands
+- name: stg__dpr_schoolyard_to_playgrounds

--- a/products/green_fast_track/models/staging/stg__nysdec_priority_estuaries.sql
+++ b/products/green_fast_track/models/staging/stg__nysdec_priority_estuaries.sql
@@ -4,7 +4,7 @@ WITH clipped_to_nyc AS (
 
 SELECT
     'priority_waterbodies_estuaries' AS variable_type,
-    pwl_id || '-' || name AS variable_id,
+    seg_id || '-' || waterbody AS variable_id,
     geom AS raw_geom,
     NULL AS buffer
 FROM clipped_to_nyc

--- a/products/green_fast_track/models/staging/stg__nysdec_priority_lakes.sql
+++ b/products/green_fast_track/models/staging/stg__nysdec_priority_lakes.sql
@@ -4,7 +4,7 @@ WITH clipped_to_nyc AS (
 
 SELECT
     'priority_waterbodies_lakes' AS variable_type,
-    pwl_id || '-' || name AS variable_id,
+    seg_id || '-' || waterbody AS variable_id,
     geom AS raw_geom,
     NULL AS buffer
 FROM clipped_to_nyc

--- a/products/green_fast_track/models/staging/stg__nysdec_priority_streams.sql
+++ b/products/green_fast_track/models/staging/stg__nysdec_priority_streams.sql
@@ -4,7 +4,7 @@ WITH clipped_to_nyc AS (
 
 SELECT
     'priority_waterbodies_streams' AS variable_type,
-    pwl_id || '-' || name AS variable_id,
+    seg_id || '-' || waterbody AS variable_id,
     geom AS raw_geom,
     NULL AS buffer
 FROM clipped_to_nyc

--- a/products/green_fast_track/packages.yml
+++ b/products/green_fast_track/packages.yml
@@ -1,5 +1,5 @@
 packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.1.1
-  - package: calogica/dbt_expectations
-    version: 0.10.3
+- package: dbt-labs/dbt_utils
+  version: 1.1.1
+- package: calogica/dbt_expectations
+  version: 0.10.3

--- a/products/green_fast_track/recipe.yml
+++ b/products/green_fast_track/recipe.yml
@@ -4,53 +4,53 @@ version_strategy:
   pin_to_source_dataset: dcp_mappluto_wi
 inputs:
   datasets:
-    # Boundaries
-    - name: dcp_boroboundaries_wi
-    # Zoning
-    - name: dcp_mappluto_wi
-    # Air
-    - name: dep_cats_permits
-    - name: nysdec_state_facility_permits
-    - name: nysdec_title_v_facility_permits
-    - name: dcp_air_quality_vent_towers
-    - name: dcm_arterial_highways
-    # Noise
-    # - name: dcp_digital_city_map Doesn't exist yet
-    - name: panynj_jfk_65db
-    - name: panynj_lga_65db
-    - name: dcp_lion
-    - name: dcp_cscl_commonplace
-    - name: dcp_cscl_complex
-    # Natural Resources
-    - name: dcp_beaches
-    - name: dcp_wrp_recognized_ecological_complexes
-    - name: dcp_wrp_special_natural_waterfront_areas
-    - name: dpr_forever_wild
-    - name: nysdec_freshwater_wetlands_checkzones
-    - name: nysdec_freshwater_wetlands
-    - name: nysdec_tidal_wetlands
-    - name: nysdec_priority_lakes
-    - name: nysdec_priority_estuaries
-    - name: nysdec_priority_streams
-    - name: nysdec_natural_heritage_communities
-    - name: usfws_nyc_wetlands
-    - name: dob_natural_resource_check_flags
-    # Historic
-    - name: lpc_scenic_landmarks # e.g. Central Park / Ocean Parkway / etc.
-    - name: lpc_historic_district_areas # polygons for a neighborhood
-    - name: lpc_landmarks # landmark buildings -> ncre-qhxs. In spreadsheet as `Historic Building (NYC)` - 38.8k rows
-    - name: nysparks_historicplaces
-    - name: nysshpo_historic_buildings_points
-    - name: nysshpo_historic_buildings_polygons
-    - name: nysshpo_archaeological_buffer_areas
-    # Shadows
-    - name: dpr_parksproperties
-    - name: dpr_schoolyard_to_playgrounds
-    - name: dcp_pops
-    - name: dcp_waterfront_access_map_wpaa
-    - name: dcp_waterfront_access_map_pow
-    - name: nysparks_parks
-    - name: usnps_parks
-    # Other
-    - name: dcp_edesignation_csv
+  # Boundaries
+  - name: dcp_boroboundaries_wi
+  # Zoning
+  - name: dcp_mappluto_wi
+  # Air
+  - name: dep_cats_permits
+  - name: nysdec_state_facility_permits
+  - name: nysdec_title_v_facility_permits
+  - name: dcp_air_quality_vent_towers
+  - name: dcm_arterial_highways
+  # Noise
+  # - name: dcp_digital_city_map Doesn't exist yet
+  - name: panynj_jfk_65db
+  - name: panynj_lga_65db
+  - name: dcp_lion
+  - name: dcp_cscl_commonplace
+  - name: dcp_cscl_complex
+  # Natural Resources
+  - name: dcp_beaches
+  - name: dcp_wrp_recognized_ecological_complexes
+  - name: dcp_wrp_special_natural_waterfront_areas
+  - name: dpr_forever_wild
+  - name: nysdec_freshwater_wetlands_checkzones
+  - name: nysdec_freshwater_wetlands
+  - name: nysdec_tidal_wetlands
+  - name: nysdec_priority_lakes
+  - name: nysdec_priority_estuaries
+  - name: nysdec_priority_streams
+  - name: nysdec_natural_heritage_communities
+  - name: usfws_nyc_wetlands
+  - name: dob_natural_resource_check_flags
+  # Historic
+  - name: lpc_scenic_landmarks # e.g. Central Park / Ocean Parkway / etc.
+  - name: lpc_historic_district_areas # polygons for a neighborhood
+  - name: lpc_landmarks # landmark buildings -> ncre-qhxs. In spreadsheet as `Historic Building (NYC)` - 38.8k rows
+  - name: nysparks_historicplaces
+  - name: nysshpo_historic_buildings_points
+  - name: nysshpo_historic_buildings_polygons
+  - name: nysshpo_archaeological_buffer_areas
+  # Shadows
+  - name: dpr_parksproperties
+  - name: dpr_schoolyard_to_playgrounds
+  - name: dcp_pops
+  - name: dcp_waterfront_access_map_wpaa
+  - name: dcp_waterfront_access_map_pow
+  - name: nysparks_parks
+  - name: usnps_parks
+  # Other
+  - name: dcp_edesignation_csv
   missing_versions_strategy: find_latest

--- a/products/green_fast_track/seeds/_seeds.yml
+++ b/products/green_fast_track/seeds/_seeds.yml
@@ -1,145 +1,143 @@
 version: 2
 
 seeds:
-  - name: question_flags
-    description: GFT survery questions and their flags
-    columns:
-      - name: ceqr_category
-        tests:
-          - not_null
-      - name: survey_question_id
-        tests:
-          - not_null
-          - unique
-      - name: flag_field_name
-        tests:
-          - not_null
-          - unique
-      - name: flag_id_field_name
-        tests:
-          - not_null
-          - unique
-
-  - name: variables
-    description: GFT variables used in question flags
-    columns:
-      - name: flag_id_field_name
-        tests:
-          - not_null
-          - relationships:
-              to: ref('question_flags')
-              field: flag_id_field_name
-      - name: variable_label
-        tests:
-          - not_null
-      - name: variable_type
-        tests:
-          - not_null
-      - name: dataset
-        tests:
-          - not_null
-      - name: join_to_lots
-      - name: buffer_ft
-      - name: type_ii_criteria_description
+- name: question_flags
+  description: GFT survery questions and their flags
+  columns:
+  - name: ceqr_category
     tests:
-      - dbt_utils.unique_combination_of_columns:
-          name: variables_compound_key
-          combination_of_columns:
-            - flag_id_field_name
-            - variable_type
+    - not_null
+  - name: survey_question_id
+    tests:
+    - not_null
+    - unique
+  - name: flag_field_name
+    tests:
+    - not_null
+    - unique
+  - name: flag_id_field_name
+    tests:
+    - not_null
+    - unique
 
-  - name: zoning_district_categories
-    description: All GFT zoning district categories
-    columns:
-      - name: category_type
-          - not_null
-          - unique
-      - name: label
-        tests: [not_null]
+- name: variables
+  description: GFT variables used in question flags
+  columns:
+  - name: flag_id_field_name
+    tests:
+    - not_null
+    - relationships:
+        to: ref('question_flags')
+        field: flag_id_field_name
+  - name: variable_label
+    tests:
+    - not_null
+  - name: variable_type
+    tests:
+    - not_null
+  - name: dataset
+    tests:
+    - not_null
+  - name: join_to_lots
+  - name: buffer_ft
+  - name: type_ii_criteria_description
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      name: variables_compound_key
+      combination_of_columns:
+      - flag_id_field_name
+      - variable_type
 
-  - name: zoning_district_mappings
-    description: All PLUTO zoning district types and their GFT zoning district categories
-    columns:
-      - name: zoning_district_type
-        tests:
-          - unique
-      - name: category_type
-        tests:
-            - not_null
-            - relationships:
-                to: ref('zoning_district_categories')
-                field: category_type
+- name: zoning_district_categories
+  description: All GFT zoning district categories
+  columns:
+  - name: category_type - not_null - unique
+  - name: label
+    tests: [ not_null ]
 
-  - name: nyc_parks_properties_categories
-    description: All possible values in typecategory column of recipe dpr_parksproperties
-    columns:
-      - name: typecategory
-        tests:
-          - not_null
-          - unique
-      - name: allowed
-        tests:
-          - not_null
-          - accepted_values:
-              values: ["TRUE", "FALSE"]
+- name: zoning_district_mappings
+  description: All PLUTO zoning district types and their GFT zoning district categories
+  columns:
+  - name: zoning_district_type
+    tests:
+    - unique
+  - name: category_type
+    tests:
+    - not_null
+    - relationships:
+        to: ref('zoning_district_categories')
+        field: category_type
 
-  - name: test_expected__pilot_projects
-    description: Mock pilot projects and their expected outputs
-    config:
-      column_types:
-        # empty columns default to integer type
-        special_coastal_risk: text
-        vent_tower: text
-        e_des_air_quality: text
-        e_des_noise: text
-        e_des_hazmat: text
-        # columns where ids are numeric need to be manually set to text
-        bbl: text
-        industrial_lots: text
-        wetland_checkzone: text
-        # geometry column type
-        geom: geometry(Geometry, 2263)
-    columns:
-      - name: project_label
-        tests:
-          - not_null
-      - name: bbl
-        tests:
-          - not_null
-          - unique
-      - name: geom
-        tests:
-          - not_null
-          - is_epsg_2263
+- name: nyc_parks_properties_categories
+  description: All possible values in typecategory column of recipe dpr_parksproperties
+  columns:
+  - name: typecategory
+    tests:
+    - not_null
+    - unique
+  - name: allowed
+    tests:
+    - not_null
+    - accepted_values:
+        values: [ "TRUE", "FALSE" ]
 
-  - name: test_expected__flags_zoning
-    description: Particular lots, their zoning fields, and the expected GFT zoning flag results
-    columns:
-      - name: lot_label
-        tests:
-          - not_null
-      - name: bbl
-        tests:
-          - not_null
-          - unique
-      - name: zonedist1
-      - name: zonedist2
-      - name: zonedist3
-      - name: zonedist4
-      - name: Zoning Districts
-    config:
-      column_types:
-        bbl: text
+- name: test_expected__pilot_projects
+  description: Mock pilot projects and their expected outputs
+  config:
+    column_types:
+      # empty columns default to integer type
+      special_coastal_risk: text
+      vent_tower: text
+      e_des_air_quality: text
+      e_des_noise: text
+      e_des_hazmat: text
+      # columns where ids are numeric need to be manually set to text
+      bbl: text
+      industrial_lots: text
+      wetland_checkzone: text
+      # geometry column type
+      geom: geometry(Geometry, 2263)
+  columns:
+  - name: project_label
+    tests:
+    - not_null
+  - name: bbl
+    tests:
+    - not_null
+    - unique
+  - name: geom
+    tests:
+    - not_null
+    - is_epsg_2263
 
-  - name: railyards_hudsonyards_erase
-    description: area to remove from exposed railyards data source (from dcp_cscl_commonplace)
-    columns:
-      - name: geom
-      - name: complexid
-      - name: globalid
-      - name: parentid
-      - name: shape_area
-      - name: shape_length
-    config:
-      column_types:
-        geom: geometry(Geometry, 2263)
+- name: test_expected__flags_zoning
+  description: Particular lots, their zoning fields, and the expected GFT zoning flag results
+  columns:
+  - name: lot_label
+    tests:
+    - not_null
+  - name: bbl
+    tests:
+    - not_null
+    - unique
+  - name: zonedist1
+  - name: zonedist2
+  - name: zonedist3
+  - name: zonedist4
+  - name: Zoning Districts
+  config:
+    column_types:
+      bbl: text
+
+- name: railyards_hudsonyards_erase
+  description: area to remove from exposed railyards data source (from dcp_cscl_commonplace)
+  columns:
+  - name: geom
+  - name: complexid
+  - name: globalid
+  - name: parentid
+  - name: shape_area
+  - name: shape_length
+  config:
+    column_types:
+      geom: geometry(Geometry, 2263)


### PR DESCRIPTION
Closes #1530 

Certainly go by commit: I also I reformatted yml in gft product. For these more complicated yml files, I thought that the extra indents for arrays made it less readable. As you get further in the files, you get really indented

Also added a line to export int__flags_all as a csv - most useful output for us to compare to when trying to answer questions around specific variable types in past builds. Should probably be a parquet! But for now just wanted to use the utils we have.

Build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14064935466/job/39384902585). A little tough to qc this one, repeat build is failing and the only outputs in s3 are the gdb of the final wide (aggregated across variable_type too) table. However, I think it's okay to assume these datasets are being used as needed - there are 75 priority waterbodies in the city resulting in 18160 flags (including both the actual intersections and the buffered shadows intersections)