### PR TITLE
Refactor Build Publishing and Implement for PFF

### DIFF
--- a/dcpy/lifecycle/builds/_cli.py
+++ b/dcpy/lifecycle/builds/_cli.py
@@ -2,6 +2,10 @@ import typer
 
 
 from dcpy.lifecycle.builds.load import app as load_app
+from dcpy.lifecycle.builds.plan import app as plan_app
+from dcpy.lifecycle.builds.build import app as build_app
 
 app = typer.Typer()
+app.add_typer(plan_app, name="plan")
+app.add_typer(build_app, name="build")
 app.add_typer(load_app, name="load")

--- a/dcpy/lifecycle/builds/build.py
+++ b/dcpy/lifecycle/builds/build.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import typer
+
+from dcpy.lifecycle.builds import plan
+from dcpy.lifecycle.connector_registry import connectors
+
+
+app = typer.Typer(add_completion=False)
+
+STAGE = "builds.build"
+
+
+@app.command("upload")
+def _upload_build(
+    build_path: Path,
+    recipe_lock_path: Path = typer.Option(
+        None,
+        "--recipe-path",
+        "-r",
+        help="Path of recipe lock file to use",
+    ),
+):
+    """Upload a build to the destination configured in the recipe."""
+    recipe = plan.recipe_from_yaml(
+        recipe_lock_path or (Path(build_path).parent / "recipe.lock.yml")
+    )
+
+    stage_config = recipe.stage_config[STAGE]
+    # TODO: eventually we should add stage_config defaults in lifecycle.config
+    assert stage_config.destination, "A destination must be defined"
+
+    connector_key = stage_config.destination_key or recipe.product
+
+    result = connectors[stage_config.destination].push(
+        build_path=build_path,
+        key=connector_key,
+        connector_args=stage_config.get_connector_args_dict(),
+        # TODO: eventually also pass the metadata from the build stage output, which would allow us to skip passing the build path
+    )
+    typer.echo(result)

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -164,7 +164,7 @@ def plan_recipe(recipe_path: Path, version: str | None = None) -> Recipe:
             )
 
     # Resolve any unresolved conf values (e.g. from the environment)
-    for conf in recipe.get_unresolved_conf_values():
+    for conf in recipe.get_unresolved_stage_config_values():
         if "env" in conf.value_from:
             env_var = conf.value_from["env"]
             if env_var not in os.environ:

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -88,20 +88,21 @@ def plan_recipe(recipe_path: Path, version: str | None = None) -> Recipe:
         recipe.vars["VERSION_TYPE"] = recipe.version_type.value
 
     # Determine previous version
-    try:
-        previous_recipe = publishing.get_previous_version(
-            product=recipe.product, version=recipe.version
-        )
-        logger.info(
-            f"Previous version of {recipe.product}: {previous_recipe.label} ({previous_recipe})"
-        )
-        recipe.vars["VERSION_PREV"] = previous_recipe.label
-    except (
-        LookupError,
-        ValueError,
-        TypeError,
-    ) as e:  # versions not found, or don't parse correctly
-        logger.error(f"Error: {e}")
+    if "VERSION_PREV" not in recipe.vars:
+        try:
+            previous_recipe = publishing.get_previous_version(
+                product=recipe.product, version=recipe.version
+            )
+            logger.info(
+                f"Previous version of {recipe.product}: {previous_recipe.label} ({previous_recipe})"
+            )
+            recipe.vars["VERSION_PREV"] = previous_recipe.label
+        except (
+            LookupError,
+            ValueError,
+            TypeError,
+        ) as e:  # versions not found, or don't parse correctly
+            logger.error(f"Error: {e}")
 
     # Add vars to environ so both can be accessed in environ
     logger.info(f"Export envars: {recipe.vars}")
@@ -161,6 +162,14 @@ def plan_recipe(recipe_path: Path, version: str | None = None) -> Recipe:
             ds.file_type = ds.file_type or recipes.get_preferred_file_type(
                 ds.dataset, RECIPE_FILE_TYPE_PREFERENCE
             )
+
+    # Resolve any unresolved conf values (e.g. from the environment)
+    for conf in recipe.get_unresolved_conf_values():
+        if "env" in conf.value_from:
+            env_var = conf.value_from["env"]
+            if env_var not in os.environ:
+                raise Exception(f"build.plan requires missing env var: {env_var}")
+            conf.value = os.environ[env_var]
 
     return recipe
 

