### PR TITLE
add issue template for data updates distribution

### DIFF
--- a/.github/ISSUE_TEMPLATE/distribute_updates.yml
+++ b/.github/ISSUE_TEMPLATE/distribute_updates.yml
@@ -1,0 +1,16 @@
+name: Distribute Data Updates
+description: Track the periodic distribution of DCP data updates
+title: "Distribute data updates (sprint XX)"
+labels: ["data update"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Distribution from Bytes to OpenData of datasets specified in GIS's [Open_Data excel file](https://nyco365.sharepoint.com/:x:/r/sites/NYCPLANNING/itd/edm/_layouts/15/Doc.aspx?sourcedoc=%7B6735537b-8d8e-437a-b5e5-3a6b54194b24%7D&action=edit&wdenableroaming=1&wdlcid=en-US&wdorigin=Teams-HL.Sharing.DirectLink.Copy.LOF&wdhostclicktime=1734629518613&wdredirectionreason=Force_SingleStepBoot&wdinitialsession=2a2b33b6-e1b0-d655-31ed-6ebe4e2c927f&wdrldsc=2&wdrldc=1&wdrldr=ServiceCreationTimedOut) in sharepoint.
+
+        [github action](https://github.com/NYCPlanning/data-engineering/actions/workflows/distribute_socrata_from_bytes.yml) to distribute data from bytes 
+
+        [product metadata repo](https://github.com/NYCPlanning/product-metadata)
+
+        - [ ] Data Product A
+        - [ ] Data Product B


### PR DESCRIPTION
An issue template makes it easy to create an issue like https://github.com/NYCPlanning/data-engineering/issues/1717 every sprint