### PR TITLE
Lion - validating against current etl outputs

### DIFF
--- a/products/lion/dat_loader.py
+++ b/products/lion/dat_loader.py
@@ -1,3 +1,10 @@
+"""
+This script is for parsing a lion.dat file into its individual fields
+and loading the result into a postgres table
+
+This is done ad-hoc and not on an operational basis
+"""
+
 import pandas as pd
 from pathlib import Path
 import typer

--- a/products/lion/dat_loader.py
+++ b/products/lion/dat_loader.py
@@ -1,0 +1,61 @@
+import pandas as pd
+from pathlib import Path
+import typer
+
+from dcpy.utils import postgres
+
+DAT_FORMATTING_FILE = Path("seeds/lion_dat_formatting.csv")
+
+
+def parse_dat(dat_file: Path, max_records: int | None = None) -> pd.DataFrame:
+    formatting = pd.read_csv(DAT_FORMATTING_FILE)
+
+    records = []
+    with open(dat_file) as f:
+        i = 0
+        for row in f:
+            if max_records and i > max_records:
+                break
+            record = {}
+            for j, field in formatting.iterrows():
+                label = field["field_label"]
+                start_index = field["start_index"] - 1
+                end_index = field["end_index"]
+                record[label] = row[start_index:end_index]
+            records.append(record)
+            i += 1
+
+    return pd.DataFrame(records)
+
+
+def load_dat(dat_file: Path, table_name: str | None, schema: str | None = None) -> None:
+    dat_df = parse_dat(dat_file)
+    table_name = table_name or dat_file.stem
+    postgres.PostgresClient(schema=schema).insert_dataframe(dat_df, table_name)
+
+
+app = typer.Typer()
+
+
+@app.command()
+def head(
+    filepath: Path = typer.Argument(),
+    save_to_csv: bool = typer.Option(False, "-c"),
+):
+    df = parse_dat(filepath, 10)
+    if save_to_csv:
+        df.to_csv(filepath.stem + ".csv")
+    typer.echo(df.head())
+
+
+@app.command("load")
+def _load_dat(
+    filepath: Path = typer.Argument(),
+    table_name: str | None = typer.Option(None, "--table", "-t"),
+    schema: str | None = typer.Option(None, "--schema", "-s"),
+):
+    load_dat(filepath, table_name, schema)
+
+
+if __name__ == "__main__":
+    app()

--- a/products/lion/models/intermediate/2.2.3/_int_223.yml
+++ b/products/lion/models/intermediate/2.2.3/_int_223.yml
@@ -24,8 +24,8 @@ models:
 
 - name: int__centerline_offsets
   columns:
-  - name: segmentid,
-  - name: left_line,
-  - name: right_line,
-  - name: left_offset_point,
+  - name: segmentid
+  - name: left_line
+  - name: right_line
+  - name: left_offset_point
   - name: right_offset_point

--- a/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
+++ b/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
@@ -43,4 +43,4 @@ LEFT JOIN
     ON ST_WITHIN(co.left_offset_point, left_poly.geom)
 LEFT JOIN
     {{ source("recipe_sources", "dcp_cscl_atomicpolygons") }} AS right_poly
-    ON ST_WITHIN(co.left_offset_point, right_poly.geom)
+    ON ST_WITHIN(co.right_offset_point, right_poly.geom)

