### PR TITLE
allow overwrite for ingest

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -11,16 +11,15 @@ on:
         description: "Build PLUTO (Minor) after dataloading is complete"
         type: boolean
         default: false
+      overwrite:
+        description: "This data is correcting previously loaded data from the same version (allows previously archived data to be overwritten)"
+        type: boolean
+        default: false
       promote:
         description: "Promote ZTL (and PLUTO if built) to `draft` folder after build"
         type: boolean
         required: true
         default: true
-      overwrite:
-        description: "Overwrite previously archived source data? Only choose this if correcting
-          bad data"
-        type: boolean
-        default: false
       dev_image:
         description: "Use dev image specific to this branch? (If exists)"
         type: boolean

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -4,29 +4,31 @@ on:
   workflow_dispatch:
     inputs:
       build_ztl:
-        description: "Build Zoning Tax Lots after dataloading is complete"
+        description: Build Zoning Tax Lots after dataloading is complete
         type: boolean
         default: true
       build_pluto_minor:
-        description: "Build PLUTO (Minor) after dataloading is complete"
+        description: Build PLUTO (Minor) after dataloading is complete
         type: boolean
         default: false
       overwrite:
-        description: "This data is correcting previously loaded data from the same version (allows previously archived data to be overwritten)"
+        description: >-
+          This data is correcting previously loaded data from the same version (allows
+          previously archived data to be overwritten)
         type: boolean
         default: false
       promote:
-        description: "Promote ZTL (and PLUTO if built) to `draft` folder after build"
+        description: Promote ZTL (and PLUTO if built) to `draft` folder after build
         type: boolean
         required: true
         default: true
       dev_image:
-        description: "Use dev image specific to this branch? (If exists)"
+        description: Use dev image specific to this branch? (If exists)
         type: boolean
         required: true
         default: false
       dev_bucket:
-        description: "Dev bucket in DO to use, if not a production run."
+        description: Dev bucket in DO to use, if not a production run.
         type: string
         required: false
 
@@ -34,14 +36,11 @@ jobs:
   dataloading:
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/build-base:${{ inputs.dev_image && format('dev-{0}', github.head_ref
-        || github.ref_name) || 'latest' }}
+      image: nycplanning/build-base:${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
     env:
       TEMPLATE_DIR: ./ingest_templates
-      RECIPES_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) ||
-        'edm-recipes' }}
-      PUBLISHING_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) ||
-        'edm-publishing' }}
+      RECIPES_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || 'edm-recipes' }}
+      PUBLISHING_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || 'edm-publishing' }}
     strategy:
       matrix:
         dataset:

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -16,6 +16,10 @@ on:
         type: boolean
         required: true
         default: true
+      overwrite:
+        description: "Overwrite previously archived source data? Only choose this if correcting bad data"
+        type: boolean
+        default: false
       dev_image: 
         description: "Use dev image specific to this branch? (If exists)"
         type: boolean
@@ -68,7 +72,11 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Ingest
-        run: python3 -m dcpy lifecycle scripts ingest_or_library_archive ${{ matrix.dataset }} --latest --push-to-s3
+        run: |
+          python3 -m dcpy lifecycle ingest ${{ matrix.dataset }} \
+            --latest \
+            --push-to-s3 \
+            ${{ inputs.overwrite && '--overwrite' || '' }}
 
   build_ztl:
     needs: [dataloading]

--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -17,10 +17,11 @@ on:
         required: true
         default: true
       overwrite:
-        description: "Overwrite previously archived source data? Only choose this if correcting bad data"
+        description: "Overwrite previously archived source data? Only choose this if correcting
+          bad data"
         type: boolean
         default: false
-      dev_image: 
+      dev_image:
         description: "Use dev image specific to this branch? (If exists)"
         type: boolean
         required: true
@@ -34,52 +35,55 @@ jobs:
   dataloading:
     runs-on: ubuntu-22.04
     container:
-      image: nycplanning/build-base:${{ inputs.dev_image && format('dev-{0}', github.head_ref || github.ref_name) || 'latest' }}
+      image: nycplanning/build-base:${{ inputs.dev_image && format('dev-{0}', github.head_ref
+        || github.ref_name) || 'latest' }}
     env:
       TEMPLATE_DIR: ./ingest_templates
