### PR TITLE
unpin a few ceqr source file types

### DIFF
--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -58,7 +58,6 @@ inputs:
       file_type: pg_dump
     - name: dpr_walk_to_a_park
     - name: lpc_landmarks
-      file_type: pg_dump
     - name: lpc_historic_district_areas
     - name: lpc_scenic_landmarks
       file_type: pg_dump

--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -60,7 +60,6 @@ inputs:
     - name: lpc_landmarks
     - name: lpc_historic_district_areas
     - name: lpc_scenic_landmarks
-      file_type: pg_dump
     - name: nysshpo_historic_buildings_points
     - name: nysshpo_historic_buildings_polygons
     - name: nysparks_historicplaces


### PR DESCRIPTION
Two of the datasets pinned to library `pg_dump` in #1670 had its first `ingest` archival over the weekend, meaning the pinned `pg_dump` cannot be found (#1676)

New build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/15115110841/job/42483723860)