### PR TITLE
fix s3 ingest

### DIFF
--- a/dcpy/lifecycle/ingest/configure.py
+++ b/dcpy/lifecycle/ingest/configure.py
@@ -48,7 +48,9 @@ def read_template(
 
 def get_version(source: Source, timestamp: datetime):
     connector = source_connectors[source.type]
-    version = connector.get_latest_version(source.get_key(), **source.model_dump())
+    source_model_dict = source.model_dump()
+    source_model_dict.pop("key", None)  # Safely remove "key" if it exists
+    version = connector.get_latest_version(source.get_key(), **source_model_dict)
     return version or timestamp.strftime("%Y%m%d")
 
 

--- a/dcpy/test/lifecycle/ingest/test_configure.py
+++ b/dcpy/test/lifecycle/ingest/test_configure.py
@@ -4,7 +4,7 @@ import pytest
 from unittest import mock
 from pydantic import BaseModel
 
-from dcpy.configuration import PUBLISHING_BUCKET
+from dcpy.configuration import RECIPES_BUCKET, PUBLISHING_BUCKET
 from dcpy.models import file
 from dcpy.models.lifecycle.ingest import (
     FileDownloadSource,
@@ -81,6 +81,15 @@ class TestGetVersion:
         source = Sources.esri
         ### based on mocked response in dcpy/test/conftest.py
         configure.get_version(source, None) == "20240806"
+
+    def test_s3(self, create_buckets):
+        timestamp = datetime.today()
+        version = timestamp.strftime("%Y%m%d")
+        s3.client().put_object(
+            Bucket=RECIPES_BUCKET,
+            Key=f"datasets/{TEST_DATASET_NAME}/{version}/{TEST_DATASET_NAME}.zip",
+        )
+        assert configure.get_version(Sources.s3, timestamp) == version
 
     def test_gis_dataset(self, create_buckets):
         datestring = "20240412"


### PR DESCRIPTION
closes https://github.com/NYCPlanning/data-engineering/issues/1624

successful ingest run on main [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14606072502) and with a new template [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14606126367)

this seemed like the simplest fix for now. changing `S3Source` to use `path` instead of `key` would be nice but I didn't feel confident in that change being simple (would old config.json files parse correctly?)