### PR TITLE
Align `edm-publishing` ingest model with connector

### DIFF
--- a/dcpy/models/lifecycle/ingest.py
+++ b/dcpy/models/lifecycle/ingest.py
@@ -67,7 +67,7 @@ class GenericApiSource(ConnectorSource, extra="forbid"):
 class DEPublished(ConnectorSource, extra="forbid"):
     type: Literal["edm.publishing.published"]
     product: str
-    filename: str
+    filepath: str
 
     def get_key(self) -> str:
         return self.product

--- a/dcpy/test/lifecycle/ingest/shared.py
+++ b/dcpy/test/lifecycle/ingest/shared.py
@@ -51,7 +51,7 @@ class Sources:
     )
     s3 = S3Source(type="s3", bucket=RECIPES_BUCKET, key="inbox/test/test.txt")
     de_publish = DEPublished(
-        type="edm.publishing.published", product=TEST_DATASET_NAME, filename="file.csv"
+        type="edm.publishing.published", product=TEST_DATASET_NAME, filepath="file.csv"
     )
     esri = ESRIFeatureServer(
         type="arcgis_feature_server",

--- a/ingest_templates/dcp_zoningtaxlots.yml
+++ b/ingest_templates/dcp_zoningtaxlots.yml
@@ -15,7 +15,7 @@ ingestion:
   source:
     type: edm.publishing.published
     product: db-zoningtaxlots
-    filename: zoningtaxlot_db.csv
+    filepath: zoningtaxlot_db.csv
   file_format:
     type: csv
   processing_steps:


### PR DESCRIPTION
ztl is our only ingest dataset that currently pulls straight from publishing. Failing on [main](https://github.com/NYCPlanning/data-engineering/actions/runs/14777594762)

fixed [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14778079601)