--- a/products/lion/models/intermediate/2.2.3/int__centerline_offsets.sql
+++ b/products/lion/models/intermediate/2.2.3/int__centerline_offsets.sql
@@ -12,10 +12,7 @@
 ) }}
 
 WITH centerline AS (
-    SELECT
-        segmentid,
-        st_linemerge(geom) AS geom
-    FROM {{ ref("stg__centerline") }}
+    SELECT * FROM {{ ref("stg__centerline") }}
     -- TODO remove this -> likely from odd source data.
     WHERE segmentid NOT IN (
         354785, -- Large circular segment extending into other states

--- a/products/lion/models/product/dat/_dat.yml
+++ b/products/lion/models/product/dat/_dat.yml
@@ -553,11 +553,8 @@ models:
   columns:
   - name: dat_column
     tests:
-    # Must warn until all columns are populated
     - dbt_expectations.expect_column_value_lengths_to_equal:
         value: 400
-        config:
-          severity: warn
 
 - name: manhattan_lion_dat
   columns:

--- a/products/lion/models/product/dat/_dat.yml
+++ b/products/lion/models/product/dat/_dat.yml
@@ -338,17 +338,17 @@ models:
     tests:
     - dbt_expectations.expect_column_value_lengths_to_equal:
         value: 1
-  - name: '"Street Width"'
+  - name: '"STREETWIDTH_MIN"'
     data_type: string
     tests:
     - dbt_expectations.expect_column_value_lengths_to_equal:
         value: 3
-  - name: '"Irregular Street Width Flag"'
+  - name: '"STREETWIDTH_IRR"'
     data_type: string
     tests:
     - dbt_expectations.expect_column_value_lengths_to_equal:
         value: 1
-  - name: '"Bike Lane Indicator"'
+  - name: '"BIKELANE_1"'
     data_type: string
     tests:
     - dbt_expectations.expect_column_value_lengths_to_equal:

--- a/products/lion/models/product/dat/lion_dat.sql
+++ b/products/lion/models/product/dat/lion_dat.sql
@@ -3,5 +3,5 @@
 WITH lion AS (
     SELECT * FROM {{ ref('lion_dat_fields') }}
 )
-SELECT rtrim(ltrim(replace(lion::text, ',', ''), '('), ')') AS dat_column
+SELECT rtrim(ltrim(replace(replace(lion::text, ',', ''), '"', ''), '('), ')') AS dat_column
 FROM lion

--- a/products/lion/models/product/dat/lion_dat_fields.sql
+++ b/products/lion/models/product/dat/lion_dat_fields.sql
@@ -55,13 +55,13 @@ SELECT
     format_lion_text(center_of_curvature_x, 7, '0', TRUE) AS "Center of Curvature X-Coordinate",
     format_lion_text(center_of_curvature_y, 7, '0', TRUE) AS "Center of Curvature Y-Coordinate",
     format_lion_text(segment_length_ft::TEXT, 5, '0') AS "Segment Length in Feet",
-    from_level_code AS "From Level Code",
-    to_level_code AS "To Level Code",
+    coalesce(from_level_code, ' ') AS "From Level Code",
+    coalesce(to_level_code, ' ') AS "To Level Code",
     coalesce(trafdir_ver_flag, ' ') AS "Traffic Direction Verification Flag",
     segment_type AS "Segment Type Code",
     coincident_seg_count::INT::TEXT AS "Coincident Segment Counter",
     coalesce(incex_flag, ' ') AS "Include/Exclude Flag",
-    format_lion_text(rw_type::TEXT, 2, '0', TRUE) AS "Roadway Type", -- TODO doesn't say if zf or sf
+    format_lion_text(rw_type::TEXT, 2, ' ', TRUE) AS "Roadway Type",
     format_lion_text(physicalid::INT::TEXT, 7, '0', TRUE) AS "PHYSICALID", -- TODO - ingest read as int
     format_lion_text(genericid::INT::TEXT, 7, '0', TRUE) AS "GENERICID", -- TODO - ingest read as int
     format_lion_text(nypdid::INT::TEXT, 7, '0', TRUE) AS "NYPDID", -- TODO - ingest read as int
@@ -69,7 +69,7 @@ SELECT
     '       ' AS "Filler (formerly Left BLOCKFACEID)",
     '       ' AS "Filler (formerly Right BLOCKFACEID)",
     coalesce(status, ' ') AS "STATUS",
-    format_lion_text(round(streetwidth)::TEXT, 3, '0', TRUE) AS "STREETWIDTH_MIN", -- TODO - confirm. docs don't say to justify but we need to
+    format_lion_text(round(streetwidth)::TEXT, 3, ' ', TRUE) AS "STREETWIDTH_MIN",
     coalesce(streetwidth_irr, ' ') AS "STREETWIDTH_IRR",
     coalesce(bike_lane, ' ') AS "BIKELANE_1",
     coalesce(fcc, '  ') AS "FCC",
@@ -96,7 +96,7 @@ SELECT
     '   ' AS "Filler L89",
     format_lion_text(l_blockfaceid::INT::TEXT, 10, '0', TRUE) AS "Left BLOCKFACEID", -- TODO - ingest read as int
     format_lion_text(r_blockfaceid::INT::TEXT, 10, '0', TRUE) AS "Right BLOCKFACEID", -- TODO - ingest read as int
-    format_lion_text(number_travel_lanes::INT::TEXT, 2, '0', TRUE) AS "NUMBER TRAVEL LANES", -- TODO - ingest read as int
+    format_lion_text(number_travel_lanes::INT::TEXT, 2, ' ', TRUE) AS "NUMBER TRAVEL LANES", -- TODO - ingest read as int
     format_lion_text(number_park_lanes::INT::TEXT, 2, ' ') AS "NUMBER PARK LANES", -- TODO - ingest read as int
     format_lion_text(number_total_lanes::INT::TEXT, 2, ' ') AS "NUMBER TOTAL LANES", -- TODO - ingest read as int
     format_lion_text(bike_traffic_direction, 2, ' ') AS "BIKE TRAFFIC DIR",

--- a/products/lion/models/product/dat/lion_dat_fields.sql
+++ b/products/lion/models/product/dat/lion_dat_fields.sql
@@ -17,8 +17,8 @@ SELECT
     format_lion_text(to_nodeid::TEXT, 7, '0') AS "To-Node ID",
     format_lion_text(round(to_x)::INT::TEXT, 7, '0') AS "To-X Coordinate",
     format_lion_text(round(to_y)::INT::TEXT, 7, '0') AS "To-Y Coordinate",
-    left_2000_census_tract AS "Left 2000 Census Tract", -- TODO section 1.4
-    right(left_atomicid, 3) AS "Left Dynamic Block",
+    format_lion_text(left_2000_census_tract, 6, ' ', TRUE) AS "Left 2000 Census Tract", -- TODO section 1.4
+    coalesce(right(left_atomicid, 3), '   ') AS "Left Dynamic Block",
     format_lion_text(l_low_hn, 7, ' ', TRUE) AS "Left Low House Number", -- TODO section 1.4
     format_lion_text(l_high_hn, 7, ' ', TRUE) AS "Left High House Number", -- TODO section 1.4
     format_lion_text(left(lsubsect, 2), 2, '0', TRUE) AS "Left Dept of Sanitation Subsection",
@@ -26,8 +26,8 @@ SELECT
     format_lion_text(left_assembly_district, 2, '0', TRUE) AS "Left Assembly District",
     format_lion_text(left_election_district, 3, '0', TRUE) AS "Left Election District",
     format_lion_text(left_school_district, 2, '0', TRUE) AS "Left School District",
-    right_2000_census_tract AS "Right 2000 Census Tract", -- TODO section 1.4
-    right(right_atomicid, 3) AS "Right Dynamic Block",
+    format_lion_text(right_2000_census_tract, 6, ' ', TRUE) AS "Right 2000 Census Tract", -- TODO section 1.4
+    coalesce(right(right_atomicid, 3), '   ') AS "Right Dynamic Block",
     format_lion_text(r_low_hn, 7, ' ', TRUE) AS "Right Low House Number", -- TODO section 1.4
     format_lion_text(r_high_hn, 7, ' ', TRUE) AS "Right High House Number", -- TODO section 1.4
     format_lion_text(left(rsubsect, 2), 2, '0', TRUE) AS "Right Dept of Sanitation Subsection",
@@ -74,8 +74,8 @@ SELECT
     coalesce(bike_lane, ' ') AS "BIKELANE_1",
     coalesce(fcc, '  ') AS "FCC",
     coalesce(right_of_way_type, ' ') AS "Right of Way Type",
-    left_2010_census_tract AS "Left 2010 Census Tract", -- TODO section 1.4
-    right_2010_census_tract AS "Right 2010 Census Tract", -- TODO section 1.4
+    format_lion_text(left_2010_census_tract, 6, ' ', TRUE) AS "Left 2010 Census Tract", -- TODO section 1.4
+    format_lion_text(right_2010_census_tract, 6, ' ', TRUE) AS "Right 2010 Census Tract", -- TODO section 1.4
     format_lion_text(lgc5, 2, '0', TRUE) AS "LGC5",
     format_lion_text(lgc6, 2, '0', TRUE) AS "LGC6",
     format_lion_text(lgc7, 2, '0', TRUE) AS "LGC7",
@@ -104,8 +104,8 @@ SELECT
     format_lion_text(left_nypd_service_area, 1, ' ') AS "Left NYPD Service Area",
     format_lion_text(right_nypd_service_area, 1, ' ') AS "Right NYPD Service Area",
     format_lion_text(truck_route_type, 1, ' ') AS "Truck Route Type",
-    left_2020_census_tract AS "LEFT 2020 CENSUS TRACT", -- TODO 1.4
-    right_2020_census_tract AS "RIGHT 2020 CENSUS TRACT", -- TODO 1.4
+    format_lion_text(left_2020_census_tract, 6, ' ', TRUE) AS "LEFT 2020 CENSUS TRACT", -- TODO 1.4
+    format_lion_text(right_2020_census_tract, 6, ' ', TRUE) AS "RIGHT 2020 CENSUS TRACT", -- TODO 1.4
     format_lion_text(left_2020_census_block_basic, 4, ' ') AS "LEFT CENSUS BLOCK 2020 BASIC",
     coalesce(left_2020_census_block_suffix, ' ') AS "LEFT CENSUS BLOCK 2020 SUFFIX",
     format_lion_text(right_2020_census_block_basic, 4, ' ') AS "RIGHT CENSUS BLOCK 2020 BASIC",

--- a/products/lion/models/product/dat/lion_dat_fields.sql
+++ b/products/lion/models/product/dat/lion_dat_fields.sql
@@ -69,9 +69,9 @@ SELECT
     '       ' AS "Filler (formerly Left BLOCKFACEID)",
     '       ' AS "Filler (formerly Right BLOCKFACEID)",
     coalesce(status, ' ') AS "STATUS",
-    format_lion_text(round(streetwidth)::TEXT, 3, '0', TRUE) AS "Street Width", -- TODO - confirm. docs don't say to justify but we need to
-    coalesce(streetwidth_irr, ' ') AS "Irregular Street Width Flag",
-    coalesce(bike_lane, ' ') AS "Bike Lane Indicator",
+    format_lion_text(round(streetwidth)::TEXT, 3, '0', TRUE) AS "STREETWIDTH_MIN", -- TODO - confirm. docs don't say to justify but we need to
+    coalesce(streetwidth_irr, ' ') AS "STREETWIDTH_IRR",
+    coalesce(bike_lane, ' ') AS "BIKELANE_1",
     coalesce(fcc, '  ') AS "FCC",
     coalesce(right_of_way_type, ' ') AS "Right of Way Type",
     left_2010_census_tract AS "Left 2010 Census Tract", -- TODO section 1.4

--- a/products/lion/models/product/dat/lion_dat_fields.sql
+++ b/products/lion/models/product/dat/lion_dat_fields.sql
@@ -1,3 +1,11 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['"Segment ID"']},
+      {'columns': ['"Borough"', '"Sequence Number"', '"Segment ID"']}
+    ]
+) }}
+
 SELECT
     boroughcode AS "Borough",
     format_lion_text(face_code, 4, '0') AS "Face Code",

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -1,3 +1,11 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['segmentid']},
+      {'columns': ['boroughcode', 'segment_seqnum', 'segmentid']}
+    ]
+) }}
+
 WITH centerline AS (
     SELECT * FROM {{ ref("stg__centerline") }}
 ),

