### PR TITLE
CEQR: Add Remaining Chapters

### DIFF
--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -80,3 +80,8 @@ inputs:
     - name: nysdot_annual_average_daily_trafic
     - name: panynj_jfk_65db # Airport noise zone - JFK
     - name: panynj_lga_65db # Airport noise zone - LGA
+    - name: dep_cats_permits
+    - name: nysdec_state_facility_permits
+    - name: nysdec_title_v_facility_permits
+    - name: dcp_air_quality_vent_towers
+    - name: dcm_arterial_highways

--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -9,6 +9,8 @@ inputs:
     file_type: parquet
 
   datasets:
+    - name: dcp_edesignation_csv
+    - name: dcp_cscl_complex
     - name: dcp_mappluto_clipped
     - name: dcp_green_fast_track_lots
     - name: dcp_projects
@@ -76,3 +78,5 @@ inputs:
     - name: dot_traffic_sample_volume_counts
     - name: dot_truck_routes
     - name: nysdot_annual_average_daily_trafic
+    - name: panynj_jfk_65db # Airport noise zone - JFK
+    - name: panynj_lga_65db # Airport noise zone - LGA

--- a/products/ceqr/seeds/chapter_datasets.csv
+++ b/products/ceqr/seeds/chapter_datasets.csv
@@ -30,7 +30,7 @@ land_use,Policy,EDC Plans,Public policy evaluation
 land_use,Policy,197-a Plans,Public policy evaluation
 land_use,Policy,Housing New York,Public policy evaluation
 land_use,Policy,Where We Live NYC 2025,Public policy evaluation
-land_use,Base Map,Streets,Location Maps
+land_use,Base Map,DCP LION,Location Maps (Streets)
 land_use,Base Map,Borough Boundaries,Location Maps
 land_use,Base Map,DPR Parks Properties,Location Maps
 land_use,Base Map,Subways,Location Maps
@@ -143,7 +143,7 @@ water_and_sewer,Stormwater,Stormwater Flood Map - Limited Current Sea Levels,Con
 water_and_sewer,Sewer,Facilities Database,identifying the wastewater resource recovery facilities that the project is near
 water_and_sewer,Sewer,Open Sewer Atlas,Various data related to DEP infrastructure and policy
 water_and_sewer,Worksheet,Water and sewer calculations,For sewer and stormwater calculations
-transportation,Base Map,Streets,Location Maps 
+transportation,Base Map,DCP LION,Location Maps (Streets)
 transportation,Base Map,Subways,Study area transportation
 transportation,Base Map,Railroads,Study area transportation
 transportation,Base Map,Buses,Study area transportation
@@ -168,7 +168,7 @@ transportation,Basemap,Roadbeds,Location Maps
 transportation,Existing and No Action Condition,DCP Housing and Population Projections,"A workbook for use in establishing the existing and no action condition housing and population characteristics within various study areas. Combines our best available population data, housing permit data, and assumptions about household size and vacancy to estimate current conditions and conditions for build years 3-5 years in the future"
 transportation,Resources,Various DOT Data Feeds,	
 noise,E-Designations,E-Designations,Existing e-designation locations to understand existing conditions on site
-noise,Existing Sources,Exposed Railways,Helpful in determining noise measurement requirements
+noise,Existing Sources,DCP LION,Helpful in determining noise measurement requirements (Exposed Railways)
 noise,Existing Sources,Exposed Railyards,Helpful in determining noise measurement requirements
 noise,Existing Sources,Airport Noise Zone - JFK,Helpful in determining noise measurement requirements
 noise,Existing Sources,Airport Noise Zone - LGA,Helpful in determining noise measurement requirements

--- a/products/ceqr/seeds/chapter_datasets.csv
+++ b/products/ceqr/seeds/chapter_datasets.csv
@@ -172,3 +172,10 @@ noise,Existing Sources,Exposed Railways,Helpful in determining noise measurement
 noise,Existing Sources,Exposed Railyards,Helpful in determining noise measurement requirements
 noise,Existing Sources,Airport Noise Zone - JFK,Helpful in determining noise measurement requirements
 noise,Existing Sources,Airport Noise Zone - LGA,Helpful in determining noise measurement requirements