-      RECIPES_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || 'edm-recipes' }}
-      PUBLISHING_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) || 'edm-publishing' }}
+      RECIPES_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) ||
+        'edm-recipes' }}
+      PUBLISHING_BUCKET: ${{ inputs.dev_bucket && format('de-dev-{0}', inputs.dev_bucket) ||
+        'edm-publishing' }}
     strategy:
       matrix:
         dataset:
-          - dcp_mih
-          - dcp_edesignation
-          - dcp_commercialoverlay
-          - dcp_limitedheight
-          - dcp_zoningdistricts
-          - dcp_specialpurpose
-          - dcp_specialpurposesubdistricts
-          - dcp_zoningmapamendments
-          - dof_dtm
-          - dof_shoreline
-          - dof_condo
+        - dcp_mih
+        - dcp_edesignation
+        - dcp_commercialoverlay
+        - dcp_limitedheight
+        - dcp_zoningdistricts
+        - dcp_specialpurpose
+        - dcp_specialpurposesubdistricts
+        - dcp_zoningmapamendments
+        - dof_dtm
+        - dof_shoreline
+        - dof_condo
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - name: Load Secrets
-        uses: 1password/load-secrets-action@v1
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
-          AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
-          AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
-          BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+    - name: Load Secrets
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: true
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        AWS_S3_ENDPOINT: "op://Data Engineering/DO_keys/AWS_S3_ENDPOINT"
+        AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
+        AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
+        BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
 
-      - name: Finish container setup
-        working-directory: ./
-        run: ./bash/docker_container_setup.sh
+    - name: Finish container setup
+      working-directory: ./
+      run: ./bash/docker_container_setup.sh
 
-      - name: Ingest
-        run: |
-          python3 -m dcpy lifecycle ingest ${{ matrix.dataset }} \
-            --latest \
-            --push-to-s3 \
-            ${{ inputs.overwrite && '--overwrite' || '' }}
+    - name: Ingest
+      run: |
+        python3 -m dcpy lifecycle ingest ${{ matrix.dataset }} \
+          --latest \
+          --push \
+          ${{ inputs.overwrite && '--overwrite' || '' }}
 
   build_ztl:
-    needs: [dataloading]
+    needs: [ dataloading ]
     name: Build ZTL
     if: inputs.build_ztl
     uses: ./.github/workflows/build.yml
@@ -91,7 +95,7 @@ jobs:
       recipe_file: recipe
 
   pluto_minor:
-    needs: [dataloading]
+    needs: [ dataloading ]
     name: Build Pluto Minor
     if: inputs.build_pluto_minor
     uses: ./.github/workflows/build.yml
@@ -103,7 +107,7 @@ jobs:
       recipe_file: recipe-minor
 
   promote_ztl_to_draft:
-    needs: [dataloading, build_ztl]
+    needs: [ dataloading, build_ztl ]
     name: Promote ZTL build to Draft folder
     if: inputs.promote
     uses: ./.github/workflows/promote_to_draft.yml
@@ -115,7 +119,7 @@ jobs:
       dev_bucket: ${{ inputs.dev_bucket }}
 
   promote_pluto_to_draft:
