### PR TITLE
cleanup ingest logging

### DIFF
--- a/dcpy/lifecycle/ingest/configure.py
+++ b/dcpy/lifecycle/ingest/configure.py
@@ -43,7 +43,6 @@ def read_template(
     and insert version as jinja var if provided.
     """
     file = template_dir / f"{dataset_id}.yml"
-    logger.info(f"Reading template from {file}")
     with open(file, "r") as f:
         template_string = f.read()
     vars = get_jinja_vars(template_string)
@@ -148,6 +147,8 @@ def get_config(
 ) -> Config:
     """Generate config object for dataset and optional version"""
     run_details = metadata.get_run_details()
+
+    logger.info(f"Reading template from {template_dir / dataset_id}.yml")
     template = read_template(dataset_id, version=version, template_dir=template_dir)
 
     filename = get_filename(template.ingestion.source, template.id)

--- a/dcpy/lifecycle/ingest/extract.py
+++ b/dcpy/lifecycle/ingest/extract.py
@@ -26,7 +26,7 @@ def download_file_from_source(
     From parsed config template and version, download raw data from source to provided path
     """
     path = dir / filename
-    logger.info(f"Extracting source data to {path}")
+    logger.info(f"Extracting {path.name} from source to staging folder")
     match source:
         ## Non reqeust-based methods
         case LocalFileSource():

--- a/dcpy/lifecycle/ingest/extract.py
+++ b/dcpy/lifecycle/ingest/extract.py
@@ -11,6 +11,7 @@ from dcpy.models.lifecycle.ingest import (
 )
 from dcpy.models.connectors import socrata, web as web_models
 from dcpy.models.connectors.edm.publishing import GisDataset
+from dcpy.utils.logging import logger
 from dcpy.utils import s3
 from dcpy.connectors.edm import publishing
 from dcpy.connectors.socrata import extract as extract_socrata
@@ -25,6 +26,7 @@ def download_file_from_source(
     From parsed config template and version, download raw data from source to provided path
     """
     path = dir / filename
+    logger.info(f"Extracting source data to {path}")
     match source:
         ## Non reqeust-based methods
         case LocalFileSource():

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 import shutil
+
+from dcpy.utils.logging import logger
 from dcpy.models.lifecycle.ingest import Config
 from dcpy.connectors.edm import recipes
 from dcpy.configuration import TEMPLATE_DIR
@@ -86,6 +88,9 @@ def ingest(
 
     dataset_output_dir = ingest_output_dir / dataset_id / config.version
     dataset_output_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        f"Copying {config.filename} and config file from {dataset_staging_dir} to {dataset_output_dir}"
+    )
     shutil.copy(dataset_staging_dir / CONFIG_FILENAME, dataset_output_dir)
     shutil.copy(dataset_staging_dir / config.filename, dataset_output_dir)
 

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -51,6 +51,7 @@ def ingest(
         dataset_staging_dir.mkdir(parents=True)
     else:
         dataset_staging_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Using {dataset_staging_dir} to stage data")
 
     with open(dataset_staging_dir / CONFIG_FILENAME, "w") as f:
         json.dump(config.model_dump(mode="json"), f, indent=4)
@@ -88,9 +89,7 @@ def ingest(
 
     dataset_output_dir = ingest_output_dir / dataset_id / config.version
     dataset_output_dir.mkdir(parents=True, exist_ok=True)
-    logger.info(
-        f"Copying {config.filename} and config file from {dataset_staging_dir} to {dataset_output_dir}"
-    )
+    logger.info(f"Copying {config.filename} to {dataset_output_dir}")
     shutil.copy(dataset_staging_dir / CONFIG_FILENAME, dataset_output_dir)
     shutil.copy(dataset_staging_dir / config.filename, dataset_output_dir)
 

--- a/dcpy/lifecycle/ingest/transform.py
+++ b/dcpy/lifecycle/ingest/transform.py
@@ -48,7 +48,7 @@ def to_parquet(
     assert local_data_path.is_file() or local_data_path.is_dir(), (
         "Local path should be a valid file or directory"
     )
-    logger.info(f"✅ Raw data was found locally at {local_data_path}")
+    logger.info(f"Converting {local_data_path} to {output_file_path}")
 
     gdf = data.read_data_to_df(file_format, local_data_path)
 
@@ -58,9 +58,6 @@ def to_parquet(
         gdf[OUTPUT_GEOM_COLUMN] = gdf.make_valid()
 
     gdf.to_parquet(output_file_path, index=False)
-    logger.info(
-        f"✅ Converted raw data to parquet file and saved as {output_file_path}"
-    )
 
 
 class ProcessingFunctions:
@@ -362,6 +359,7 @@ def process(
     output_csv: bool = False,
 ):
     """Validates and runs processing steps defined in config object"""
+    logger.info(f"Processing {input_path} to {output_path}")
     df = geoparquet.read_df(input_path)
     compiled_steps = validate_processing_steps(dataset_id, processing_steps)
 

--- a/dcpy/lifecycle/ingest/transform.py
+++ b/dcpy/lifecycle/ingest/transform.py
@@ -48,7 +48,7 @@ def to_parquet(
     assert local_data_path.is_file() or local_data_path.is_dir(), (
         "Local path should be a valid file or directory"
     )
-    logger.info(f"Converting {local_data_path} to {output_file_path}")
+    logger.info(f"Converting {local_data_path.name} to {output_filename}")
 
     gdf = data.read_data_to_df(file_format, local_data_path)
 
@@ -359,7 +359,7 @@ def process(
     output_csv: bool = False,
 ):
     """Validates and runs processing steps defined in config object"""
-    logger.info(f"Processing {input_path} to {output_path}")
+    logger.info(f"Processing {input_path.name} to {output_path.name}")
     df = geoparquet.read_df(input_path)
     compiled_steps = validate_processing_steps(dataset_id, processing_steps)
 


### PR DESCRIPTION
closes #1537

from tweaks in commit 1, looks like
```
12:53:15 INFO:dcpy:registering edm.recipes
12:53:15 INFO:dcpy:registering edm.publishing.drafts
12:53:15 INFO:dcpy:registering edm.publishing.published
12:53:15 INFO:dcpy:Registered Connectors: ['edm.recipes', 'edm.publishing.drafts', 'edm.publishing.published']
12:53:16 INFO:dcpy:Reading template from templates/dcp_colp.yml
12:53:17 INFO:dcpy:Extracting source data to .lifecycle/ingest/staging/dcp_colp/2025-03-26T12:53:16.772762-04:00/dcp_colp.geojson
12:53:23 INFO:dcpy:Converting .lifecycle/ingest/staging/dcp_colp/2025-03-26T12:53:16.772762-04:00/dcp_colp.geojson to .lifecycle/ingest/staging/dcp_colp/2025-03-26T12:53:16.772762-04:00/init.parquet
12:53:27 INFO:dcpy:Processing .lifecycle/ingest/staging/dcp_colp/2025-03-26T12:53:16.772762-04:00/init.parquet to .lifecycle/ingest/staging/dcp_colp/2025-03-26T12:53:16.772762-04:00/dcp_colp.parquet
12:53:28 INFO:dcpy:Copying dcp_colp.parquet and config file from .lifecycle/ingest/staging/dcp_colp/2025-03-26T12:53:16.772762-04:00 to .lifecycle/ingest/datasets/dcp_colp/20240826
```

Commit 2 I though maybe just stating the directories once is cleaner
```
13:05:30 INFO:dcpy:registering edm.recipes
13:05:30 INFO:dcpy:registering edm.publishing.drafts
13:05:30 INFO:dcpy:registering edm.publishing.published
13:05:30 INFO:dcpy:Registered Connectors: ['edm.recipes', 'edm.publishing.drafts', 'edm.publishing.published']
13:05:33 INFO:dcpy:Reading template from templates/dcp_colp.yml
13:05:33 INFO:dcpy:Using .lifecycle/ingest/staging/dcp_colp/2025-03-26T13:05:33.390037-04:00 to stage data
13:05:33 INFO:dcpy:Extracting dcp_colp.geojson from source to staging folder
13:05:35 INFO:dcpy:Converting dcp_colp.geojson to init.parquet
13:05:41 INFO:dcpy:Processing init.parquet to dcp_colp.parquet
13:05:42 INFO:dcpy:Copying dcp_colp.parquet to .lifecycle/ingest/datasets/dcp_colp/20240826
```

Curious to your thoughts!