+air_quality,E-Designations,E-Designations,Existing e-designation locations to understand existing conditions on site
+air_quality,Permits,CATS Permits,Existing industrial source locations for assessment
+air_quality,Permits,DEC State Facilities,Existing industrial source locations for assessment
+air_quality,Permits,Title V Permits,Existing industrial source locations for assessment
+air_quality,Existing Sources,Vent Tower Data,Identifying stationary source
+air_quality,Existing Sources,Arterial Highways,Identifying source
+air_quality,Land Use,MapPLUTO Shoreline Clipped,Helpful for understanding potential unpermitted sources

--- a/products/ceqr/seeds/chapter_datasets.csv
+++ b/products/ceqr/seeds/chapter_datasets.csv
@@ -167,3 +167,8 @@ transportation,Traffic,DOT Current Projects,No-Action condition changes to trans
 transportation,Basemap,Roadbeds,Location Maps 
 transportation,Existing and No Action Condition,DCP Housing and Population Projections,"A workbook for use in establishing the existing and no action condition housing and population characteristics within various study areas. Combines our best available population data, housing permit data, and assumptions about household size and vacancy to estimate current conditions and conditions for build years 3-5 years in the future"
 transportation,Resources,Various DOT Data Feeds,	
+noise,E-Designations,E-Designations,Existing e-designation locations to understand existing conditions on site
+noise,Existing Sources,Exposed Railways,Helpful in determining noise measurement requirements
+noise,Existing Sources,Exposed Railyards,Helpful in determining noise measurement requirements
+noise,Existing Sources,Airport Noise Zone - JFK,Helpful in determining noise measurement requirements
+noise,Existing Sources,Airport Noise Zone - LGA,Helpful in determining noise measurement requirements

--- a/products/ceqr/seeds/chapter_datasets.csv
+++ b/products/ceqr/seeds/chapter_datasets.csv
@@ -179,3 +179,4 @@ air_quality,Permits,Title V Permits,Existing industrial source locations for ass
 air_quality,Existing Sources,Vent Tower Data,Identifying stationary source
 air_quality,Existing Sources,Arterial Highways,Identifying source
 air_quality,Land Use,MapPLUTO Shoreline Clipped,Helpful for understanding potential unpermitted sources
+hazmat,E-Designations,E-Designations,Existing e-designation locations to understand existing conditions on site

--- a/products/ceqr/seeds/chapters.csv
+++ b/products/ceqr/seeds/chapters.csv
@@ -11,3 +11,4 @@ water_and_sewer,Water and Sewer Infrastructure
 transportation,Transportation
 noise,Noise
 air_quality,Air Quality
+hazmat,Hazardous Materials

--- a/products/ceqr/seeds/chapters.csv
+++ b/products/ceqr/seeds/chapters.csv
@@ -9,3 +9,4 @@ historic_resources,Historic and Cultural Resources
 natural_resources,Natural Resources
 water_and_sewer,Water and Sewer Infrastructure
 transportation,Transportation
+noise,Noise

--- a/products/ceqr/seeds/chapters.csv
+++ b/products/ceqr/seeds/chapters.csv
@@ -10,3 +10,4 @@ natural_resources,Natural Resources
 water_and_sewer,Water and Sewer Infrastructure
 transportation,Transportation
 noise,Noise
+air_quality,Air Quality

--- a/products/ceqr/seeds/datasets.csv
+++ b/products/ceqr/seeds/datasets.csv
@@ -26,7 +26,7 @@ EDC Plans,,webpage,,,https://edc.nyc/explore-our-work
 197-a Plans,,webpage,,,https://www.nyc.gov/site/planning/community/community-based-planning.page
 Housing New York,,webpage,,,https://www.nyc.gov/site/housing/index.page
 Where We Live NYC 2025,,webpage,,,https://wherewelive.cityofnewyork.us/
-Streets,dcp_lion,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-lion.page
+DCP LION,dcp_lion,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-lion.page
 Borough Boundaries,dcp_boroboundaries,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page
 DPR Parks Properties,dpr_parksproperties,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/Recreation/Parks-Properties/enfh-gkve/about_data
 Subways,,webpage,,,https://www.mta.info/developers
@@ -125,7 +125,6 @@ Hourly Bus Ridership 2020-2024,,webpage,,,https://data.ny.gov/Transportation/MTA
 DOT Current Projects,,webpage,,,https://www.nyc.gov/html/dot/html/about/current-projects.shtml
 Various DOT Data Feeds,,webpage,,,https://www.nyc.gov/html/dot/html/about/datafeeds.shtml
 E-Designations,dcp_edesignation_csv,download,csv,,https://www.nyc.gov/content/planning/pages/resources/datasets/e-designations