--- a/products/lion/models/staging/stg__centerline.sql
+++ b/products/lion/models/staging/stg__centerline.sql
@@ -10,5 +10,5 @@ SELECT
     st_linemerge(geom) AS geom -- TODO - any reason to not do this here?
 FROM {{ source("recipe_sources", "dcp_cscl_centerline") }}
 WHERE
-    NOT (rwjurisdiction = '3' AND status = '2')
+    NOT (rwjurisdiction = '3' AND status <> '2')
     AND rw_type <> 8

--- a/products/lion/seeds/lion_dat_formatting.csv
+++ b/products/lion/seeds/lion_dat_formatting.csv
@@ -1,0 +1,109 @@
+field_number,field_label,field_length,start_index,end_index,formatting
+L1,Borough,1,1,1,Digit > 0
+L2,Face Code,4,2,5,RJZF
+L3,Sequence Number,5,6,10,RJZF
+L4,Segment ID,7,11,17,RJZF
+L5,5-Digit Street Code (5SC),5,18,22,RJZF
+L6,LGC1,2,23,24,RJZF
+L7,LGC2,2,25,26,RJZF - blank if none
+L8,LGC3,2,27,28,RJZF - blank if none
+L9,LGC4,2,29,30,RJZF - blank if none
+L10,Board of Elections LGC Pointer,1,31,31,Blank if none
+L11,From-Sectional Map,2,32,33,RJZF
+L12,From-Node ID,7,34,40,RJZF
+L13,From-X Coordinate,7,41,47,RJZF
+L14,From-Y Coordinate,7,48,54,RJZF
+L15,To-Sectional Map,2,55,56,RJZF
+L16,To-Node ID,7,57,63,RJZF
+L17,To-X Coordinate,7,64,70,RJZF
+L18,To-Y Coordinate,7,71,77,RJZF
+L19,Left 2000 Census Tract,6,78,83,See Sec. 1.4
+L20,Left Dynamic Block,3,84,86,RJZF or blank if none
+L21,Left Low House Number,7,87,93,See Sec. 1.4
+L22,Left High House Number,7,94,100,See Sec. 1.4
+L23,Left Dept of Sanitation Subsection,2,101,102,RJZF - blank if none
+L24,Left Zip Code,5,103,107,Blank if none
+L25,Left Assembly District,2,108,109,RJZF - blank if none
+L26,Left Election District,3,110,112,RJZF - blank if none
+L27,Left School District,2,113,114,RJZF - blank if none
+L28,Right 2000 Census Tract,6,115,120,See Sec. 1.4
+L29,Right Dynamic Block,3,121,123,RJZF - blank if none
+L30,Right Low House Number,7,124,130,See Sec. 1.4
+L31,Right High House Number,7,131,137,See Sec. 1.4
+L32,Right Dept of Sanitation Subsection,2,138,139,RJZF - blank if none
+L33,Right Zip Code,5,140,144,Blank if none
+L34,Right Assembly District,2,145,146,RJZF - blank if none
+L35,Right Election District,3,147,149,RJZF - blank if none
+L36,Right School District,2,150,151,RJZF - blank if none
+L37,Split Election District Flag,1,152,152,Blank if none
+L38,Filler (formerly Split Community School District Flag),1,153,153,Blank
+L39,Sanitation District Boundary Indicator,1,154,154,Blank if none
+L40,Traffic Direction,1,155,155,Blank if none
+L41,Segment Locational Status,1,156,156,Blank if none
+L42,Feature Type Code,1,157,157,Blank if none
+L43,Non-Pedestrian Flag,1,158,158,Blank if none
+L44,Continuous Parity Indicator,1,159,159,Blank if none
+L45,Filler (formerly the Near BQ-Boundary Flag),1,160,160,Blank
+L46,Borough Boundary Indicator,1,161,161,Blank if none
+L47,Twisted Parity Flag,1,162,162,Blank if none
+L48,Special Address Flag,1,163,163,Blank if none
+L49,Curve Flag,1,164,164,Blank if none
+L50,Center of Curvature X-Coordinate,7,165,171,Leading zeros
+L51,Center of Curvature Y-Coordinate,7,172,178,Leading zeros
+L52,Segment Length in Feet,5,179,183,RJZF
+L53,From Level Code,1,184,184,Character
+L54,To Level Code,1,185,185,Character
+L55,Traffic Direction Verification Flag,1,186,186,Blank if none
+L56,Segment Type Code,1,187,187,Character
+L57,Coincident Segment Counter,1,188,188,Integer > 0
+L58,Include/Exclude Flag,1,189,189,Blank if none
+L59,Roadway Type,2,190,191,Blank if none
+L60,PHYSICALID,7,192,198,RJZF - blank if none
+L61,GENERICID,7,199,205,RJZF - blank if none
+L62,NYPDID,7,206,212,RJZF - blank if none
+L63,FDNYID,7,213,219,RJZF - blank if none
+L64,Filler (formerly Left BLOCKFACEID),7,220,226,RJZF - blank if none
+L65,Filler (formerly Right BLOCKFACEID),7,227,233,RJZF - blank if none
+L66,STATUS,1,234,234,Blank if none
+L67,STREETWIDTH_MIN,3,235,237,Blank if none
+L68,STREETWIDTH_IRR,1,238,238,Blank if none
+L69_1,BIKELANE_1,1,239,239,Blank if none
+L70,FCC,2,240,241,Blank if none
+L71,Right of Way Type,1,242,242,Blank if none
+L72,Left 2010 Census Tract,6,243,248,See Sec. 1.4
+L73,Right 2010 Census Tract,6,249,254,See Sec. 1.4
+L74,LGC5,2,255,256,01 to 99 or Blanks
+L75,LGC6,2,257,258,01 to 99 or Blanks
+L76,LGC7,2,259,260,01 to 99 or Blanks
+L77,LGC8,2,261,262,01 to 99 or Blanks
+L78,LGC9,2,263,264,01 to 99 or Blanks
+L79,Legacy SEGMENTID,7,265,271,RJZFbut Shoreline 
+L80,LEFT CENSUS BLOCK 2000 BASIC,4,272,275,RJSF
+L81,LEFT CENSUS BLOCK 2000 SUFFIX,1,276,276,Blank if none
+L82,RIGHT CENSUS BLOCK 2000 BASIC,4,277,280,RJSF
+L83,RIGHT CENSUS BLOCK 2000 SUFFIX,1,281,281,Blank if none
+L84,LEFT CENSUS BLOCK 2010 BASIC,4,282,285,RJSF
+L85,LEFT CENSUS BLOCK 2010 SUFFIX,1,286,286,Blank if none
+L86,RIGHT CENSUS BLOCK 2010 BASIC,4,287,290,RJSF
+L87,RIGHT CENSUS BLOCK 2010 SUFFIX,1,291,291,Blank if none
+L88,SNOW PRIORITY,1,292,292,Blank if none
+L69_2,BIKELANE_2,2,293,294,RJSF 1-11 Blank if none
+L67_2,STREET WIDTH MAX,3,295,297,RJSF - Blank if none
+L89,Filler L89,3,298,300,
+L90,Left BLOCKFACEID,10,301,310,RJZF - blank if none
+L91,Right BLOCKFACEID,10,311,320,RJZF - blank if none
+L92,NUMBER TRAVEL LANE,2,321,322,RJZF - blank if none
+L93,NUMBER PARK LANES,2,323,324,RJSF
+L94,NUMBER TOTAL LANES,2,325,326,RJSF
+L95,BIKE TRAFFIC DIR,2,327,328,RJSF
+L96,POSTED SPEED,2,329,330,RJSF
+L97,Left NYPD Service Area,1,331,331,RJSF 
+L98,Right NYPD Service Area,1,332,332,RJSF
+L99,Truck Route Type,1,333,333,RJSF
+L100,LEFT 2020 CENSUS TRACT,6,334,339,See Sec. 1.4 
+L101,RIGHT 2020 CENSUS TRACT,6,340,345,See Sec. 1.4
+L102,LEFT CENSUS BLOCK 2020 BASIC,4,346,349,RJSF
+L103,LEFT CENSUS BLOCK 2020 SUFFIX,1,350,350,Blank if none
+L104,RIGHT CENSUS BLOCK 2020 BASIC,4,351,354,RJSF
+L105,RIGHT CENSUS BLOCK 2020 SUFFIX,1,355,355,Blank if none
+L199,Filler L199,45,356,400,


### PR DESCRIPTION
Start of #1577 

## Motivation - how to use the loaded dat tables to spot check

I've loaded parsed .dat outputs of the current etl tool into the db under the schema "production_outputs". We should have more complete tools around validation, but for now I've just been running some spot checks like

```sql
select 'ref' as source, * from production_outputs.manhattan_lion where "Segment ID" = '0018067'
union all
select 'poc' as source, * from fvk_lion_validation.lion_dat_fields ldf where "Segment ID" = '0018067'
```

For easy comparison. Again, it's not a thorough validation of the whole result set but it's a good sanity check while developing.
<img width="877" alt="image" src="https://github.com/user-attachments/assets/5cc896fe-4c0e-400c-93c2-9fdcad65f9cd" />

## Review
a couple main things here
- a few little cleanup things
- dat loader script -> python script to go from .dat files (from sharepoint - outputs of existing etl) to tables in postgres
- seed file that's used by the script. Has all fields and their respective indices in the .dat file
- some fixes I discovered when doing my first spot checks

build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14674723934) with all tests passing! Exciting for the dat fields and the one-column dat table
