### PR TITLE
CEQR Hub: Add new dataset `dpr_active_passive_recreation`

### DIFF
--- a/bash/docker_container_setup.sh
+++ b/bash/docker_container_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-mc config host add spaces "$AWS_S3_ENDPOINT" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" --api S3v4
+mc alias set spaces "$AWS_S3_ENDPOINT" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" --api S3v4
 
 PARENT_DIR=$(dirname "$(readlink -f "$0")")
 

--- a/ingest_templates/dpr_active_passive_recreation.yml
+++ b/ingest_templates/dpr_active_passive_recreation.yml
@@ -1,0 +1,40 @@
+id: dpr_active_passive_recreation
+acl: public-read
+
+attributes:
+  name: NYC Parks Active and Passive Recreation
+  description: >-
+    This dataset includes a list of public open spaces, primarily under the jurisdiction of 
+    and/or managed by NYC Parks, as well as the percentage of active and passive recreation 
+    in each space. It also includes Schoolyard to Playground (SYPG) sites under the jurisdiction 
+    of the NYC Department of Education (DOE), and sites managed in partnership with NYC Parks, 
+    such as Central Park, Brooklyn Bridge Park, and Battery Park City, among others.
+
+    Active open space refers to areas used for sports, exercise, or active play, including but 
+    not limited to, playgrounds, sports fields, and fitness equipment. Passive open space refers 
+    to areas for relaxation, such as sitting, strolling, or picnicking. These areas may include 
+    plazas, beaches, walking paths, as well as features that contribute to the overall use of 
+    public open spaces, such as bathroom and maintenance structures, parking lots, and cultural 
+    institutions. While these latter features are not defined as 'passive' in the 2021 CEQR Open 
+    Space chapter, they will be included in the forthcoming updated version of the chapter.
+
+    This dataset is intended for use in completing an Open Space analysis as part of the City 
+    Environmental Quality Review (CEQR) process only. 
+    
+    Please fully read the Data Dictionary linked below before using this dataset to complete 
+    a CEQR Open Space analysis. Additional research may be necessary to identify other open space 
+    resources within a given study area, including those managed by federal, state, and city 
+    agencies, as well as private entities. For more information on the Open Space analysis and 
+    lists of passive and active features as defined by CEQR, visit: 
+    https://www.nyc.gov/assets/oec/technical-manual/07_Open_Space_2021.pdf
+
+  url: https://data.cityofnewyork.us/Recreation/NYC-Parks-Active-and-Passive-Recreation/kcqe-vnci/about_data
+
+ingestion:
+  source:
+    type: socrata
+    org: nyc
+    uid: kcqe-vnci
+    format: csv
+  file_format:
+    type: csv

--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -57,6 +57,7 @@ inputs:
     - name: dpr_capitalprojects
       file_type: pg_dump
     - name: dpr_walk_to_a_park
+    - name: dpr_active_passive_recreation
     - name: lpc_landmarks
     - name: lpc_historic_district_areas
     - name: lpc_scenic_landmarks

--- a/products/ceqr/seeds/chapter_datasets.csv
+++ b/products/ceqr/seeds/chapter_datasets.csv
@@ -76,6 +76,7 @@ open_space,Open Spaces,Waterfront Public Access Areas,Open Space Inventory
 open_space,Open Spaces,Publicly Owned Waterfront,Open Space Inventory
 open_space,Open Spaces,NYS Parks,Open Space Inventory
 open_space,Open Spaces,Federal Parks,Open Space Inventory
+open_space,Open Spaces,NYC Parks Active and Passive Recreation,Open Space Inventory- for public open spaces managed by NYC Parks
 open_space,No Action Condition,Parks Capital Projects Tracker,Establishing new park spaces in the No-Action Condion
 open_space,Screening Assessment,Walk to a Park Service Area,Open Space screening for detailed analysis
 open_space,Detailed Assessment,Population Fact Finder,Dicennial Census to establish existing population age characteristics for a detailed indirect effects analysis

--- a/products/ceqr/seeds/datasets.csv
+++ b/products/ceqr/seeds/datasets.csv
@@ -58,6 +58,7 @@ Waterfront Public Access Areas,dcp_waterfront_public_access_areas,download,shape
 Publicly Owned Waterfront,dcp_publicly_owned_waterfront,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-waterfront-access-map
 NYS Parks,nysparks_parks,download,shapefile,MULTIPOLYGON,https://data.gis.ny.gov/datasets/nysparks::ny-state-parks-property/about
 Federal Parks,usnps_parks,download,shapefile,MULTIPOLYGON,https://nps.maps.arcgis.com/apps/webappviewer/index.html?id=43bc9db4736140e88e661c67460936e6
+NYC Parks Active and Passive Recreation,dpr_active_passive_recreation,download,csv,,https://data.cityofnewyork.us/Recreation/NYC-Parks-Active-and-Passive-Recreation/kcqe-vnci/about_data
 Parks Capital Projects Tracker,dpr_capitalprojects,download,shapefile,MULTIPOINT,https://www.nycgovparks.org/planning-and-building/capital-project-tracker/upcoming
 Walk to a Park Service Area,dpr_walk_to_a_park,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/dataset/Walk-to-a-Park-Service-Area-for-CEQR-Open-Space-As/k66c-pzws/about_data
 2014 3D Model,,webpage,,,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-nyc-3d-model-download.page


### PR DESCRIPTION
Closes [this](https://github.com/NYCPlanning/caps-process/issues/112) issue.

* Add new NYC Parks dataset to ingest. Successful run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/15280202109).
* Add the dataset to CEQR Hub seed files.

CEQR Hub build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/15283595997/job/42988351773).

Markdown files:
- [chapters_tables.md](https://github.com/user-attachments/files/20465424/chapters_tables.md)
- [datasets_table.md](https://github.com/user-attachments/files/20465425/datasets_table.md)

