### PR TITLE
update bytes path for upad/tpad

### DIFF
--- a/admin/run_environment/docker/config.sh
+++ b/admin/run_environment/docker/config.sh
@@ -20,7 +20,7 @@ function install_geosupport {
         else
             echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
             mkdir linux_upad_tpad_${RELEASE}${PATCH} &&
-                curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/linux_upad_tpad_${RELEASE}${PATCH}.zip &&
+                curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/geosupport/linux_upad_tpad_${RELEASE}${PATCH}.zip &&
                 unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/ &&
                 rm -r linux_upad_tpad_${RELEASE}${PATCH}
         fi


### PR DESCRIPTION
Fixes issue in #1548. Not sure why the plain geosupport url (above) hasn't changed, but the upad/tpad one did

Running action [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14204769019) showing fixed behavior (but also those images are built in the pr test for this branch)