### PR TITLE
gru page refresh

### DIFF
--- a/apps/qa/src/pages/gru/components.py
+++ b/apps/qa/src/pages/gru/components.py
@@ -86,9 +86,17 @@ def check_table(workflows: dict[str, WorkflowRun], geosupport_version: str) -> N
                         st.error("Not found")
 
                 filenames = sorted(s3.get_filenames(bucket, s3_folder))
+
+                def get_url(f: str) -> str:
+                    """
+                    page refreshes every 10 min as set in gru.py
+                    urls valid just past that
+                    """
+                    return s3.get_presigned_get_url(bucket, f"{s3_folder}/{f}", 610)
+
                 files = "  \n".join(
                     [
-                        f"[{filename}]({s3.get_presigned_get_url(bucket, f'{s3_folder}/{filename}')})"
+                        f"[{filename}]({get_url(filename)})"
                         for filename in filenames
                         if filename != "versions.csv"
                     ]

--- a/apps/qa/src/pages/gru/components.py
+++ b/apps/qa/src/pages/gru/components.py
@@ -64,14 +64,14 @@ def check_table(workflows: dict[str, WorkflowRun], geosupport_version: str) -> N
             name.write(check["display_name"])
 
             s3_folder = f"db-gru-qaqc/{geosupport_version}/{action_name}/latest"
-            http_path = (
-                f"https://edm-publishing.nyc3.digitaloceanspaces.com/{s3_folder}"
-            )
 
             if not running:
                 with sources:
                     try:
-                        versions = pd.read_csv(f"{http_path}/versions.csv")
+                        path = s3.get_presigned_get_url(
+                            bucket, f"{s3_folder}/versions.csv", 5
+                        )
+                        versions = pd.read_csv(path)
                         st.download_button(
                             label="\n".join(check["sources"]),
                             data=versions.to_csv(index=False).encode("utf-8"),
@@ -88,7 +88,7 @@ def check_table(workflows: dict[str, WorkflowRun], geosupport_version: str) -> N
                 filenames = sorted(s3.get_filenames(bucket, s3_folder))
                 files = "  \n".join(
                     [
-                        f"[{filename}]({http_path}/{filename})"
+                        f"[{filename}]({s3.get_presigned_get_url(bucket, f'{s3_folder}/{filename}')})"
                         for filename in filenames
                         if filename != "versions.csv"
                     ]

--- a/apps/qa/src/pages/gru/constants.py
+++ b/apps/qa/src/pages/gru/constants.py
@@ -1,59 +1,46 @@
 import pandas as pd
 
+bucket = "edm-publishing"
 qa_checks = pd.DataFrame(
     [
         (
             "Address Points vs PAD",
             "address-points-vs-pad",
-            ["rejects_pad_addrpts", "geocode_bin_diffs_pad_addrpts"],
             ["dcp_addresspoints"],
         ),
         (
             "Address Points (Spatial) vs GRID",
             "addresses-spatial",
-            ["geocode_diffs_address_spatial"],
             ["dcp_atomicpolygons", "dcp_addresspoints"],
         ),
         (
             "Footprint BINs vs PAD",
             "footprints-vs-pad",
-            ["rejects_footprintbin_padbin"],
             ["doitt_buildingfootprints"],
         ),
         (
             "Historical Footprint BINs vs PAD",
             "historical-footprints-vs-pad",
-            ["all_results_historicalfootprintbin_padbin"],
             ["doitt_buildingfootprints_historical", "doitt_buildingfootprints"],
         ),
-        ("TBINs vs. C/Os", "housing", ["tbins_certf_occp"], ["dcp_developments"]),
+        ("TBINs vs. C/Os", "housing", ["dcp_developments"]),
         (
             "PAD BINs vs Footprint BINs",
             "pad-vs-footprint",
-            ["rejects_padbin_footprintbin"],
             ["doitt_buildingfootprints", "dcp_pad"],
         ),
         (
             "DCM Names vs SND Names",
             "dcm-streetname",
-            ["rejects_sn_dcm_snd"],
             ["dcp_dcmstreetcenterline"],
         ),
         (
             "Generic SAF Addresses vs PAD Roadbed SAF Addresses vs PAD",
             "saf-vs-pad",
-            [
-                "saf_gen_1A_pad",
-                "saf_gen_1R_pad",
-                "saf_gen_1_pad",
-                "saf_rb_1A_pad",
-                "saf_rb_1R_pad",
-                "saf_rb_1_pad",
-            ],
             ["dcp_saf"],
         ),
     ],
-    columns=["display_name", "action_name", "files", "sources"],
+    columns=["display_name", "action_name", "sources"],
 )
 
 readme_markdown_text = """### Source Data Info

--- a/apps/qa/src/pages/gru/gru.py
+++ b/apps/qa/src/pages/gru/gru.py
@@ -44,6 +44,12 @@ Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
     st.markdown(readme_markdown_text)
 
     # this state gets set when an action is triggered, set to false once it's complete
-    while any([workflow.is_running for workflow in workflows.values()]):
+    running = any([workflow.is_running for workflow in workflows.values()])
+    while running:
         time.sleep(5)
+        st.rerun()
+
+    # refresh after 10 min
+    while not running:
+        time.sleep(600)
         st.rerun()

--- a/apps/qa/src/pages/gru/helpers.py
+++ b/apps/qa/src/pages/gru/helpers.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import time
 import streamlit as st
 import requests
@@ -10,26 +11,31 @@ from dcpy.models import library
 from .constants import qa_checks
 
 
-def get_source_version(dataset: str) -> library.ArchivalMetadata:
+def get_source_version(dataset: str) -> dict:
     if dataset == "dcp_saf":
         bucket = "edm-publishing"
         prefix = "gru/dcp_saf/"
         folders = s3.get_subfolders(bucket, prefix)
         if "latest" in folders:
             folders.remove("latest")
-        latest_version = max(folders)
+        version = max(folders)
         timestamp = s3.get_metadata(
-            bucket, f"{prefix}{latest_version}/dcp_saf.zip"
+            bucket, f"{prefix}{version}/dcp_saf.zip"
         ).last_modified
-        return library.ArchivalMetadata(
-            name="dcp_saf", version=latest_version, timestamp=timestamp
-        )
     else:
-        return recipes.get_archival_metadata(dataset)
+        config_obj = recipes.get_config_obj(dataset)
+        if "dataset" in config_obj:
+            version = config_obj["dataset"]["version"]
+            timestamp_str = config_obj["execution_details"]["timestamp"]
+        else:
+            version = config_obj["version"]
+            timestamp_str = config_obj["run_details"]["timestamp"]
+        timestamp = datetime.fromisoformat(timestamp_str)
+    return {"name": dataset, "version": version, "timestamp": timestamp}
 
 
 @st.cache_data(ttl=120)
-def get_source_versions() -> dict[str, library.ArchivalMetadata]:
+def get_source_versions() -> dict[str, dict]:
     versions = {}
     for dataset in [source for sources in qa_checks["sources"] for source in sources]:
         versions[dataset] = get_source_version(dataset)

--- a/apps/qa/src/pages/gru/helpers.py
+++ b/apps/qa/src/pages/gru/helpers.py
@@ -7,7 +7,6 @@ import re
 from dcpy.utils import s3
 from dcpy.connectors import github
 from dcpy.connectors.edm import recipes
-from dcpy.models import library
 from .constants import qa_checks
 
 

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -162,6 +162,14 @@ def get_metadata(bucket: str, key: str) -> Metadata:
     )
 
 
+def get_presigned_get_url(bucket: str, key: str, expires_in: int = 3600) -> str:
+    return client().generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=expires_in,
+    )
+
+
 def get_file(
     bucket: str,
     key: str,


### PR DESCRIPTION
A few things
- wanted to list filenames dynamically since gru has requested renaming some of them in #1391 
- reworked the looking up of archival information to be just a little less finicky. Annoying to lose type safety but these issues weren't being caught anyways because the function that was being used is so unmaintained
- noticed that the page is broken because the bucket no longer defaults to completely publicly available (thanks @alexrichey ). Instead of making these outputs public read, figured it'd make sense to just use presigned urls. Right now am doing them with an hour before they expire, seems perfectly reasonable that someone would need to refresh the page after an hour

It works now locally
![image](https://github.com/user-attachments/assets/25f3566b-273f-4b4a-ac2f-069b109705e5)
