### PR TITLE
simpler check if version exists

### DIFF
--- a/dcpy/lifecycle/ingest/validate.py
+++ b/dcpy/lifecycle/ingest/validate.py
@@ -15,8 +15,7 @@ def validate_against_existing_version(ds: str, version: str, filepath: Path) -> 
     The last archived dataset with the same version is pulled in by pandas and compared to what was just processed
     If they differ, an error is raised
     """
-    existing_config = processed_datastore.try_get_config(ds, version)
-    if existing_config:
+    if processed_datastore.version_exists(ds, version):
         with TemporaryDirectory() as tmp:
             existing_file = processed_datastore.pull_versioned(ds, version, Path(tmp))[
                 "path"


### PR DESCRIPTION
Failed ZTL data loading action because structure of old config changed slightly, and this function that was checking existence of older version was failing because it attempted to read the entire config object. Per an earlier PR (will link), we decided it was simpler to minimize interaction with obsolete config objects when possible rather than maintain backwards compatibility with our pydantic models