--- a/dcpy/lifecycle/config.py
+++ b/dcpy/lifecycle/config.py
@@ -15,6 +15,7 @@ def _set_default_conf():
                 "stages": {
                     "plan": {"local_data_path": "plan"},
                     "load": {"local_data_path": "load"},
+                    "build": {"local_data_path": "build"},
                 },
             },
             "package": {
@@ -33,7 +34,19 @@ def _set_default_conf():
 CONF = _set_default_conf()
 
 
-def stage_conf(stages: str):
+def list_stages():
+    stage_names = set()
+
+    # this assumes no sub-sub-stages...
+    for stage_name, stage in CONF["stages"].items():
+        if "stages" in stage:
+            stage_names.update([f"{stage_name}.{s}" for s in stage["stages"].keys()])
+        else:
+            stage_names.add(stage_name)
+    return stage_names
+
+
+def stage_config(stages: str):
     """Retrieve the configuration for a stage.
 
     stage should be a dot delmited list of stages.substages.etc, e.g. `package.qa`

--- a/dcpy/lifecycle/connector_registry.py
+++ b/dcpy/lifecycle/connector_registry.py
@@ -24,6 +24,9 @@ def _set_default_connectors():
     connectors.register(connector=web.WebConnector(), conn_type="api")
     connectors.register(connector=filesystem.Connector(), conn_type="local_file")
     connectors.register(connector=s3.S3Connector(), conn_type="s3")
+    connectors.register(
+        connector=publishing.BuildsConnector(), conn_type="edm.publishing.builds"
+    )
     logger.info(f"Registered Connectors: {connectors.list_registered()}")
 
 

--- a/dcpy/models/lifecycle/builds.py
+++ b/dcpy/models/lifecycle/builds.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 import pandas as pd
 from pathlib import Path
 from pydantic import AliasChoices, BaseModel, Field, model_validator
-from typing import Any, List, Optional, ClassVar
+from typing import Any, List, ClassVar
 from typing_extensions import Self
 
 from dcpy.utils import versions
@@ -65,14 +65,14 @@ class RecipeInputs(BaseModel):
     dataset_defaults: InputDatasetDefaults | None = None
 
 
-class StageConfValue(BaseModel, extra="forbid"):
+class StageConfigValue(BaseModel, extra="forbid"):
     UNRESOLVABLE_ERROR: ClassVar[str] = (
         "Stage Conf Value requires either `value` or `value_from`"
     )
 
     name: str
     value: str | None = None
-    value_from: Optional[dict[str, str]] = None
+    value_from: dict[str, str] = {}
 
     @model_validator(mode="after")
     def check_resolvable(self) -> Self:
@@ -81,10 +81,10 @@ class StageConfValue(BaseModel, extra="forbid"):
         return self
 
 
-class StageConf(BaseModel, extra="forbid", arbitrary_types_allowed=True):
-    destination: Optional[str] = None
-    destination_key: Optional[str] = None
-    connector_args: Optional[list[StageConfValue]] = []
+class StageConfig(BaseModel, extra="forbid", arbitrary_types_allowed=True):
+    destination: str | None = None
+    destination_key: str | None = None
+    connector_args: list[StageConfigValue] = []
 
     def get_connector_args_dict(self) -> dict[str, Any]:
         return {a.name: a.value for a in self.connector_args or []}
@@ -99,7 +99,7 @@ class Recipe(BaseModel, extra="forbid", arbitrary_types_allowed=True):
     version: str | None = None
     vars: dict[str, str] | None = None
     inputs: RecipeInputs
-    stage_config: dict[str, StageConf] = {}
+    stage_config: dict[str, StageConfig] = {}
 
     def is_resolved(self):
         return (

--- a/dcpy/models/lifecycle/builds.py
+++ b/dcpy/models/lifecycle/builds.py
@@ -108,12 +108,12 @@ class Recipe(BaseModel, extra="forbid", arbitrary_types_allowed=True):
                 len(self.inputs.datasets) == 0
                 or len([x for x in self.inputs.datasets if not x.is_resolved()]) == 0
             )
-            and not self.get_unresolved_conf_values()
+            and not self.get_unresolved_stage_config_values()
         )
 
-    def get_unresolved_conf_values(self):
+    def get_unresolved_stage_config_values(self):
         unresolved = []
-        for stage_name, conf in self.stage_config.items():
+        for _, conf in self.stage_config.items():
             for conn_args in conf.connector_args or []:
                 if conn_args.value_from and not conn_args.value:
                     unresolved.append(conn_args)

--- a/dcpy/test/lifecycle/builds/resources/recipe_w_stages.yml
+++ b/dcpy/test/lifecycle/builds/resources/recipe_w_stages.yml
@@ -1,0 +1,27 @@
+name: Tester
+version: 23v1
+vars:
+  VERSION_PREV: 23v0
+
+product: db-test
+version_type: major
+
+inputs:
+  datasets: []
+
+
+stage_config:
+  builds.build:
+    destination: edm.publish.builds_mock
+    connector_args:
+      - name: acl
+        value: public
+      - name: build_note
+        value_from:
+          env: "BUILD_NOTE"
+
+  build.publish_published:
+    destination: edm.publish.published_mock
+    connector_args:
+      - name: acl
+        value: public

--- a/dcpy/test/lifecycle/builds/resources/recipe_w_unresolvable_var.yml
+++ b/dcpy/test/lifecycle/builds/resources/recipe_w_unresolvable_var.yml
@@ -1,0 +1,17 @@
+name: Tester
+version: 23v1
+vars:
+  VERSION_PREV: 23v0
+
+product: db-test
+version_type: major
+
+inputs:
+  datasets: []
+
+
+stage_config:
+  builds.build:
+    destination: edm.publish.builds_mock
+    connector_args:
+      - name: build_note

--- a/dcpy/test/lifecycle/builds/test_plan.py
+++ b/dcpy/test/lifecycle/builds/test_plan.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock, Mock
 
 from dcpy.connectors.registry import ConnectorRegistry
-from dcpy.models.lifecycle.builds import InputDataset, StageConfValue
+from dcpy.models.lifecycle.builds import InputDataset, StageConfigValue
 from dcpy.utils import versions
 from dcpy.connectors.edm import recipes, publishing
 from dcpy.lifecycle.builds import plan
@@ -398,6 +398,6 @@ class TestPlanStageConfs(TestCase):
         with self.assertRaises(Exception) as e:
             plan.recipe_from_yaml(RECIPE_W_UNRESOLVABLE_STAGES)
 
-        assert StageConfValue.UNRESOLVABLE_ERROR in str(e.exception), (
+        assert StageConfigValue.UNRESOLVABLE_ERROR in str(e.exception), (
             "The error should mention that the stage var is unresolvable."
         )

--- a/products/factfinder/acs.yml
+++ b/products/factfinder/acs.yml
@@ -18,3 +18,15 @@ inputs:
       destination: file
       file_type: xlsx
   missing_versions_strategy: find_latest
+
+
+stage_config:
+  builds.build:
+    destination: edm.publishing.builds
+    destination_key: db-factfinder
+    connector_args:
+      - name: acl
+        value: public-read
+      - name: build_note
+        value_from:
+          env: "BUILD_NOTE"

--- a/products/factfinder/pipelines/__init__.py
+++ b/products/factfinder/pipelines/__init__.py
@@ -1,8 +1,9 @@
 import os
 from pathlib import Path
+from dcpy.lifecycle import config
 
 PRODUCT_PATH = Path(__file__).parent.parent
 DATA_PATH = PRODUCT_PATH / "factfinder" / "data"
-OUTPUT_FOLDER = DATA_PATH / ".output"
+OUTPUT_FOLDER = config.local_data_path_for_stage("builds.build") / "factfinder"
 
 API_KEY = os.environ["API_KEY"]

--- a/products/factfinder/pipelines/acs_community_profiles.py
+++ b/products/factfinder/pipelines/acs_community_profiles.py
@@ -8,7 +8,7 @@ from pathos.pools import ProcessPool
 from factfinder.calculate import Calculate
 
 from . import API_KEY, DATA_PATH
-from .utils import parse_args, s3_upload
+from .utils import parse_args
 
 with open(DATA_PATH / "acs_community_profiles" / "metadata.json", "r") as f:
     acs_variables = json.load(f)
@@ -44,6 +44,3 @@ if __name__ == "__main__":
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(output_file, index=False)
-
-    if upload:
-        s3_upload(output_file)

--- a/products/factfinder/pipelines/acs_manual_update.py
+++ b/products/factfinder/pipelines/acs_manual_update.py
@@ -12,7 +12,6 @@ from .utils import (
     apply_ccd_prefix,
     pivot_factfinder_table,
     export_df,
-    s3_upload,
 )
 
 DATASET = "acs"
@@ -93,17 +92,15 @@ def process_latest_data(file: Path, year: str):
         process_domain_data(df, domain, year)
 
 
-def run(load_result: load.LoadResult, upload: bool = False):
-    if OUTPUT_FOLDER.is_dir():
-        shutil.rmtree(OUTPUT_FOLDER)
+def build(version, load_result: load.LoadResult):
+    output_folder = OUTPUT_FOLDER / version / "acs"
+    if output_folder.is_dir():
+        shutil.rmtree(output_folder)
     process_2010_data(load_result)
 
     latest = load_result.datasets["dcp_pop_acs"]
     assert isinstance(latest.destination, Path)
     process_latest_data(latest.destination, latest.version)
-
-    if upload:
-        s3_upload(DATASET, ["2010", latest.version])
 
 
 if __name__ == "__main__":

--- a/products/factfinder/pipelines/decennial_manual_update.py
+++ b/products/factfinder/pipelines/decennial_manual_update.py
@@ -5,7 +5,7 @@ import shutil
 from dcpy.utils.logging import logger
 from dcpy.lifecycle.builds import load
 from . import OUTPUT_FOLDER
-from .utils import process_metadata, apply_ccd_prefix, export_df, s3_upload
+from .utils import process_metadata, apply_ccd_prefix, export_df
 
 DATASET = "decennial"
 SHEET_CONFIG = {
@@ -70,12 +70,10 @@ def process_file(dataset: str, excel: Path):
         export_df(df, DATASET, year)
 
 
-def run(load_result: load.LoadResult, upload: bool = False):
-    shutil.rmtree(OUTPUT_FOLDER, ignore_errors=True)
+def build(version, load_result: load.LoadResult):
+    output_folder = OUTPUT_FOLDER / version / "decennial"
+    shutil.rmtree(output_folder, ignore_errors=True)
 
     for dataset in load_result.datasets:
         file_path = load.get_imported_filepath(load_result, dataset)
         process_file(dataset, file_path)
-
-    if upload:
-        s3_upload(DATASET, YEARS)

--- a/products/factfinder/pipelines/utils.py
+++ b/products/factfinder/pipelines/utils.py
@@ -1,5 +1,4 @@
 import argparse
-from datetime import date
 import json
 import pandas as pd
 from pathlib import Path
@@ -7,11 +6,8 @@ import re
 import shutil
 from typing import Tuple
 
-from dcpy.connectors.edm import publishing
-from dcpy.lifecycle.builds import metadata
 from dcpy.utils import string
 from . import DATA_PATH, OUTPUT_FOLDER
-from ..paths import ROOT_PATH
 
 
 COLUMN_CLEANUP = {"Male ": "Male", "Male P": "MaleP"}
@@ -187,21 +183,6 @@ def export_df(df: pd.DataFrame, dataset: str, year: str, copy_metadata=False):
     if copy_metadata:
         shutil.copy(
             DATA_PATH / dataset / year / "metadata.json", OUTPUT_FOLDER / dataset / year
-        )
-
-
-def s3_upload(dataset: str, years: list[str], latest=True):
-    for year in years:
-        output = OUTPUT_FOLDER / dataset / year
-        shutil.copy(str(ROOT_PATH / "build_metadata.json"), output)
-        publishing.legacy_upload(
-            output=output,
-            publishing_folder="db-factfinder",
-            version=str(date.today()),
-            acl="public-read",
-            s3_subpath=str(Path(metadata.build_name()) / dataset / year),
-            latest=latest,
-            contents_only=True,
         )
 
 

--- a/products/factfinder/run.py
+++ b/products/factfinder/run.py
@@ -10,6 +10,7 @@ app = typer.Typer(add_completion=False)
 @app.command()
 def _run(
     dataset: str = typer.Argument(),
+    vesion: str = typer.Argument(),
     upload: bool = typer.Option(
         False,
         "-u",
@@ -25,10 +26,10 @@ def _run(
     load_result = load.load_source_data_from_resolved_recipe(lockfile)
     match dataset:
         case "acs":
-            acs_manual_update.run(load_result, upload)
+            acs_manual_update.build(vesion, load_result)
 
         case "decennial":
-            decennial_manual_update.run(load_result, upload)
+            decennial_manual_update.build(vesion, load_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## TLDR
This Implements:
1) build directory and upload changes for PFF
2) recipe changes to enable stage confs, with env vars. 

I'd start by glancing at the recipe files for both the acs.yml recipe and the test recipes. That should give a sense of the changes here. 

Also, apologies, commits are not atomic. After having to rebase a few times, I lost the patience to keep things tidy.

## More detail

### PFF
defaults to dumping data in the configured lifecycle directory
<img width="303" alt="image" src="https://github.com/user-attachments/assets/a706c668-dadf-4a48-9467-cf40cf96a625" />

This changes to call ACS data files `current` and `previous` so that dataset names don't change over time. (at least not until 2030, when there's a new census). We should probably also add JSON file with info about which years are included in these files. 


### Recipe Changes
This is a first step towards declaring build variables upfront, so that we can accomplish [this](https://github.com/NYCPlanning/data-engineering/discussions/1575). There's potentially a little more planning to do, but for this side of things, I'd start reviewing the test recipes. 
