### PR TITLE
Lion: `2.2.6` & `2.2.8`

### DIFF
--- a/.github/workflows/lion_build.yml
+++ b/.github/workflows/lion_build.yml
@@ -69,20 +69,8 @@ jobs:
         dbt deps
         dbt debug
 
-        echo "Build seed tables"
-        dbt build --select config.materialized:seed --indirect-selection=cautious --full-refresh
-
-        echo "Test source tables"
-        dbt test --select "source:*"
-
-        echo "Build staging tables"
-        dbt build --select staging
-
-        echo "Build intermediate tables"
-        dbt build --select intermediate
-
-        echo "Build product tables"
-        dbt build --select product
+        echo "Run full dbt build"
+        dbt build --full-refresh
 
     - name: Export
       run: |

--- a/products/lion/models/intermediate/2.2.3/_int_223.yml
+++ b/products/lion/models/intermediate/2.2.3/_int_223.yml
@@ -4,7 +4,11 @@ models:
   columns:
   - name: segmentid
     tests: [ unique, not_null ]
+  - name: centerline_segment_borocode
+    tests:
+    - not_null
   - name: left_atomicid
+  - name: left_borocode
   - name: left_2000_census_tract
     tests:
     - dbt_expectations.expect_column_value_lengths_to_equal:
@@ -27,6 +31,7 @@ models:
   - name: left_election_district
   - name: left_school_district
   - name: right_atomicid
+  - name: right_borocode
   - name: right_2000_census_tract
     tests:
     - dbt_expectations.expect_column_value_lengths_to_equal:
@@ -55,6 +60,7 @@ models:
 - name: int__centerline_offsets
   columns:
   - name: segmentid
+  - name: boroughcode
   - name: left_line
   - name: right_line
   - name: left_offset_point

