### PR TITLE
CSCL ETLC POC - add atomic polygon fields

### DIFF
--- a/products/lion/models/intermediate/2.2.3/_int_223.yml
+++ b/products/lion/models/intermediate/2.2.3/_int_223.yml
@@ -1,0 +1,31 @@
+models:
+- name: int__centerline_atomicpolygons
+  description: centerline segments joined to left and right atomic polygons
+  columns:
+  - name: segmentid
+    tests: [ unique, not_null ]
+  - name: left_atomicid
+  - name: left_2000_census_tract
+  - name: left_2010_census_tract
+  - name: left_2020_census_tract
+  - name: left_assembly_district
+  - name: left_election_district
+  - name: left_school_district
+  - name: right_atomicid
+  - name: right_2000_census_tract
+  - name: right_2010_census_tract
+  - name: right_2020_census_tract
+  - name: right_assembly_district
+  - name: right_election_district
+  - name: right_school_district
+  tests: [] #
+  #- dbt_expectations.expect_table_row_count_to_equal_other_table: TODO: commented out while weird rows in source data are unresolved
+  #    compare_model: ref("stg__centerline")
+
+- name: int__centerline_offsets
+  columns:
+  - name: segmentid,
+  - name: left_line,
+  - name: right_line,
+  - name: left_offset_point,
+  - name: right_offset_point

--- a/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
+++ b/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
@@ -1,0 +1,34 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['segmentid']},
+    ]
+) }}
+WITH centerline_offsets AS (
+    SELECT * FROM {{ ref("int__centerline_offsets") }}
+)
+
+SELECT
+    co.segmentid,
+    left_poly.atomicid AS left_atomicid,
+    left_poly.censustract_2000 AS left_2000_census_tract,
+    left_poly.censustract_2010 AS left_2010_census_tract,
+    left_poly.censustract_2020 AS left_2020_census_tract,
+    left_poly.assemdist AS left_assembly_district,
+    left_poly.electdist AS left_election_district,
+    left_poly.schooldist AS left_school_district,
+    right_poly.atomicid AS right_atomicid,
+    right_poly.censustract_2000 AS right_2000_census_tract,
+    right_poly.censustract_2010 AS right_2010_census_tract,
+    right_poly.censustract_2020 AS right_2020_census_tract,
+    right_poly.assemdist AS right_assembly_district,
+    right_poly.electdist AS right_election_district,
+    right_poly.schooldist AS right_school_district
+FROM centerline_offsets AS co
+-- using a cte around atomicpolygons confused the postgres compiler to not use index
+LEFT JOIN
+    {{ source("recipe_sources", "dcp_cscl_atomicpolygons") }} AS left_poly
+    ON ST_WITHIN(co.left_offset_point, left_poly.geom)
+LEFT JOIN
+    {{ source("recipe_sources", "dcp_cscl_atomicpolygons") }} AS right_poly
+    ON ST_WITHIN(co.left_offset_point, right_poly.geom)

--- a/products/lion/models/intermediate/2.2.3/int__centerline_offsets.sql
+++ b/products/lion/models/intermediate/2.2.3/int__centerline_offsets.sql
@@ -1,0 +1,44 @@
+-- int__centerline_offsets
+-- takes centerline segment, finds adjoining atomic polygons
+-- method in docs is 
+--     "To determine the given segment’s left and right APs, the ETL tool will generate 
+--     temporary left and right “offset points” positioned on both sides of the segment,
+--     offset two feet perpendicularly from the segment’s midpoint"
+-- the current method is an approximation. See comments in #1568
+-- TODO: decide on current method or appropriate replacement
+
+{{ config(
+    materialized = 'table'
+) }}
+
+WITH centerline AS (
+    SELECT
+        segmentid,
+        st_linemerge(geom) AS geom
+    FROM {{ ref("stg__centerline") }}
+    -- TODO remove this -> likely from odd source data.
+    WHERE segmentid NOT IN (
+        354785, -- Large circular segment extending into other states
+        9008702 -- Strange small simple line that is discontinuous
+    )
+),
+
+parallel_lines AS (
+    SELECT
+        segmentid,
+        st_offsetcurve(geom, 2, 'quad_segs=4') AS left_line,
+        st_offsetcurve(geom, -2, 'quad_segs=4') AS right_line
+    FROM centerline
+),
+
+offset_points AS (
+    SELECT
+        segmentid,
+        left_line,
+        right_line,
+        st_lineinterpolatepoint(left_line, 0.5) AS left_offset_point,
+        st_lineinterpolatepoint(right_line, 0.5) AS right_offset_point
+    FROM parallel_lines
+)
+
+SELECT * FROM offset_points

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -1,5 +1,9 @@
 WITH centerline AS (
-    SELECT * FROM {{ source("recipe_sources", "dcp_cscl_centerline") }}
+    SELECT * FROM {{ ref("stg__centerline") }}
+),
+
+atomic_polygons AS (
+    SELECT * FROM {{ ref("int__centerline_atomicpolygons") }}
 )
 
 SELECT