-    needs: [dataloading, pluto_minor]
+    needs: [ dataloading, pluto_minor ]
     name: Promote PLUTO build to Draft folder
     if: inputs.promote
     uses: ./.github/workflows/promote_to_draft.yml

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -36,6 +36,11 @@ def _cli_wrapper_run(
         "-t",
         help="Local path to folder with templates. Overrides `TEMPLATE_DIR` env variable.",
     ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="If existing version found, overwrite. This should be phased out, but is needed to support ZTL workflow",
+    ),
 ):
     ingest(
         dataset_id,
@@ -46,4 +51,5 @@ def _cli_wrapper_run(
         output_csv=csv,
         local_file_path=local_file_path,
         template_dir=template_dir,
+        overwrite_okay=overwrite,
     )

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -101,12 +101,11 @@ def ingest(
     shutil.copy(dataset_staging_dir / config.filename, dataset_output_dir)
 
     version_exists = processed_datastore.version_exists(dataset_id, config.version)
-    if version_exists:
+    if version_exists and not overwrite_okay:
         validate.validate_against_existing_version(
             dataset_id,
             config.version,
             dataset_staging_dir / config.filename,
-            overwrite_okay=overwrite_okay,
         )
 
     if push and (overwrite_okay or not version_exists):

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -30,6 +30,7 @@ def ingest(
     output_csv: bool = False,
     template_dir: Path | None = TEMPLATE_DIR,
     local_file_path: Path | None = None,
+    overwrite_okay: bool = False,
 ) -> Config:
     if template_dir is None:
         raise KeyError("Missing required env variable: 'TEMPLATE_DIR'")
@@ -102,17 +103,20 @@ def ingest(
     version_exists = processed_datastore.version_exists(dataset_id, config.version)
     if version_exists:
         validate.validate_against_existing_version(
-            dataset_id, config.version, dataset_staging_dir / config.filename
+            dataset_id,
+            config.version,
+            dataset_staging_dir / config.filename,
+            overwrite_okay=overwrite_okay,
         )
 
-    if push and not version_exists:
+    if push and (overwrite_okay or not version_exists):
         assert config.archival.acl
         processed_datastore.push(
             dataset_id,
             version=config.version,
             filepath=dataset_staging_dir / config.filename,
             config=config,
-            overwrite=False,  ## TODO - allow this via flag?
+            overwrite=overwrite_okay,
             latest=latest,
         )
     else:

--- a/dcpy/lifecycle/ingest/validate.py
+++ b/dcpy/lifecycle/ingest/validate.py
@@ -6,9 +6,7 @@ from dcpy.utils.logging import logger
 from dcpy.lifecycle.ingest.connectors import processed_datastore
 
 
-def validate_against_existing_version(
-    ds: str, version: str, filepath: Path, overwrite_okay: bool = False
-) -> None:
+def validate_against_existing_version(ds: str, version: str, filepath: Path) -> None:
     """
     This function is called after a dataset has been processed, just before archival
     It's called in the case that the version of the dataset in the config (either provided or calculated)
@@ -29,11 +27,9 @@ def validate_against_existing_version(
                     f"Dataset id='{ds}' version='{version}' already exists and matches newly processed data"
                 )
             else:
-                message = f"Archived dataset id='{ds}' version='{version}' already exists and has different data."
-                if overwrite_okay:
-                    logger.warning(message)
-                else:
-                    raise FileExistsError(message)
+                raise FileExistsError(
+                    f"Archived dataset id='{ds}' version='{version}' already exists and has different data."
+                )
 
     # if previous was archived with library, we both expect some potential slight changes and will not compare
     else:

--- a/dcpy/lifecycle/ingest/validate.py
+++ b/dcpy/lifecycle/ingest/validate.py
@@ -6,7 +6,9 @@ from dcpy.utils.logging import logger
 from dcpy.lifecycle.ingest.connectors import processed_datastore
 
 
-def validate_against_existing_version(ds: str, version: str, filepath: Path) -> None:
+def validate_against_existing_version(
+    ds: str, version: str, filepath: Path, overwrite_okay: bool = False
+) -> None:
     """
     This function is called after a dataset has been processed, just before archival
     It's called in the case that the version of the dataset in the config (either provided or calculated)
@@ -27,9 +29,11 @@ def validate_against_existing_version(ds: str, version: str, filepath: Path) -> 
                     f"Dataset id='{ds}' version='{version}' already exists and matches newly processed data"
                 )
             else:
-                raise FileExistsError(
-                    f"Archived dataset id='{ds}' version='{version}' already exists and has different data."
-                )
+                message = f"Archived dataset id='{ds}' version='{version}' already exists and has different data."
+                if overwrite_okay:
+                    logger.warning(message)
+                else:
+                    raise FileExistsError(message)
 
     # if previous was archived with library, we both expect some potential slight changes and will not compare
     else:


### PR DESCRIPTION
Closes #1724

[successful run](https://github.com/NYCPlanning/data-engineering/actions/runs/15612083539)

So our concept of immutability for ingest datasets doesn't really fit GIS's workflow. For ZTL, they
- process various zoning-related datasets
- load them to edm-publishing/datasets
- run "ztl loading" action, which
  - calls ingest on all these datasets
  - builds ztl

Finally, they QA ztl - this is treated as the QA of the source datasets.

So... if an issue is found, they correct data, overwrite the files in edm-publishing/datasets, and re-run ingest/build ztl. So they very much need to overwrite the files in edm-recipes.

Long term solution - this data maybe does not make it into edm-recipes until we "publish" ztl. I think this makes sense - ztl build could pull from `edm.publishing.gis` connector which already exists, and then we essentially have a dependency on the "publish" action that signals that we're good to archive data into edm-recipes for use in other data products

Short term - let GIS overwrite them with this checkbox

![image](https://github.com/user-attachments/assets/3b2714da-cf94-468a-97f6-d7da6c29e931)