-Exposed Railways,dcp_lion,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-lion.page
 Exposed Railyards,dcp_cscl_complex,download,shapefile,MULTIPOLYGON,https://nycmaps.nyc.gov/datasets/nyc::complex/about
 Airport Noise Zone - JFK,panynj_jfk_65db,download,shapefile,MULTIPOLYGON,
 Airport Noise Zone - LGA,panynj_lga_65db,download,shapefile,MULTIPOLYGON,

--- a/products/ceqr/seeds/datasets.csv
+++ b/products/ceqr/seeds/datasets.csv
@@ -129,3 +129,8 @@ Exposed Railways,dcp_lion,download,shapefile,MULTILINESTRING,https://www.nyc.gov
 Exposed Railyards,dcp_cscl_complex,download,shapefile,MULTIPOLYGON,https://nycmaps.nyc.gov/datasets/nyc::complex/about
 Airport Noise Zone - JFK,panynj_jfk_65db,download,shapefile,MULTIPOLYGON,
 Airport Noise Zone - LGA,panynj_lga_65db,download,shapefile,MULTIPOLYGON,
+CATS Permits,dep_cats_permits,download,csv,,https://gisservices.dec.ny.gov/gis/dil/
+DEC State Facilities,nysdec_state_facility_permits,download,csv,,https://gisservices.dec.ny.gov/gis/dil/
+Title V Permits,nysdec_title_v_facility_permits,download,csv,,https://gisservices.dec.ny.gov/gis/dil/
+Vent Tower Data,dcp_air_quality_vent_towers,download,shapefile,MULTIPOLYGON,
+Arterial Highways,dcm_arterial_highways,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-digital-city-map.page

--- a/products/ceqr/seeds/datasets.csv
+++ b/products/ceqr/seeds/datasets.csv
@@ -124,3 +124,8 @@ Hourly Subway Ridership 2020-2024,,webpage,,,https://data.ny.gov/Transportation/
 Hourly Bus Ridership 2020-2024,,webpage,,,https://data.ny.gov/Transportation/MTA-Bus-Hourly-Ridership-2020-2024/kv7t-n8in/about_data
 DOT Current Projects,,webpage,,,https://www.nyc.gov/html/dot/html/about/current-projects.shtml
 Various DOT Data Feeds,,webpage,,,https://www.nyc.gov/html/dot/html/about/datafeeds.shtml
+E-Designations,dcp_edesignation_csv,download,csv,,https://www.nyc.gov/content/planning/pages/resources/datasets/e-designations
+Exposed Railways,dcp_lion,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-lion.page
+Exposed Railyards,dcp_cscl_complex,download,shapefile,MULTIPOLYGON,https://nycmaps.nyc.gov/datasets/nyc::complex/about
+Airport Noise Zone - JFK,panynj_jfk_65db,download,shapefile,MULTIPOLYGON,
+Airport Noise Zone - LGA,panynj_lga_65db,download,shapefile,MULTIPOLYGON,


### PR DESCRIPTION
Closes #1649
Closes #1650
Closes #1651 

### What
Add remaining 3 chapters and its datasets (colored with green) from the "DE Chapter Datasets" & "DE Datasets" tabs of the [Data Sources excel file](https://nyco365.sharepoint.com/:x:/r/sites/NYCPLANNING/cp/_layouts/15/Doc.aspx?sourcedoc=%7BE9735A2D-C211-4F87-B0B5-095FE8BBC7FF%7D&file=Data%20Sources.xlsx&action=default&mobileredirect=true).

### Testing
- Successful CEQR build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/14938225125/job/41970489261) 
- Generated by the CEQR build markdown files: 
    - [chapters_tables.md](https://github.com/user-attachments/files/20129604/chapters_tables.md)
    - [datasets_table.md](https://github.com/user-attachments/files/20129605/datasets_table.md)



### TODO:
After merging to `main`:
- [ ] update the excel file (remove colors)
- [ ] run and promote CEQR build to drafts folder
- [ ] put CEQR build files into CEQR bucket 
- [ ] update CEQR hub repo
- [ ] re-deploy CEQR Hub