### PR TITLE
LION - join segments to nodes with tolerance

### DIFF
--- a/ingest_templates/dcp_cscl_addresspoints.yml
+++ b/ingest_templates/dcp_cscl_addresspoints.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: AddressPoint

--- a/ingest_templates/dcp_cscl_altsegmentdata.yml
+++ b/ingest_templates/dcp_cscl_altsegmentdata.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: ALTSEGMENTDATA

--- a/ingest_templates/dcp_cscl_atomicpolygons.yml
+++ b/ingest_templates/dcp_cscl_atomicpolygons.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: AtomicPolygon

--- a/ingest_templates/dcp_cscl_centerline.yml
+++ b/ingest_templates/dcp_cscl_centerline.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: Centerline

--- a/ingest_templates/dcp_cscl_commonplace_gdb.yml
+++ b/ingest_templates/dcp_cscl_commonplace_gdb.yml
@@ -11,7 +11,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: CommonPlace

--- a/ingest_templates/dcp_cscl_featurename.yml
+++ b/ingest_templates/dcp_cscl_featurename.yml
@@ -8,11 +8,11 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: FEATURENAME
     crs: EPSG:2263
   processing_steps:
-    - name: clean_column_names
-      args: { lower: True }
+  - name: clean_column_names
+    args: { lower: True }

--- a/ingest_templates/dcp_cscl_nodes.yml
+++ b/ingest_templates/dcp_cscl_nodes.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: Node

--- a/ingest_templates/dcp_cscl_nypdbeat.yml
+++ b/ingest_templates/dcp_cscl_nypdbeat.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: NYPDBeat

--- a/ingest_templates/dcp_cscl_sectionalmap.yml
+++ b/ingest_templates/dcp_cscl_sectionalmap.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: SectionalMap

--- a/ingest_templates/dcp_cscl_sedat.yml
+++ b/ingest_templates/dcp_cscl_sedat.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: SEDAT

--- a/ingest_templates/dcp_cscl_segment_lgc.yml
+++ b/ingest_templates/dcp_cscl_segment_lgc.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: SEGMENT_LGC

--- a/ingest_templates/dcp_cscl_specialsedat.yml
+++ b/ingest_templates/dcp_cscl_specialsedat.yml
@@ -8,7 +8,7 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: SPECIALSEDAT

--- a/ingest_templates/dcp_cscl_streetname.yml
+++ b/ingest_templates/dcp_cscl_streetname.yml
@@ -8,11 +8,11 @@ ingestion:
   source:
     type: s3
     bucket: edm-private
-    key: cscl_etl/ETL Working GDB.gdb.zip
+    key: cscl_etl/{{ version }}/ETL Working GDB.gdb.zip
   file_format:
     type: geodatabase
     layer: STREETNAME
     crs: EPSG:2263
   processing_steps:
-    - name: clean_column_names
-      args: { lower: True }
+  - name: clean_column_names
+    args: { lower: True }

--- a/products/lion/models/intermediate/2.2.2/_int_222.yml
+++ b/products/lion/models/intermediate/2.2.2/_int_222.yml
@@ -11,7 +11,9 @@ models:
   - name: to_x
   - name: to_y
   - name: from_nodeid
+    tests: [ not_null ]
   - name: to_nodeid
+    tests: [ not_null ]
   - name: from_sectionalmap
   - name: to_sectionalmap
   tests: [] # currently doesn't pass due to duplicate rows from sectionalmap join

--- a/products/lion/models/intermediate/2.2.2/int__centerline_segments_with_nodes.sql
+++ b/products/lion/models/intermediate/2.2.2/int__centerline_segments_with_nodes.sql
@@ -24,11 +24,10 @@ SELECT
     from_sm.sectional_map AS from_sectionalmap,
     to_sm.sectional_map AS to_sectionalmap
 FROM centerline
--- ~75 segments are missing nodes
--- TODO research whether this is consistent with current method and if we might need to join spatially with some minimal buffer
-LEFT JOIN {{ source("recipe_sources", "dcp_cscl_nodes") }} AS n_from ON centerline.from_geom = n_from.geom
-LEFT JOIN {{ source("recipe_sources", "dcp_cscl_nodes") }} AS n_to ON centerline.to_geom = n_to.geom
--- 6 segments with endpoint on border. This currently results in duplicate rows
+LEFT JOIN {{ source("recipe_sources", "dcp_cscl_nodes") }} AS n_from
+    ON st_dwithin(centerline.from_geom, n_from.geom, 0.001)
+LEFT JOIN {{ source("recipe_sources", "dcp_cscl_nodes") }} AS n_to
+    ON st_dwithin(centerline.to_geom, n_to.geom, 0.001)
 LEFT JOIN
     {{ source("recipe_sources", "dcp_cscl_sectionalmap") }} AS from_sm
     ON st_contains(from_sm.geom, centerline.from_geom)


### PR DESCRIPTION
closes #1710 - see issue for a description of the issue. Essentially, it was a tolerance issue with joining ends of segments to nodes.

Originally (before this PR), I joined essentially non-spatially - just checking point equality. This worked for 99+ % of rows, whereas the rest are not perfectly "snapped" in CSCL so need to be joined with some spatial tolerance.

For this PR, I had originally thought a "two-tiered" approach made sense

```mermaid
flowchart LR
    A[centerline] --> B[segment_2_node_only_exact]
    C[nodes] --join exact--> B
    B --without nodes--> D[segments_missing_nodes]
    D --> E[segment_2_node_with_tolerance]
    C --join with tolerance--> E
```

With the theoretical advantage being that the first join should be much more performant, and the second more costly spatial join could only happen on rows that didn't get joined to begin with. However, we could just do


```mermaid
flowchart LR
    A[centerline] --> B[segment_2_node]
    C[nodes] --join with tolerance--> B
```

Option 1 took 6 seconds to run, option 2 took 12... So not exactly a world of difference. Given that, I think it makes most sense to just to option 2

## Results
ALL centerline segment to and from nodes now match production!