@@ -21,24 +25,24 @@ SELECT
     NULL AS "To-Node ID",
     NULL AS "To-X Coordinate",
     NULL AS "To-Y Coordinate",
-    NULL AS "Left 2000 Census Tract",
-    NULL AS "Left Dynamic Block",
+    ap.left_2000_census_tract AS "Left 2000 Census Tract",
+    ap.left_atomicid AS "Left Dynamic Block", -- TODO: "last 3 bytes"
     centerline.l_low_hn AS "Left Low House Number",
     centerline.l_high_hn AS "Left High House Number",
     centerline.lsubsect AS "Left Dept of Sanitation Subsection", -- TODO: only 2 leftmost bytes
     centerline.l_zip AS "Left Zip Code",
-    NULL AS "Left Assembly District",
-    NULL AS "Left Election District",
-    NULL AS "Left School District",
-    NULL AS "Right 2000 Census Tract",
-    NULL AS "Right Dynamic Block",
+    ap.left_assembly_district AS "Left Assembly District",
+    ap.left_election_district AS "Left Election District",
+    ap.left_school_district AS "Left School District",
+    ap.right_2000_census_tract AS "Right 2000 Census Tract",
+    ap.right_atomicid AS "Right Dynamic Block", -- TODO: "last 3 bytes"
     centerline.r_low_hn AS "Right Low House Number",
     centerline.r_high_hn AS "Right High House Number",
     centerline.rsubsect AS "Right Dept of Sanitation Subsection", -- TODO: only 2 leftmost bytes
     centerline.r_zip AS "Right Zip Code",
-    NULL AS "Right Assembly District",
-    NULL AS "Right Election District",
-    NULL AS "Right School District",
+    ap.right_assembly_district AS "Right Assembly District",
+    ap.right_election_district AS "Right Election District",
+    ap.right_school_district AS "Right School District",
     NULL AS "Split Election District Flag",
     NULL AS "Filler (formerly Split Community School District Flag)", -- single space on export
     centerline.sandist_ind AS "Sanitation District Boundary Indicator",
@@ -77,8 +81,9 @@ SELECT
     centerline.bike_lane AS "Bike Lane Indicator",
     centerline.fcc AS "FCC",
     NULL AS "Right of Way Type", -- blank
-    NULL AS "Left 2010 Census Tract",
-    NULL AS "Right 2010 Census Tract",
+    ap.left_2010_census_tract AS "Left 2010 Census Tract",
+    ap.right_2010_census_tract AS "Right 2010 Census Tract",
+    -- TODO: 2020 census tracts?
     NULL AS "LGC5",
     NULL AS "LGC6",
     NULL AS "LGC7",
@@ -86,3 +91,4 @@ SELECT
     NULL AS "LGC9",
     centerline.legacy_segmentid AS "Legacy SEGMENTID"
 FROM centerline
+LEFT JOIN atomic_polygons AS ap ON centerline.segmentid = ap.segmentid

--- a/products/lion/models/staging/stg__centerline.sql
+++ b/products/lion/models/staging/stg__centerline.sql
@@ -1,0 +1,8 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['segmentid']}
+    ]
+) }}
+
+SELECT * FROM {{ source("recipe_sources", "dcp_cscl_centerline") }}

--- a/products/lion/packages.yml
+++ b/products/lion/packages.yml
@@ -1,5 +1,3 @@
 packages:
-- package: dbt-labs/dbt_utils
-  version: 1.1.1
 - package: calogica/dbt_expectations
-  version: 0.10.3
+  version: 0.10.4


### PR DESCRIPTION
addresses #1568, though some questions remain there. See issue for description of problem and implementation questions.

There are also a few weird data things - see comments in `int__centerline_offsetpoints`

build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14361781898)

Before any more of these issues are tackled, I'm going to flush out the project in GH especially around validation - that's probably worth focusing on before getting too far into any specific transformation. But it seemed like this and the node-based joins were the big "prickly" transformations, so just wanted to make sure that they were going to be feasible and not too hard (to write the code, or in terms of runtime)