### PR TITLE
Lion - simple transformations

### DIFF
--- a/products/lion/models/product/dat/_dat.yml
+++ b/products/lion/models/product/dat/_dat.yml
@@ -217,8 +217,9 @@ models:
   - name: '"Feature Type Code"'
     data_type: string
     tests:
-    - dbt_expectations.expect_column_value_lengths_to_equal:
-        value: 1
+    - accepted_values:
+        # this enforces length as well
+        values: [ " ", "5", "6", "9", "A", "W", "F", "C" ]
   - name: '"Non-Pedestrian Flag"'
     data_type: string
     tests:

--- a/products/lion/models/product/dat/_dat.yml
+++ b/products/lion/models/product/dat/_dat.yml
@@ -243,8 +243,8 @@ models:
   - name: '"Twisted Parity Flag"'
     data_type: string
     tests:
-    - dbt_expectations.expect_column_value_lengths_to_equal:
-        value: 1
+    - accepted_values:
+        values: [ " ", "T" ]
   - name: '"Special Address Flag"'
     data_type: string
     tests:

--- a/products/lion/models/product/dat/_dat.yml
+++ b/products/lion/models/product/dat/_dat.yml
@@ -273,13 +273,13 @@ models:
   - name: '"From Level Code"'
     data_type: string
     tests:
-    - dbt_expectations.expect_column_value_lengths_to_equal:
-        value: 1
+    - accepted_values:
+        values: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, "*"]
   - name: '"To Level Code"'
     data_type: string
     tests:
-    - dbt_expectations.expect_column_value_lengths_to_equal:
-        value: 1
+    - accepted_values:
+        values: [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, "*"]
   - name: '"Traffic Direction Verification Flag"'
     data_type: string
     tests:

--- a/products/lion/models/product/dat/_dat.yml
+++ b/products/lion/models/product/dat/_dat.yml
@@ -206,8 +206,9 @@ models:
   - name: '"Traffic Direction"'
     data_type: string
     tests:
-    - dbt_expectations.expect_column_value_lengths_to_equal:
-        value: 1
+    - accepted_values:
+        # this enforces length as well
+        values: [ " ", "W", "A", "P", "T" ]
   - name: '"Segment Locational Status"'
     data_type: string
     tests:

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -61,7 +61,12 @@ SELECT
     ap.right_school_district,
     NULL AS split_election_district_flag,
     centerline.sandist_ind,
-    NULL AS traffic_direction,
+    CASE
+        WHEN trafdir = 'FT' THEN 'W'
+        WHEN trafdir = 'TF' THEN 'A'
+        WHEN trafdir = 'NV' THEN 'P'
+        WHEN trafdir = 'TW' THEN 'T'
+    END AS traffic_direction,
     NULL AS segment_locational_status,
     NULL AS feature_type_code,
     centerline.nonped,

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -80,7 +80,9 @@ SELECT
     centerline.nonped,
     centerline.continuous_parity_flag,
     NULL AS borough_boundary_indicator,
-    NULL AS twisted_parity_flag,
+    CASE
+        WHEN twisted_parity_flag = 'Y' THEN 'T'
+    END AS twisted_parity_flag,
     saf.special_address_flag,
     NULL AS curve_flag,
     NULL AS center_of_curvature_x,

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -88,8 +88,14 @@ SELECT
     NULL AS center_of_curvature_x,
     NULL AS center_of_curvature_y,
     round(centerline.shape_length)::INT AS segment_length_ft,
-    NULL AS from_level_code,
-    NULL AS to_level_code,
+    CASE
+        WHEN from_level_code BETWEEN 1 AND 26 THEN chr(64 + from_level_code)
+        WHEN from_level_code = 99 THEN '*'
+    END AS from_level_code,
+    CASE
+        WHEN to_level_code BETWEEN 1 AND 26 THEN chr(64 + to_level_code)
+        WHEN to_level_code = 99 THEN '*'
+    END AS to_level_code,
     centerline.trafdir_ver_flag,
     centerline.segment_type,
     centerline.coincident_seg_count, -- TODO do not count subterranean subway/rail segments

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -68,7 +68,15 @@ SELECT
         WHEN trafdir = 'TW' THEN 'T'
     END AS traffic_direction,
     NULL AS segment_locational_status,
-    NULL AS feature_type_code,
+    CASE
+        WHEN status = '3' THEN '5'
+        WHEN status = '2' AND rwjurisdiction = '3' THEN '6'
+        WHEN status = '9' THEN '9'
+        WHEN rw_type = 10 THEN 'A'
+        WHEN trafdir = 'NV' AND (l_low_hn <> '0' OR l_high_hn <> '0' OR r_low_hn <> '0' OR r_high_hn <> '0') THEN 'W'
+        WHEN rw_type = 14 THEN 'F'
+        WHEN status = '2' AND rwjurisdiction = '5' THEN 'C'
+    END AS feature_type_code,
     centerline.nonped,
     centerline.continuous_parity_flag,
     NULL AS borough_boundary_indicator,

--- a/products/lion/models/staging/_stg.yml
+++ b/products/lion/models/staging/_stg.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+- name: stg__centerline
+  columns:
+  - name: trafdir
+    tests:
+    - accepted_values:
+        values: [ "TF", "FT", "NV", "TW" ]

--- a/products/lion/models/staging/_stg.yml
+++ b/products/lion/models/staging/_stg.yml
@@ -2,8 +2,13 @@ version: 2
 
 models:
 - name: stg__centerline
+  # only columns with tests currently listed
   columns:
   - name: trafdir
     tests:
     - accepted_values:
         values: [ "TF", "FT", "NV", "TW" ]
+  - name: twisted_parity_flag
+    tests:
+    - accepted_values:
+        values: [ "Y", "N" ]


### PR DESCRIPTION
closes #1570 

passing build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14740634292/job/41377502728)

- traffic_dir - all values match prod
- feature_type_code - had to iterate a little (which is always nice - sanity check that I am in fact catching issues with these queries against the prod data) but they all match!
- twisted_parity_flag - all values match prod
- level codes - all values match prod