### PR TITLE
Update PLUTO & MAPPLUTO urls

### DIFF
--- a/dcpy/library/templates/dcp_mappluto.yml
+++ b/dcpy/library/templates/dcp_mappluto.yml
@@ -3,7 +3,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_mappluto_{{ version | replace(".","_") }}_unclipped_shp.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/mappluto/nyc_mappluto_{{ version | replace(".","_") }}_unclipped_shp.zip
       subpath: MapPLUTO_UNCLIPPED.shp
     options:
       - "AUTODETECT_TYPE=NO"

--- a/dcpy/library/templates/dcp_pluto.yml
+++ b/dcpy/library/templates/dcp_pluto.yml
@@ -3,7 +3,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_pluto_{{ version | replace(".","_") }}_csv.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/pluto/nyc_pluto_{{ version | replace(".","_") }}_csv.zip
       subpath: pluto_{{ version | replace(".","_") }}.csv
     options:
       - AUTODETECT_TYPE=NO


### PR DESCRIPTION
Bytes link changed for pluto & pappluto. Ingestion was failing for both.

This also fixes nightly QA for PLUTO build - it was missing 25v1 versions.

Pluto successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14089075058).
Mappluto successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14089068380).