### PR TITLE
LION Special Address Flag

### DIFF
--- a/.github/workflows/lion_build.yml
+++ b/.github/workflows/lion_build.yml
@@ -69,6 +69,9 @@ jobs:
         dbt deps
         dbt debug
 
+        echo "Build seed tables"
+        dbt build --select config.materialized:seed --indirect-selection=cautious --full-refresh
+
         echo "Test source tables"
         dbt test --select "source:*"
 

--- a/ingest_templates/dcp_cscl_addresspoints.yml
+++ b/ingest_templates/dcp_cscl_addresspoints.yml
@@ -1,0 +1,18 @@
+id: dcp_cscl_addresspoints
+acl: private
+
+attributes:
+  name: CSCL Address Points
+
+ingestion:
+  source:
+    type: s3
+    bucket: edm-private
+    key: cscl_etl/ETL Working GDB.gdb.zip
+  file_format:
+    type: geodatabase
+    layer: AddressPoint
+    crs: EPSG:2263
+  processing_steps:
+  - name: clean_column_names
+    args: { lower: True }

--- a/ingest_templates/dcp_cscl_altsegmentdata.yml
+++ b/ingest_templates/dcp_cscl_altsegmentdata.yml
@@ -1,0 +1,18 @@
+id: dcp_cscl_altsegmentdata
+acl: private
+
+attributes:
+  name: CSCL Alt Segment Data
+
+ingestion:
+  source:
+    type: s3
+    bucket: edm-private
+    key: cscl_etl/ETL Working GDB.gdb.zip
+  file_format:
+    type: geodatabase
+    layer: ALTSEGMENTDATA
+    crs: EPSG:2263
+  processing_steps:
+  - name: clean_column_names
+    args: { lower: True }

--- a/ingest_templates/dcp_cscl_commonplace_gdb.yml
+++ b/ingest_templates/dcp_cscl_commonplace_gdb.yml
@@ -3,6 +3,9 @@ acl: private
 
 attributes:
   name: CSCL Common Place
+  description: >-
+    TODO We archive commonplace from AGOL as well, this dataset is currently just to be
+    used in LION ETL POC. At some point this duplication should be resolved
 
 ingestion:
   source:

--- a/ingest_templates/dcp_cscl_commonplace_gdb.yml
+++ b/ingest_templates/dcp_cscl_commonplace_gdb.yml
@@ -1,0 +1,18 @@
+id: dcp_cscl_commonplace_gdb
+acl: private
+
+attributes:
+  name: CSCL Common Place
+
+ingestion:
+  source:
+    type: s3
+    bucket: edm-private
+    key: cscl_etl/ETL Working GDB.gdb.zip
+  file_format:
+    type: geodatabase
+    layer: CommonPlace
+    crs: EPSG:2263
+  processing_steps:
+  - name: clean_column_names
+    args: { lower: True }

--- a/products/lion/models/intermediate/2.2.10/_int_2210.yml
+++ b/products/lion/models/intermediate/2.2.10/_int_2210.yml
@@ -1,0 +1,6 @@
+models:
+- name: int__centerline_specialaddress
+  columns:
+  - name: segmentid
+  - name: boroughcode
+  - name: special_address_flag

