### PR TITLE
LION: Address LGC issue

### DIFF
--- a/products/lion/models/intermediate/2.2.1/_int_221.yml
+++ b/products/lion/models/intermediate/2.2.1/_int_221.yml
@@ -82,7 +82,6 @@ models:
   - name: face_code
     tests:
     - not_null
-  # the test below should be here but dbt errors while building staging tables
-  # tests:
-  # - dbt_expectations.expect_table_row_count_to_equal_other_table:
-  #    compare_model: ref("stg__centerline")
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+     compare_model: ref("stg__centerline")

--- a/products/lion/models/intermediate/2.2.1/int__all_local_group_code_ranked.sql
+++ b/products/lion/models/intermediate/2.2.1/int__all_local_group_code_ranked.sql
@@ -7,7 +7,7 @@
 WITH all_ranked_lgc AS (
     SELECT preferred_lgc.*
     FROM {{ ref("int__preferred_local_group_code") }} AS preferred_lgc
-    UNION
+    UNION ALL
     SELECT nonpreferred_lgc.*
     FROM {{ ref("int__nonpreferred_local_group_code") }} AS nonpreferred_lgc
 )

--- a/products/lion/models/intermediate/2.2.1/int__nonpreferred_local_group_code.sql
+++ b/products/lion/models/intermediate/2.2.1/int__nonpreferred_local_group_code.sql
@@ -14,7 +14,7 @@ nonpreferred_ranked_by_lgc AS (
     SELECT
         segmentid,
         lgc,
-        RANK() OVER (
+        ROW_NUMBER() OVER (
             PARTITION BY segmentid
             ORDER BY lgc ASC
         ) + 1 AS lgc_rank, -- value of 1 is reserved for preferred lgc

--- a/products/lion/models/sources.yml
+++ b/products/lion/models/sources.yml
@@ -14,6 +14,13 @@ sources:
   - name: dcp_cscl_streetname
   - name: dcp_cscl_featurename
   - name: dcp_cscl_segment_lgc
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - segmentid
+            - lgc
+          config:
+            severity: warn
   - name: dcp_cscl_sedat
   - name: dcp_cscl_specialsedat
   - name: dcp_cscl_nypdbeat


### PR DESCRIPTION
Closes #1709.

Our previous logic for LGC fields (section 2.2.1) de-duplicated lgc values per segment. The prod data does have duplicates and the docs don't explicitly mention the need to de-duplicate values, so I removed that part in the PR.

### Testing
See the linked issue. The PR resolved 2 out of 3 mismatches between dev & prod data. The remaining 1 mismatch appears to be the result of an error in the prod pipeline.

Runs [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Asf-lion).

### Next
Once this PR is approved, I will send out an email to the LION team describing outstanding issues.