--- a/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
+++ b/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
@@ -10,7 +10,7 @@ WITH centerline_offsets AS (
 
 SELECT
     co.segmentid,
-    co.boroughcode as centerline_segment_borocode,
+    co.boroughcode AS centerline_segment_borocode,
     left_poly.atomicid AS left_atomicid,
     left_poly.borough AS left_borocode,
     left_poly.censustract_2000 AS left_2000_census_tract,

--- a/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
+++ b/products/lion/models/intermediate/2.2.3/int__centerline_atomicpolygons.sql
@@ -10,7 +10,9 @@ WITH centerline_offsets AS (
 
 SELECT
     co.segmentid,
+    co.boroughcode as centerline_segment_borocode,
     left_poly.atomicid AS left_atomicid,
+    left_poly.borough AS left_borocode,
     left_poly.censustract_2000 AS left_2000_census_tract,
     left(left_poly.censustract_2000, 4)::INT AS left_2000_census_tract_basic,
     nullif(right(left_poly.censustract_2000, 2), '00')::INT AS left_2000_census_tract_suffix,
@@ -30,6 +32,7 @@ SELECT
     left_poly.electdist AS left_election_district,
     left_poly.schooldist AS left_school_district,
     right_poly.atomicid AS right_atomicid,
+    right_poly.borough AS right_borocode,
     right_poly.censustract_2000 AS right_2000_census_tract,
     left(right_poly.censustract_2000, 4)::INT AS right_2000_census_tract_basic,
     nullif(right(right_poly.censustract_2000, 2), '00')::INT AS right_2000_census_tract_suffix,

--- a/products/lion/models/intermediate/2.2.3/int__centerline_offsets.sql
+++ b/products/lion/models/intermediate/2.2.3/int__centerline_offsets.sql
@@ -23,6 +23,7 @@ WITH centerline AS (
 parallel_lines AS (
     SELECT
         segmentid,
+        boroughcode,
         st_offsetcurve(geom, 2, 'quad_segs=4') AS left_line,
         st_offsetcurve(geom, -2, 'quad_segs=4') AS right_line
     FROM centerline
@@ -31,6 +32,7 @@ parallel_lines AS (
 offset_points AS (
     SELECT
         segmentid,
+        boroughcode,
         left_line,
         right_line,
         st_lineinterpolatepoint(left_line, 0.5) AS left_offset_point,

--- a/products/lion/models/intermediate/2.2.6/_int_226.yml
+++ b/products/lion/models/intermediate/2.2.6/_int_226.yml
@@ -1,0 +1,9 @@
+models:
+- name: int__centerline_segment_locational_status
+  description: |
+    Centerline segments with Locational Status & Borough Boundary Indicator columns.
+  columns:
+  - name: segmentid
+    tests: [ unique, not_null ]
+  - name: borough_boundary_indicator
+  - name: segment_locational_status

--- a/products/lion/models/intermediate/2.2.6/_int_226.yml
+++ b/products/lion/models/intermediate/2.2.6/_int_226.yml
@@ -19,6 +19,9 @@ models:
     tests:
       - accepted_values:
           values: ['9', 'H', 'I', '1', '2', '3', '4', '5', 'X']
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+     compare_model: ref("int__centerline_atomicpolygons")
 
 - name: int__centerline_segment_neighbors
   description: |

--- a/products/lion/models/intermediate/2.2.6/_int_226.yml
+++ b/products/lion/models/intermediate/2.2.6/_int_226.yml
@@ -13,6 +13,8 @@ models:
     tests:
       - accepted_values:
           values: [ False ]
+          config:
+            severity: warn
   - name: segment_locational_status
     tests:
       - accepted_values:

--- a/products/lion/models/intermediate/2.2.6/_int_226.yml
+++ b/products/lion/models/intermediate/2.2.6/_int_226.yml
@@ -6,4 +6,11 @@ models:
   - name: segmentid
     tests: [ unique, not_null ]
   - name: borough_boundary_indicator
+    tests:
+      - accepted_values:
+          values: ['R', 'L']
+  - name: is_ap_boro_boundary_error
+    tests:
+      - accepted_values:
+          values: [ False ]
   - name: segment_locational_status

--- a/products/lion/models/intermediate/2.2.6/_int_226.yml
+++ b/products/lion/models/intermediate/2.2.6/_int_226.yml
@@ -18,3 +18,12 @@ models:
       - accepted_values:
           values: ['9', 'H', 'I', '1', '2', '3', '4', '5', 'X']
 
+- name: int__centerline_segment_neighbors
+  description: |
+    Centerline segments with offset nodes mapped to the neighboring segments.
+    Only contains segments having both offset nodes.
+  columns:
+  - name: segmentid
+  - name: node
+  - name: to_segment
+  - name: node_missing_neighbor

--- a/products/lion/models/intermediate/2.2.6/_int_226.yml
+++ b/products/lion/models/intermediate/2.2.6/_int_226.yml
@@ -14,3 +14,7 @@ models:
       - accepted_values:
           values: [ False ]
   - name: segment_locational_status
+    tests:
+      - accepted_values:
+          values: ['9', 'H', 'I', '1', '2', '3', '4', '5', 'X']
+

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
@@ -1,0 +1,86 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['segmentid']},
+    ]
+) }}
+WITH atomicpolygons AS (
+    SELECT
+        segmentid,
+        centerline_segment_borocode AS centerline_borocode,
+        left_atomicid,
+        left_borocode,
+        left_2020_census_tract,
+        right_atomicid,
+        right_borocode,
+        right_2020_census_tract
+    FROM {{ ref("int__centerline_atomicpolygons") }}
+),
+-- TODO:
+-- Create CTE with atomicpolygons and indicator for segment endpoints intersecting other segments
+
+-- All CTEs below divide the atomicpolygons into different categories. 
+-- When unioned together, they should have 1-1 match with atomicpolygons
+left_city_boundary_aps AS (
+    SELECT 
+        *,
+        NULL AS borough_boundary_indicator,
+        NULL AS segment_locational_status
+    FROM atomicpolygons
+    WHERE left_atomicid IS NULL AND right_atomicid IS NOT NULL
+
+),
+right_city_boundary_aps AS (
+    SELECT
+        *,
+        NULL AS borough_boundary_indicator,
+        NULL AS segment_locational_status
+    FROM atomicpolygons
+    WHERE left_atomicid IS NOT NULL AND right_atomicid IS NULL
+),
+same_ap AS (
+    SELECT
+        *,
+        NULL AS borough_boundary_indicator,
+        NULL AS segment_locational_status
+    FROM atomicpolygons
+    WHERE left_atomicid = right_atomicid
+),
+different_aps_different_boros AS (
+    SELECT
+        *,
+        NULL AS borough_boundary_indicator,
+        NULL AS segment_locational_status
+    FROM atomicpolygons
+    WHERE left_atomicid <> right_atomicid AND left_borocode <> right_borocode   -- borocode alone should be sufficient but who knows...
+),
+different_aps_same_boro AS (
+    SELECT
+        *,
+        NULL AS borough_boundary_indicator,
+        NULL AS segment_locational_status
+    FROM atomicpolygons
+    WHERE left_atomicid <> right_atomicid AND left_borocode = right_borocode
+),
+-- the CTE below accounts for erroneous segments. This is done for 1-1 matching with the segments table
+segments_without_aps AS (
+    SELECT
+        *,
+        NULL AS borough_boundary_indicator,
+        true AS is_ap_boro_boundary_error,
+        NULL AS segment_locational_status
+    FROM atomicpolygons
+    WHERE left_atomicid IS NULL AND right_atomicid IS NULL
+)
+
+SELECT * FROM left_city_boundary_aps
+UNION
+SELECT * FROM right_city_boundary_aps
+UNION
+SELECT * FROM same_ap
+UNION
+SELECT * FROM different_aps_different_boros
+UNION
+SELECT * FROM different_aps_same_boro
+UNION
+SELECT * FROM segments_without_aps

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
@@ -104,13 +104,13 @@ segments_without_aps AS (
 )
 
 SELECT * FROM left_city_boundary_aps
-UNION
+UNION ALL
 SELECT * FROM right_city_boundary_aps
-UNION
+UNION ALL
 SELECT * FROM same_ap
-UNION
+UNION ALL
 SELECT * FROM different_aps_different_boros
-UNION
+UNION ALL
 SELECT * FROM different_aps_same_boro
-UNION
+UNION ALL
 SELECT * FROM segments_without_aps

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
@@ -66,17 +66,13 @@ different_aps_different_boros AS (
     SELECT
         *,
         CASE
-            WHEN centerline_borocode <> left_borocode AND centerline_borocode = right_borocode THEN 'L'
-            WHEN centerline_borocode = left_borocode AND centerline_borocode <> right_borocode THEN 'R'
+            WHEN centerline_borocode = right_borocode THEN 'L'
+            WHEN centerline_borocode = left_borocode THEN 'R'
         END AS borough_boundary_indicator,
         centerline_borocode <> left_borocode AND centerline_borocode <> right_borocode AS is_ap_boro_boundary_error,
         CASE
-            WHEN
-                centerline_borocode <> left_borocode AND centerline_borocode = right_borocode
-                THEN left_borocode::char(1)
-            WHEN
-                centerline_borocode = left_borocode AND centerline_borocode <> right_borocode
-                THEN right_borocode::char(1)
+            WHEN centerline_borocode = right_borocode THEN left_borocode::char(1)
+            WHEN centerline_borocode = left_borocode THEN right_borocode::char(1)
         END AS segment_locational_status
     FROM atomicpolygons
     WHERE left_atomicid <> right_atomicid AND left_borocode <> right_borocode   -- borocode alone should be sufficient but who knows...

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
@@ -30,7 +30,7 @@ segments_with_orphan_node AS (
 -- All CTEs below divide the atomicpolygons into different categories. 
 -- When unioned together, they should have 1-1 match with atomicpolygons
 left_city_boundary_aps AS (
-    SELECT 
+    SELECT
         *,
         'L' AS borough_boundary_indicator,
         NULL::boolean AS is_ap_boro_boundary_error,
@@ -65,14 +65,18 @@ same_ap AS (
 different_aps_different_boros AS (
     SELECT
         *,
-        CASE 
+        CASE
             WHEN centerline_borocode <> left_borocode AND centerline_borocode = right_borocode THEN 'L'
             WHEN centerline_borocode = left_borocode AND centerline_borocode <> right_borocode THEN 'R'
         END AS borough_boundary_indicator,
         centerline_borocode <> left_borocode AND centerline_borocode <> right_borocode AS is_ap_boro_boundary_error,
-        CASE 
-            WHEN centerline_borocode <> left_borocode AND centerline_borocode = right_borocode THEN left_borocode::CHAR(1)
-            WHEN centerline_borocode = left_borocode AND centerline_borocode <> right_borocode THEN right_borocode::CHAR(1)
+        CASE
+            WHEN
+                centerline_borocode <> left_borocode AND centerline_borocode = right_borocode
+                THEN left_borocode::char(1)
+            WHEN
+                centerline_borocode = left_borocode AND centerline_borocode <> right_borocode
+                THEN right_borocode::char(1)
         END AS segment_locational_status
     FROM atomicpolygons
     WHERE left_atomicid <> right_atomicid AND left_borocode <> right_borocode   -- borocode alone should be sufficient but who knows...
@@ -93,7 +97,7 @@ segments_without_aps AS (
     SELECT
         *,
         NULL AS borough_boundary_indicator,
-        true AS is_ap_boro_boundary_error,
+        TRUE AS is_ap_boro_boundary_error,
         NULL AS segment_locational_status
     FROM atomicpolygons
     WHERE left_atomicid IS NULL AND right_atomicid IS NULL

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_locational_status.sql
@@ -26,7 +26,7 @@ left_city_boundary_aps AS (
         *,
         'L' AS borough_boundary_indicator,
         NULL::boolean AS is_ap_boro_boundary_error,
-        NULL AS segment_locational_status
+        '9' AS segment_locational_status
     FROM atomicpolygons
     WHERE left_atomicid IS NULL AND right_atomicid IS NOT NULL
 
@@ -36,7 +36,7 @@ right_city_boundary_aps AS (
         *,
         'R' AS borough_boundary_indicator,
         NULL::boolean AS is_ap_boro_boundary_error,
-        NULL AS segment_locational_status
+        '9' AS segment_locational_status
     FROM atomicpolygons
     WHERE left_atomicid IS NOT NULL AND right_atomicid IS NULL
 ),
@@ -57,7 +57,11 @@ different_aps_different_boros AS (
             WHEN centerline_borocode = left_borocode AND centerline_borocode <> right_borocode THEN 'R'
         END AS borough_boundary_indicator,
         centerline_borocode <> left_borocode AND centerline_borocode <> right_borocode AS is_ap_boro_boundary_error,
-        NULL AS segment_locational_status
+        CASE 
+            WHEN centerline_borocode <> left_borocode AND centerline_borocode = right_borocode THEN left_borocode::CHAR(1)
+            WHEN centerline_borocode = left_borocode AND centerline_borocode <> right_borocode THEN right_borocode::CHAR(1)
+        END AS borough_boundary_indicator,
+        END AS segment_locational_status
     FROM atomicpolygons
     WHERE left_atomicid <> right_atomicid AND left_borocode <> right_borocode   -- borocode alone should be sufficient but who knows...
 ),
@@ -66,7 +70,9 @@ different_aps_same_boro AS (
         *,
         NULL AS borough_boundary_indicator,
         centerline_borocode <> left_borocode AS is_ap_boro_boundary_error,
-        NULL AS segment_locational_status
+        CASE
+            WHEN left_2020_census_tract <> right_2020_census_tract THEN 'X'
+        END AS segment_locational_status
     FROM atomicpolygons
     WHERE left_atomicid <> right_atomicid AND left_borocode = right_borocode
 ),

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_neighbors.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_neighbors.sql
@@ -17,7 +17,7 @@ segment_end_nodes_unpivoted AS (
         segmentid,
         from_nodeid AS node
     FROM segment_end_nodes_pivoted
-    UNION
+    UNION ALL
     SELECT
         segmentid,
         to_nodeid AS node

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_neighbors.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_neighbors.sql
@@ -1,0 +1,35 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['segmentid']},
+    ]
+) }}
+WITH segment_end_nodes_pivoted AS (
+    SELECT
+        segmentid,
+        from_nodeid,
+        to_nodeid
+    FROM {{ ref("int__centerline_segments_with_nodes") }}
+    WHERE from_nodeid IS NOT NULL AND to_nodeid IS NOT NULL
+),
+segment_end_nodes_unpivoted AS (
+    SELECT 
+        segmentid,
+        from_nodeid AS node
+    FROM segment_end_nodes_pivoted
+    UNION
+    SELECT
+        segmentid,
+        to_nodeid as node
+    FROM segment_end_nodes_pivoted
+)
+SELECT
+    segment_to_node.segmentid,
+    segment_to_node.node,
+    node_to_segment.segmentid AS to_segment,
+    CASE
+        WHEN node_to_segment.segmentid IS NULL THEN 1 ELSE 0
+    END AS node_missing_neighbor
+FROM segment_end_nodes_unpivoted AS segment_to_node
+LEFT JOIN segment_end_nodes_unpivoted AS node_to_segment
+ON segment_to_node.node = node_to_segment.node AND segment_to_node.segmentid <> node_to_segment.segmentid

--- a/products/lion/models/intermediate/2.2.6/int__centerline_segment_neighbors.sql
+++ b/products/lion/models/intermediate/2.2.6/int__centerline_segment_neighbors.sql
@@ -13,14 +13,14 @@ WITH segment_end_nodes_pivoted AS (
     WHERE from_nodeid IS NOT NULL AND to_nodeid IS NOT NULL
 ),
 segment_end_nodes_unpivoted AS (
-    SELECT 
+    SELECT
         segmentid,
         from_nodeid AS node
     FROM segment_end_nodes_pivoted
     UNION
     SELECT
         segmentid,
-        to_nodeid as node
+        to_nodeid AS node
     FROM segment_end_nodes_pivoted
 )
 SELECT
@@ -32,4 +32,4 @@ SELECT
     END AS node_missing_neighbor
 FROM segment_end_nodes_unpivoted AS segment_to_node
 LEFT JOIN segment_end_nodes_unpivoted AS node_to_segment
-ON segment_to_node.node = node_to_segment.node AND segment_to_node.segmentid <> node_to_segment.segmentid
+    ON segment_to_node.node = node_to_segment.node AND segment_to_node.segmentid <> node_to_segment.segmentid

--- a/products/lion/models/product/dat/_dat.yml
+++ b/products/lion/models/product/dat/_dat.yml
@@ -222,8 +222,9 @@ models:
   - name: '"Segment Locational Status"'
     data_type: string
     tests:
-    - dbt_expectations.expect_column_value_lengths_to_equal:
-        value: 1
+    - accepted_values:
+        # this enforces length as well
+        values: [ " ", "9", "H", "I", "1", "2", "3", "4", "5", "X" ]
   - name: '"Feature Type Code"'
     data_type: string
     tests:
@@ -248,8 +249,8 @@ models:
   - name: '"Borough Boundary Indicator"'
     data_type: string
     tests:
-    - dbt_expectations.expect_column_value_lengths_to_equal:
-        value: 1
+    - accepted_values:
+        values: [ " ", "R", "L" ]
   - name: '"Twisted Parity Flag"'
     data_type: string
     tests:

--- a/products/lion/models/product/lion.sql
+++ b/products/lion/models/product/lion.sql
@@ -36,6 +36,10 @@ sedat AS (
 
 nypd_service_areas AS (
     SELECT * FROM {{ ref("int__centerline_nypdbeat") }}
+),
+
+segment_locational_status AS (
+    SELECT * FROM {{ ref("int__centerline_segment_locational_status") }}
 )
 
 SELECT
@@ -85,7 +89,7 @@ SELECT
         WHEN trafdir = 'NV' THEN 'P'
         WHEN trafdir = 'TW' THEN 'T'
     END AS traffic_direction,
-    NULL AS segment_locational_status,
+    segment_locational_status.segment_locational_status,
     CASE
         WHEN status = '3' THEN '5'
         WHEN status = '2' AND rwjurisdiction = '3' THEN '6'
@@ -97,7 +101,7 @@ SELECT
     END AS feature_type_code,
     centerline.nonped,
     centerline.continuous_parity_flag,
-    NULL AS borough_boundary_indicator,
+    segment_locational_status.borough_boundary_indicator,
     CASE
         WHEN twisted_parity_flag = 'Y' THEN 'T'
     END AS twisted_parity_flag,
@@ -180,3 +184,4 @@ LEFT JOIN curve ON centerline.segmentid = curve.segmentid
 LEFT JOIN streets ON centerline.segmentid = streets.segmentid
 LEFT JOIN sedat ON centerline.segmentid = sedat.segmentid AND centerline.boroughcode = sedat.boroughcode
 LEFT JOIN nypd_service_areas ON centerline.segmentid = nypd_service_areas.segmentid
+LEFT JOIN segment_locational_status ON centerline.segmentid = segment_locational_status.segmentid


### PR DESCRIPTION
Related to #1571

Successful [build](https://github.com/NYCPlanning/data-engineering/actions/runs/14851255477/job/41695181946)

This PR adds 2 fields to the `lion` table. 

For the most part, the logic between the 2 fields is very similar: it's based on a segment's atomic polygons. For `2.2.6`, commit with part || covers the case when a segment is within same atomic polygon and the output value depends on whether the segment is a dead-end (There are no other segments attached to it). 

I added the tables in red:

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/a1a98f06-5b6f-41fa-8698-693afc385c12" />

### Testing data

Please refer to the issue. There is a mismatch for the `Borough Boundary Indicator` field due to underlying atomic polygons. 