--- a/products/lion/models/intermediate/2.2.10/int__centerline_specialaddress.sql
+++ b/products/lion/models/intermediate/2.2.10/int__centerline_specialaddress.sql
@@ -1,0 +1,60 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['segmentid', 'boroughcode']},
+    ]
+) }}
+WITH altsegment_saf_records AS (
+    SELECT * FROM {{ ref("stg__altsegmentdata_saf") }}
+),
+addresspoints AS (
+    SELECT * FROM {{ source("recipe_sources", "dcp_cscl_addresspoints") }}
+),
+commonplace AS (
+    SELECT * FROM {{ source("recipe_sources", "dcp_cscl_commonplace_gdb") }}
+),
+unioned AS (
+    SELECT
+        segmentid,
+        saftype,
+        borough AS boroughcode,
+        1 AS source_priority,
+        ogc_fid
+    FROM altsegment_saf_records
+    UNION ALL
+    SELECT
+        segmentid,
+        special_condition AS saftype,
+        boroughcode,
+        2 AS source_priority,
+        ogc_fid
+    FROM addresspoints
+    UNION ALL
+    SELECT
+        segmentid,
+        saftype,
+        boroughcode,
+        3 AS source_priority,
+        ogc_fid
+    FROM commonplace
+),
+prioritized AS (
+    SELECT
+        segmentid,
+        boroughcode,
+        unioned.saftype,
+        row_number() OVER (
+            PARTITION BY segmentid, boroughcode
+            -- very specific fields have priority, as specified in seed table
+            -- beyond that, order by source and row number
+            ORDER BY p.priority, source_priority, ogc_fid
+        ) AS row_number
+    FROM unioned
+    INNER JOIN {{ ref('seed_saf_priority') }} AS p ON unioned.saftype = p.saftype
+)
+SELECT
+    segmentid,
+    boroughcode,
+    saftype AS special_address_flag
+FROM prioritized
+WHERE row_number = 1

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -16,6 +16,10 @@ atomic_polygons AS (
 
 nodes AS (
     SELECT * FROM {{ ref("int__centerline_segments_with_nodes") }}
+),
+
+saf AS (
+    SELECT * FROM {{ ref("int__centerline_specialaddress") }}
 )
 
 SELECT
@@ -64,7 +68,7 @@ SELECT
     centerline.continuous_parity_flag,
     NULL AS borough_boundary_indicator,
     NULL AS twisted_parity_flag,
-    NULL AS special_address_flag,
+    saf.special_address_flag,
     NULL AS curve_flag,
     NULL AS center_of_curvature_x,
     NULL AS center_of_curvature_y,
@@ -129,3 +133,4 @@ SELECT
 FROM centerline
 LEFT JOIN atomic_polygons AS ap ON centerline.segmentid = ap.segmentid
 LEFT JOIN nodes ON centerline.segmentid = nodes.segmentid
+LEFT JOIN saf ON centerline.segmentid = saf.segmentid AND centerline.boroughcode = saf.boroughcode

--- a/products/lion/models/sources.yml
+++ b/products/lion/models/sources.yml
@@ -8,3 +8,4 @@ sources:
   - name: dcp_cscl_centerline
   - name: dcp_cscl_nodes
   - name: dcp_cscl_sectionalmap
+  - name: dcp_cscl_altsegmentdata

--- a/products/lion/models/sources.yml
+++ b/products/lion/models/sources.yml
@@ -9,3 +9,5 @@ sources:
   - name: dcp_cscl_nodes
   - name: dcp_cscl_sectionalmap
   - name: dcp_cscl_altsegmentdata
+  - name: dcp_cscl_addresspoints
+  - name: dcp_cscl_commonplace_gdb

--- a/products/lion/models/staging/stg__altsegmentdata_saf.sql
+++ b/products/lion/models/staging/stg__altsegmentdata_saf.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM {{ source("recipe_sources", "dcp_cscl_altsegmentdata") }}
+WHERE alt_segdata_type = 'S'

--- a/products/lion/models/staging/stg__protosegments.sql
+++ b/products/lion/models/staging/stg__protosegments.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM {{ source("recipe_sources", "dcp_cscl_altsegmentdata") }}
+WHERE alt_segdata_type <> 'S' -- S denotes a SAF record

--- a/products/lion/recipe.yml
+++ b/products/lion/recipe.yml
@@ -9,5 +9,5 @@ inputs:
   - name: dcp_cscl_atomicpolygons
   - name: dcp_cscl_altsegmentdata
   - name: dcp_cscl_addresspoints
-  - name: dcp_cscl_commonplace_gdb
+  - name: dcp_cscl_commonplace_gdb # TODO - we archive commonplace from AGOL as well, at some point this duplication should be resolved
   missing_versions_strategy: find_latest # TODO - they should all match

--- a/products/lion/recipe.yml
+++ b/products/lion/recipe.yml
@@ -7,4 +7,7 @@ inputs:
   - name: dcp_cscl_nodes
   - name: dcp_cscl_sectionalmap
   - name: dcp_cscl_atomicpolygons
+  - name: dcp_cscl_altsegmentdata
+  - name: dcp_cscl_addresspoints
+  - name: dcp_cscl_commonplace_gdb
   missing_versions_strategy: find_latest # TODO - they should all match

--- a/products/lion/seeds/seed_saf_priority.csv
+++ b/products/lion/seeds/seed_saf_priority.csv
@@ -1,0 +1,14 @@
+saftype,priority
+S,1
+N,2
+G,3
+V,
+X,
+A,
+B,
+C,
+D,
+E,
+F,
+O,
+P,


### PR DESCRIPTION
closes #1622 

See section 2.2.10 of the [doc](https://nyco365.sharepoint.com/:w:/r/sites/NYCPLANNING/itd/edm/_layouts/15/Doc.aspx?sourcedoc=%7BD3194825-3026-4295-8A31-6FB030749AA1%7D&file=ETL_V8_02012024%20-%20Copy.docx&action=default&mobileredirect=true). Summary is that there are multiple tables to join centerline to find "Special Address" flags, which we will assign hierarchically to our segment

successful build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14717921619/job/41305555900)

Data tested with the following sql
```sql
select 
d."Borough",
d."Sequence Number",
d."Segment ID",
d."Special Address Flag",
p."Special Address Flag"
from  fvk_lion_sa_flag.lion_dat_fields d
inner join production_outputs.citywide_lion p
using("Borough", "Sequence Number", "Segment ID")
where d."Special Address Flag" <> p."Special Address Flag"
```

This returns 6 rows
|Borough|Sequence Number|Segment ID|Special Address Flag|Special Address Flag|
|-------|---------------|----------|--------------------|--------------------|
|1|00010|0069084|F|D|
|1|00060|0119730|F|D|
|1|02008|9017012|F|D|
|1|00789|0295871|N| |
|2|00080|0174203|N| |
|2|00080|0174203|N| |

- 3 of them (blank -> 'N') are from the "prod" data having two rows for these segments while my table only has 1. I'll need to double check that these ones are "correct", but am blocked by #1566 as it seems face code is used to create a unique identifier between rows in lion. They have been logged though in #1597 
- 3 have value "D" in prod and "F" in our pipeline. From what I can see, there's no source data that would lead to a value of "D". Per the docs, the "D" values come from AltSegmentData table, and there are no values with "D" there for the given segmentids, so I have no idea where that would come from. Logged in #1597 and will just accept it as an unanswered question for now.

Then, more of a completeness check

```sql
select 
count(*)
from  lion_dat_fields d
inner join production_outputs.citywide_lion p
using("Borough", "Sequence Number", "Segment ID")
where d."Special Address Flag" = p."Special Address Flag"
```

180248 rows. There are 180138 in lion_dat_fields -> so there's an issue with duplicate segment ids that I'm going to look into, but it seems like other than the 3 mystery D -> F rows, this is looking good