### PR TITLE
LION SAF value mismatch

### DIFF
--- a/products/lion/bash/export.sh
+++ b/products/lion/bash/export.sh
@@ -3,7 +3,7 @@ source ../../bash/utils.sh
 set_error_traps
 
 # Export tables to DAT files
-# fixed-width text files with no header or delimeter are specific to LION
+# fixed-width text files with no header or delimiter are specific to LION
 function dat_export {
     local table=${1}
     local output_file=${2:-${table}}

--- a/products/lion/models/intermediate/2.2.10/int__centerline_specialaddress.sql
+++ b/products/lion/models/intermediate/2.2.10/int__centerline_specialaddress.sql
@@ -55,6 +55,11 @@ prioritized AS (
 SELECT
     segmentid,
     boroughcode,
-    saftype AS special_address_flag
+    CASE
+        -- The SAFTYPE "F" in CSCL is a "D" in LION/Geosupport
+        -- Future exports may or may not expect this mapping
+        WHEN saftype = 'F' THEN 'D'
+        ELSE saftype
+    END AS special_address_flag
 FROM prioritized
 WHERE row_number = 1


### PR DESCRIPTION
related to #1715

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-lion-saf)

GS confirmed that `Special Address Flag` values of `F` from CSCL should become `D` for LION/Geosupport

## `poc_dat_comparison` table showing zero mismatch records for this field
<img width="427" alt="Screenshot 2025-07-02 at 4 10 18 PM" src="https://github.com/user-attachments/assets/fbffae94-aa14-4b8e-92d5-a3e0460bae45" />
