### PR TITLE
point geosupport version scraping at new website

### DIFF
--- a/admin/run_environment/docker/config.sh
+++ b/admin/run_environment/docker/config.sh
@@ -10,7 +10,7 @@ function install_geosupport {
         cd /geocode
         FILE_NAME=linux_geo${RELEASE}_${MAJOR}.${MINOR}.zip
         echo $FILE_NAME
-        curl -O https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/$FILE_NAME
+        curl -O https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/geosupport/$FILE_NAME
         unzip *.zip
         rm *.zip
 

--- a/admin/run_environment/docker/geosupport_versions.py
+++ b/admin/run_environment/docker/geosupport_versions.py
@@ -13,10 +13,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-IGNORE_UPAD_RELEASE = (
-    True  # TODO this is temporary while an image with 22c4 UPAD needs to be built
-)
-
 CALLER_ENVIRONMENT_VARIABLE_NAME = "VERSIONSTRING"
 GEOSUPPORT_RELEASE_URL = "https://apps.nyc.gov/content-api/v1/content/planning/resources/geocoding/geosupport-desktop-edition"
 # to convert a release letter to a number for the docker image tag
@@ -56,16 +52,8 @@ if __name__ == "__main__":
         release = upad_release
     else:
         logging.info("WARNING! Mismatch between posted Primary and UPAD releases")
-        # posted UPAD is not meant for current release
-        # TODO this is temporary while an image with 22c4 UPAD needs to be built
-        # note 2025-05 - not sure if this is needed
-        if IGNORE_UPAD_RELEASE:
-            logging.info("Ignoring UPAD release")
-            release = primary_release
-        else:
-            # build for the posted UPAD
-            logging.info("Prioritizing UPAD release")
-            release = upad_release
+        logging.info("Ignoring UPAD release")
+        release = primary_release
 
     logging.info(f"{release=}")
     patch = 0 if len(release) == 3 else release[3]

--- a/admin/run_environment/docker/geosupport_versions.py
+++ b/admin/run_environment/docker/geosupport_versions.py
@@ -1,7 +1,9 @@
 # Get the relevant release details from the Geosupport Open Data page
 # and set an environment variable
 import sys
+import json
 import logging
+import re
 import requests
 from bs4 import BeautifulSoup
 
@@ -16,9 +18,7 @@ IGNORE_UPAD_RELEASE = (
 )
 
 CALLER_ENVIRONMENT_VARIABLE_NAME = "VERSIONSTRING"
-GEOSUPPORT_RELEASE_URL = (
-    "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page"
-)
+GEOSUPPORT_RELEASE_URL = "https://apps.nyc.gov/content-api/v1/content/planning/resources/geocoding/geosupport-desktop-edition"
 # to convert a release letter to a number for the docker image tag
 MINOR_LETTER_LOOKUP = {
     "a": 1,
@@ -27,74 +27,54 @@ MINOR_LETTER_LOOKUP = {
     "d": 4,
 }
 
+
+def get_release_from_section(soup: BeautifulSoup, section: str) -> str:
+    header = soup.find("h2", string=section)
+    assert header, f"No h2 with text '{section}' found"
+    p = header.find_next_sibling()
+    assert p and p.name == "p", "No p section found under header"
+    regex = re.search("Latest Release: ([0-9A-D]+)\\n", p.text)
+    assert regex, "Release text not found"
+    return regex.groups()[0].lower()
+
+
 if __name__ == "__main__":
-    soup = BeautifulSoup(
-        requests.get(GEOSUPPORT_RELEASE_URL).content, features="html.parser"
-    )
-    table = soup.find_all("table", class_="table table-outline-border")[0]
-    releases = [
-        i.string.replace("Release", "").strip().lower()
-        for i in table.find_all("th")
-        if "Release" in i.string
-    ]
+    content = json.loads(requests.get(GEOSUPPORT_RELEASE_URL).content)
+    soup = BeautifulSoup(content["description"], features="lxml")
+    primary_release = get_release_from_section(soup, "Geosupport Desktop")
+    upad_release = get_release_from_section(soup, "TPAD / UPAD")
 
-    logging.info(f"Release titles from Open Data table: {releases}")
+    upad_primary_release = upad_release[:3]  # trim 25A4 to 25A
 
-    if len(releases) == 1:
-        # only one release section present
-        # no UPAD to incorporate
-        release = releases[0]
-        versions = dict(
-            RELEASE=release[:3],
-            MAJOR=release[:2],
-            MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
-            PATCH=0,
-        )
+    logging.info(f"{primary_release=}")
+    logging.info(f"{upad_release=}")
+    logging.info(f"{upad_primary_release=}")
+
+    if primary_release == upad_primary_release:
+        logging.info("Matching Primary and UPAD's Primary releases")
+        # UPAD should be incorporated
+        release = upad_release
     else:
-        # If more than 1 item in release
-        # then there must be a UPAD present
-        # Check if they are the same release
-        primary_release = releases[0]
-        upad_release = releases[1].split(" ")[-1]  # expecting "upad / tpad  22c4"
-        upad_primary_release = upad_release[0:3]
-
-        logging.info(f"{primary_release=}")
-        logging.info(f"{upad_release=}")
-        logging.info(f"{upad_primary_release=}")
-
-        if primary_release == upad_primary_release:
-            logging.info("Matching Primary and UPAD's Primary releases")
-            # UPAD should be incorporated
+        logging.info("WARNING! Mismatch between posted Primary and UPAD releases")
+        # posted UPAD is not meant for current release
+        # TODO this is temporary while an image with 22c4 UPAD needs to be built
+        # note 2025-05 - not sure if this is needed
+        if IGNORE_UPAD_RELEASE:
+            logging.info("Ignoring UPAD release")
+            release = primary_release
+        else:
+            # build for the posted UPAD
+            logging.info("Prioritizing UPAD release")
             release = upad_release
-        else:
-            logging.info("WARNING! Mismatch between posted Primary and UPAD releases")
-            # posted UPAD is not meant for current release
-            # TODO this is temporary while an image with 22c4 UPAD needs to be built
-            if IGNORE_UPAD_RELEASE:
-                logging.info("Ignoring UPAD release")
-                release = primary_release
-            else:
-                # build for the posted UPAD
-                logging.info("Prioritizing UPAD release")
-                release = upad_release
 
-        logging.info(f"{release=}")
-        if len(release) == 4:  # is a UPAD version
-            versions = dict(
-                RELEASE=release[:3],
-                MAJOR=release[:2],
-                MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
-                PATCH=release[3],
-            )
-        elif len(release) == 3:
-            versions = dict(
-                RELEASE=release[:3],
-                MAJOR=release[:2],
-                MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
-                PATCH=0,
-            )
-        else:
-            raise ValueError(f"Got release string with unexpected length: {release=}")
+    logging.info(f"{release=}")
+    patch = 0 if len(release) == 3 else release[3]
+    versions = dict(
+        RELEASE=release[:3],
+        MAJOR=release[:2],
+        MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
+        PATCH=0,
+    )
 
     version_string = f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}"
     logging.info(f"Geosupport VERSIONSTRING from is {version_string}")

--- a/admin/run_environment/docker/geosupport_versions.py
+++ b/admin/run_environment/docker/geosupport_versions.py
@@ -40,7 +40,7 @@ def get_release_from_section(soup: BeautifulSoup, section: str) -> str:
 
 if __name__ == "__main__":
     content = json.loads(requests.get(GEOSUPPORT_RELEASE_URL).content)
-    soup = BeautifulSoup(content["description"], features="lxml")
+    soup = BeautifulSoup(content["description"], features="html.parser")
     primary_release = get_release_from_section(soup, "Geosupport Desktop")
     upad_release = get_release_from_section(soup, "TPAD / UPAD")
 


### PR DESCRIPTION
Geosupport is now available on the new website, and bytes is no longer updated. Since we determine latest geosupport version by scraping that webpage (something that should ideally change long term...), the logic needed a little update

https://www.nyc.gov/content/planning/pages/resources/geocoding/geosupport-desktop-edition

output of edited python script:
![image](https://github.com/user-attachments/assets/7d965122-8ed2-4f9d-be58-a3eba7958143)

run to publish [here](https://github.com/NYCPlanning/data-engineering/actions/runs/15122360608)