### PR TITLE
CPDB Versioning: Part 2

### DIFF
--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -171,6 +171,7 @@ class TestVersions(TestCase):
             [None, 2, "23Q4.1", "24Q2"],
             [None, 1, "24exec", "24adopt"],
             [None, 1, "24adopt", "25prelim"],
+            [None, 2, "24adopt", "25exec"],
             [None, 6, "23prelim", "25prelim"],
             [None, 2, "24prelim", "24adopt"],
             ["patch", 1, "24prelim", "24prelim.1"],

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -170,6 +170,8 @@ class TestVersions(TestCase):
             ["minor", None, "23v2.2.1", "23v2.3"],
             [None, 2, "23Q4.1", "24Q2"],
             [None, 1, "24exec", "24adopt"],
+            [None, 1, "24adopt", "25prelim"],
+            [None, 6, "23prelim", "25prelim"],
             [None, 2, "24prelim", "24adopt"],
             ["patch", 1, "24prelim", "24prelim.1"],
             ["patch", 2, "24prelim.2", "24prelim.4"],

--- a/dcpy/test/utils/test_versions.py
+++ b/dcpy/test/utils/test_versions.py
@@ -24,11 +24,36 @@ class TestVersions(TestCase):
                     format=versions.DateVersionFormat.quarter,
                 ),
             ],
-            ["26prelim", versions.CapitalBudget(year=26, release_num=1)],
-            ["24exec", versions.CapitalBudget(year=24, release_num=2)],
-            ["22adopt", versions.CapitalBudget(year=22, release_num=3)],
-            ["25adopt.3", versions.CapitalBudget(year=25, release_num=3, patch=3)],
-            ["25prelim", versions.CapitalBudget(year=25, release_num=1, patch=0)],
+            [
+                "26prelim",
+                versions.CapitalBudget(
+                    year=26, release=versions.CapitalBudgetRelease(1)
+                ),
+            ],
+            [
+                "24exec",
+                versions.CapitalBudget(
+                    year=24, release=versions.CapitalBudgetRelease(2)
+                ),
+            ],
+            [
+                "22adopt",
+                versions.CapitalBudget(
+                    year=22, release=versions.CapitalBudgetRelease(3)
+                ),
+            ],
+            [
+                "25adopt.3",
+                versions.CapitalBudget(
+                    year=25, release=versions.CapitalBudgetRelease(3), patch=3
+                ),
+            ],
+            [
+                "25prelim",
+                versions.CapitalBudget(
+                    year=25, release=versions.CapitalBudgetRelease(1), patch=0
+                ),
+            ],
         ]:
             self.assertEqual(parsed, versions.parse(version))
 
@@ -124,7 +149,9 @@ class TestVersions(TestCase):
             ].sort()
         with self.assertRaises(ValueError):
             [
-                versions.CapitalBudget(year=25, release_num=1),
+                versions.CapitalBudget(
+                    year=25, release=versions.CapitalBudgetRelease(1)
+                ),
                 versions.Date(date(2025, 1, 1), format=versions.DateVersionFormat.date),
             ].sort()
 

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -73,9 +73,9 @@ class CapitalBudget(Version):
     def __lt__(self, other) -> bool:
         match other:
             case CapitalBudget():
-                return (self.year, self.release.value, self.patch) < (
+                return (self.year, self.release, self.patch) < (
                     other.year,
-                    other.release.value,
+                    other.release,
                     other.patch,
                 )
             case Date():
@@ -92,9 +92,9 @@ class CapitalBudget(Version):
     def __eq__(self, other) -> bool:
         match other:
             case CapitalBudget():
-                return (self.year, self.release.value, self.patch) == (
+                return (self.year, self.release, self.patch) == (
                     other.year,
-                    other.release.value,
+                    other.release,
                     other.patch,
                 )
             case _:
@@ -440,20 +440,13 @@ def bump(
                 f"Version subtype {bump_type} not applicable for Date versions"
             )
         case CapitalBudget(), None:
-            total_bumped_value = previous_version.release.value + bump_by
+            total_bumped_value = previous_version.release + bump_by
+            bumped_release = (total_bumped_value - 1) % 3 + 1
             bumped_year = previous_version.year + ((total_bumped_value - 1) // 3)
-
-            # Map total bump value to a valid release value: adopt (0), prelim (1), exec (2)
-            if total_bumped_value % 3 == 0:
-                bumped_release = CapitalBudgetRelease(3)
-            elif total_bumped_value % 3 == 1:
-                bumped_release = CapitalBudgetRelease(1)
-            else:
-                bumped_release = CapitalBudgetRelease(2)
 
             return CapitalBudget(
                 year=bumped_year,
-                release=bumped_release,
+                release=CapitalBudgetRelease(bumped_release),
             )
         case CapitalBudget(), VersionSubType.patch:
             return CapitalBudget(

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -20,20 +20,6 @@ class CapitalBudgetRelease(IntEnum):
     exec = 2
     adopt = 3
 
-    @classmethod
-    def resolve_bumped_release(cls, value: int) -> CapitalBudgetRelease:
-        """
-        Resolves a bumped release value (e.g. original + bump) to a valid
-        release value, cycling through 1–3.
-        """
-        mod = value % 3
-        if mod == 0:
-            return cls.adopt
-        elif mod == 1:
-            return cls.prelim
-        else:  # mod == 2
-            return cls.exec
-
 
 @dataclass
 class RegexSpmMatch:
@@ -457,10 +443,16 @@ def bump(
             )
         case CapitalBudget(), None:
             total_bumped_value = previous_version.release_num + bump_by
-            bumped_release = CapitalBudgetRelease.resolve_bumped_release(
-                total_bumped_value
-            ).value
             bumped_year = previous_version.year + ((total_bumped_value - 1) // 3)
+
+            # Map total bump value to a valid release value: adopt (0), prelim (1), exec (2)
+            if total_bumped_value % 3 == 0:
+                bumped_release = CapitalBudgetRelease.adopt.value
+            elif total_bumped_value % 3 == 1:
+                bumped_release = CapitalBudgetRelease.prelim.value
+            else:
+                bumped_release = CapitalBudgetRelease.exec.value
+
             return CapitalBudget(
                 year=bumped_year,
                 release_num=bumped_release,


### PR DESCRIPTION
Follow-up to #1723


Baby PR to fix CPDB versioning across years. Previously, bumping of a CPDB version would only work for same year (e.g. `24exec` -> `24adopt`)

The new code lets us bump like `25adopt` -> `26prelim`.

~~Ignore the failing test: it's related to Socrata.~~