### PR TITLE
Upgrade gdal - one more time

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM nycplanning/dev:latest
+ARG TAG=latest
+FROM nycplanning/dev:${TAG}
 
 ENV PYTHONUNBUFFERED 1
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    args:
-      TAG: ${IMAGE_TAG:-latest}
+      args:
+        TAG: ${IMAGE_TAG:-latest}
     env_file:
       - ../.env
     working_dir: /home/vscode/workspace

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+    args:
+      TAG: ${IMAGE_TAG:-latest}
     env_file:
       - ../.env
     working_dir: /home/vscode/workspace

--- a/.github/workflows/data/pytest.yml
+++ b/.github/workflows/data/pytest.yml
@@ -1,11 +1,14 @@
+# This file determines what pytests are run as part of test_helper.yml
+# Each element in the list is a pytest job that will get run in by the matrix strategy
+# Each job can have multiple calls, which will be run in order with the prefix "python3 -m pytest"
 - name: checkbook
   db: db-checkbook
-  calls: ["./products/checkbook -s --verbose --verbose"]
+  calls: [ "./products/checkbook -s --verbose --verbose" ]
 - name: zap
   working-directory: products/zap-opendata
   calls:
-    - "-m 'not end_to_end' -s --verbose --verbose --durations=0 --cov ."
-    - "-m 'end_to_end' -s --verbose --verbose --durations=0 --cov ."
+  - -m 'not end_to_end' -s --verbose --verbose --durations=0 --cov .
+  - -m 'end_to_end' -s --verbose --verbose --durations=0 --cov .
 - name: qa
   working-directory: apps/qa
-  calls: ["."]
+  calls: [ "." ]

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -169,6 +169,7 @@ jobs:
       RECIPES_BUCKET: edm-recipes
       BUILD_ENGINE_DB: ${{ matrix.db }}
       TEST_SCHEMA_SUFFIX: pr_${{ github.event.pull_request.number || 'workflow_dispatch' }}
+      IMAGE_TAG: ${{ inputs.image_tag }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -196,7 +196,14 @@ jobs:
     - name: dcpy main pytests
       run: |
         docker exec -u 0 de \
-        python3 -m pytest dcpy/test -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml
+        python3 -m pytest dcpy/test --ignore dcpy/test/library -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml
+
+    # separate because of issues w/ gdal and pyarrow
+    # errors occur when writing/reading parquet files after importing gdal
+    - name: dcpy library pytests
+      run: |
+        docker exec -u 0 de \
+        python3 -m pytest dcpy/test/library -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
 
     - name: dcpy integration pytests
       run: |

--- a/admin/run_environment/constraints.txt
+++ b/admin/run_environment/constraints.txt
@@ -179,7 +179,7 @@ folium==0.20.0
     #   streamlit-folium
 fonttools==4.58.5
     # via matplotlib
-gdal==3.8.3
+gdal==3.11.3
     # via -r requirements.in
 gdown==5.2.0
     # via leafmap

--- a/admin/run_environment/docker/base/setup.sh
+++ b/admin/run_environment/docker/base/setup.sh
@@ -3,6 +3,8 @@
 source config.sh
 set -e
 
+gdal_version=3.11.3
+gdal_short_version="$(echo "$gdal_version" | tr -d ".")"
 COMMON_APT_PACKAGES="curl zip unzip git wget ca-certificates lsb-release build-essential sudo postgresql-client-15 libpq-dev jq locales pandoc weasyprint"
 
 apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -29,9 +31,9 @@ function install_gdal {
 
     echo "installing gdal from source" && (
         cd ~
-        wget https://github.com/fvankrieken/gdal/archive/refs/heads/3.8-revert-null-date-behavior.zip
-        unzip "3.8-revert-null-date-behavior.zip"
-        cd gdal-3.8-revert-null-date-behavior
+        wget download.osgeo.org/gdal/${gdal_version}/gdal${gdal_short_version}.zip
+        unzip gdal${gdal_short_version}.zip
+        cd gdal-${gdal_version}
         mkdir build
         cd build
         sudo cmake -DPROJ_INCLUDE_DIR=/usr/include ..
@@ -39,8 +41,8 @@ function install_gdal {
         sudo cmake --build . --target install
 
         cd ~
-        rm -rf gdal-3.8-revert-null-date-behavior
-        rm "3.8-revert-null-date-behavior.zip"
+        rm -rf gdal-${gdal_version}
+        rm gdal${gdal_short_version}.zip
     )
     echo "gdal installed successfully"
 }

--- a/admin/run_environment/requirements.in
+++ b/admin/run_environment/requirements.in
@@ -10,7 +10,7 @@ diagrams>=0.23.3
 duckdb
 faker
 folium
-GDAL==3.8.3
+GDAL==3.11.3
 geopandas
 geoalchemy2
 graphviz>=0.20.1

--- a/admin/run_environment/requirements.txt
+++ b/admin/run_environment/requirements.txt
@@ -179,7 +179,7 @@ folium==0.20.0
     #   streamlit-folium
 fonttools==4.58.5
     # via matplotlib
-gdal==3.8.3
+gdal==3.11.3
     # via -r requirements.in
 gdown==5.2.0
     # via leafmap

--- a/dcpy/library/sources.py
+++ b/dcpy/library/sources.py
@@ -5,32 +5,6 @@ from osgeo import gdal
 from .utils import parse_engine
 
 
-def format_field_names(dataset: gdal.Dataset, fields: list[str] | None = None):
-    """
-    dataset: Given source data source, usually a local file / s3 url
-    fields: a list of predefined field names
-
-    If we have a list of new field names, then rename fields with "fields"
-    otherwise, change all field names to lower case connected by underscore
-    """
-    assert dataset, "dataset: gdal.Dataset shouldn't be None"
-    fields = fields or []
-    layer = dataset.GetLayer(0)
-    layerDefn = layer.GetLayerDefn()
-
-    if len(fields) == 0:
-        for i in range(layerDefn.GetFieldCount()):
-            fieldDefn = layerDefn.GetFieldDefn(i)
-            fieldName = fieldDefn.GetName()
-            fieldDefn.SetName(fieldName.replace(" ", "_").lower())
-    else:
-        for i in range(len(fields)):
-            fieldDefn = layerDefn.GetFieldDefn(i)
-            fieldDefn.SetName(fields[i])
-
-    return dataset
-
-
 def get_allowed_drivers(url: str) -> list:
     """
     Returns allowed drivers for OpenEx
@@ -55,9 +29,7 @@ def postgres_source(url: str) -> gdal.Dataset:
     return gdal.OpenEx(parsed, gdal.OF_VECTOR)
 
 
-def generic_source(
-    path: str, options: list | None = None, fields: list | None = None
-) -> gdal.Dataset:
+def generic_source(path: str, options: list | None = None) -> gdal.Dataset:
     """
     path: filepath, http url or s3 file url
     e.g.
@@ -71,5 +43,4 @@ def generic_source(
         path, gdal.OF_VECTOR, open_options=options, allowed_drivers=allowed_drivers
     )
     assert dataset, f"{path} is invalid"
-    dataset = format_field_names(dataset, fields)
     return dataset

--- a/dcpy/test/library/data/field_names.csv
+++ b/dcpy/test/library/data/field_names.csv
@@ -1,0 +1,2 @@
+Column 1,col2,the_geom
+a,1,POINT (1 2)

--- a/dcpy/test/library/data/field_names.yml
+++ b/dcpy/test/library/data/field_names.yml
@@ -1,0 +1,24 @@
+dataset:
+  name: field_names
+  version: test
+  acl: public-read
+  source:
+    url:
+      path: dcpy/test/library/data/field_names.csv
+    options:
+    - "AUTODETECT_TYPE=NO"
+    - "EMPTY_STRING_AS_NULL=YES"
+    - "GEOM_POSSIBLE_NAMES=the_geom"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+    - "OVERWRITE=YES"
+    - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null

--- a/dcpy/test/library/test_ingest.py
+++ b/dcpy/test/library/test_ingest.py
@@ -1,82 +1,97 @@
 import os
 from unittest.mock import patch
-from sqlalchemy import text
+from osgeo import gdal
+import pandas as pd
 
-from dcpy.library.ingest import Ingestor
+from dcpy.library.ingest import Ingestor, format_field_names
 from dcpy.test.conftest import mock_request_get
 
 from . import (
-    pg,
-    recipe_engine,
     get_config_file,
-    TEST_DATASET_NAME,
-    TEST_DATASET_VERSION,
-    TEST_DATASET_CONFIG_FILE,
-    TEST_DATASET_OUTPUT_PATH,
+    test_root_path,
     template_path,
 )
 
 
-def test_ingest_postgres():
-    ingestor = Ingestor()
-    ingestor.postgres(TEST_DATASET_CONFIG_FILE, postgres_url=recipe_engine)
-    with pg.connect() as conn:
-        for version in [TEST_DATASET_VERSION, "latest"]:
-            sql = f"""
-            SELECT EXISTS (
-                SELECT FROM information_schema.tables
-                WHERE  table_schema = '{TEST_DATASET_NAME}'
-                AND    table_name   = '{version}'
-            );
-            """
-            result = conn.execute(text(sql)).fetchall()
-            assert result[0][0], (
-                f"{TEST_DATASET_NAME}.{version} is not in postgres database yet"
-            )
-        conn.execute(text(f"DROP SCHEMA IF EXISTS {TEST_DATASET_NAME} CASCADE;"))
-
-
-def test_ingest_csv():
-    ingestor = Ingestor()
-    ingestor.csv(TEST_DATASET_CONFIG_FILE, compress=True)
-    assert os.path.isfile(f"{TEST_DATASET_OUTPUT_PATH}.csv")
-
-
-def test_ingest_pgdump():
-    ingestor = Ingestor()
-    ingestor.pgdump(TEST_DATASET_CONFIG_FILE, compress=True)
-    assert os.path.isfile(f"{TEST_DATASET_OUTPUT_PATH}.sql")
-
-
-def test_ingest_geojson():
-    ingestor = Ingestor()
-    ingestor.geojson(TEST_DATASET_CONFIG_FILE, compress=True)
-    assert os.path.isfile(f"{TEST_DATASET_OUTPUT_PATH}.geojson")
-
-
-def test_ingest_shapefile():
-    ingestor = Ingestor()
-    ingestor.shapefile(TEST_DATASET_CONFIG_FILE)
-    assert os.path.isfile(f"{TEST_DATASET_OUTPUT_PATH}.shp.zip")
-
-
-def test_ingest_version_overwrite():
-    version_overwrite = "test_version"
-    ingestor = Ingestor()
-    ingestor.csv(TEST_DATASET_CONFIG_FILE, version=version_overwrite)
-    assert os.path.isfile(
-        f".library/datasets/{TEST_DATASET_NAME}/{version_overwrite}/{TEST_DATASET_NAME}.csv"
+class TestFormatFieldNames:
+    ds = gdal.OpenEx(
+        test_root_path / "data" / "field_names.csv",
+        gdal.OF_VECTOR,
+        open_options=["GEOM_POSSIBLE_NAMES=the_geom"],
     )
 
+    def test_basic(self):
+        expected = 'SELECT\n\t"Column 1" AS "column_1",\n\t"col2" AS "col2",\n\t"the_geom" AS "the_geom"\nFROM field_names'
+        assert format_field_names(self.ds, [], None, False, "CSV") == expected
 
-@patch("requests.get", side_effect=mock_request_get)
-def test_ingest_with_sql(request_get):
+    def test_geom_dont_remove(self):
+        expected = 'SELECT\n\t"Column 1" AS "column_1",\n\t"col2" AS "col2",\n\t"the_geom" AS "the_geom",\n\t"Geometry" AS "WKT"\nFROM field_names'
+        assert format_field_names(self.ds, [], None, True, "CSV") == expected
+
+    def test_geom(self):
+        expected = 'SELECT\n\t"Column 1" AS "column_1",\n\t"col2" AS "col2",\n\t"Geometry" AS "WKT"\nFROM field_names'
+        assert (
+            format_field_names(self.ds, [], None, True, "CSV", ["the_geom"]) == expected
+        )
+
+    def test_with_fields(self):
+        fields = ["col1", "col2", "geom"]
+        expected = """SELECT\n\t"Column 1" AS "col1",\n\t"col2" AS "col2",\n\t"the_geom" AS "geom",\n\t"Geometry" AS "WKT"\nFROM field_names"""
+        result = format_field_names(self.ds, fields, None, True, "CSV")
+        assert result == expected
+
+    def test_with_sql_cte(self):
+        sql = "WITH something AS (SELECT * FROM @filename WHERE col2 > 10) SELECT * FROM something"
+        expected = (
+            'WITH __cte__ AS (SELECT\n\t"Column 1" AS "column_1",\n\t"col2" AS "col2",\n\t"Geometry" AS "WKT"\nFROM field_names),\n'
+            "something AS (SELECT * FROM __cte__ WHERE col2 > 10) SELECT * FROM something"
+        )
+        result = format_field_names(self.ds, [], sql, True, "CSV", ["the_geom"])
+        assert result == expected
+
+    def test_with_sql_no_cte(self):
+        sql = "SELECT * FROM @filename WHERE col2 > 10"
+        expected = (
+            'WITH __cte__ AS (SELECT\n\t"Column 1" AS "column_1",\n\t'
+            '"col2" AS "col2",\n\t"the_geom" AS "the_geom"\nFROM field_names)\n'
+            "SELECT * FROM __cte__ WHERE col2 > 10"
+        )
+        result = format_field_names(self.ds, [], sql, False, "CSV")
+        assert result == expected
+
+    def test_output_format_parquet(self):
+        expected = 'SELECT\n\t"Column 1" AS "column_1",\n\t"col2" AS "col2",\n\t"Geometry" AS "geom"\nFROM field_names'
+        result = format_field_names(self.ds, [], None, True, "Parquet", ["the_geom"])
+        assert result == expected
+
+
+class TestIngestor:
+    """Slightly more integration-y tests for the Ingestor class."""
+
+    test_dataset = "field_names"
+    template = get_config_file(test_dataset)
+    output_file_csv = f".library/datasets/{test_dataset}/test/{test_dataset}.csv"
+    output_file_parquet = (
+        f".library/datasets/{test_dataset}/test/{test_dataset}.parquet"
+    )
     ingestor = Ingestor()
-    ingestor.csv(get_config_file("bpl_libraries_sql"))
 
+    def test_creates_output_successfully(self):
+        print(self.template)
+        self.ingestor.csv(self.template)
+        assert os.path.isfile(self.output_file_csv)
 
-@patch("requests.get", side_effect=mock_request_get)
-def test_script(request_get):
-    ingestor = Ingestor()
-    ingestor.csv(f"{template_path}/bpl_libraries.yml", version="test")
-    assert os.path.isfile(".library/datasets/bpl_libraries/test/bpl_libraries.csv")
+    def test_output_columns_csv(self):
+        self.ingestor.csv(self.template)
+        df = pd.read_csv(self.output_file_csv)
+        assert list(df.columns) == ["WKT", "column_1", "col2"]
+
+    def test_output_columns_parquet(self):
+        self.ingestor.parquet(self.template)
+        df = pd.read_parquet(self.output_file_parquet)
+        assert list(df.columns) == ["column_1", "col2", "geom", "geom_bbox"]
+
+    @patch("requests.get", side_effect=mock_request_get)
+    def test_script(self, request_get):
+        self.ingestor.csv(f"{template_path}/bpl_libraries.yml", version="test")
+        assert os.path.isfile(".library/datasets/bpl_libraries/test/bpl_libraries.csv")


### PR DESCRIPTION
Begone, Finn's fork of gdal!

We're using gdal 3.8.3. I forked it because there was a bug in handling null dates. We're stuck there because in 3.9.x and beyond, we started getting errors with the way we attempt to rename fields (see deleted code in `sources.py` in the big commit).

It'd be nicer to just drop library, but that hasn't happened yet. And building our `base` docker image is failing with gdal/pyarrow conflicts, so I've
- bumped gdal
- tweaked library code to rename fields using sql in the call to vector_translate instead of trying to modify the data source
- added pytests around the new logic

The commits are relatively self-explanatory (and have descriptions)

One benefit of this - if you have gdal installed via homebrew and have it at all up to date, after this you won't need to use dev container to run library, can just have your venv.

## Testing

I think my pytests should mostly cover it. We only have two datasets where we actually supply the "sql" field, so I've run one [here](https://github.com/NYCPlanning/data-engineering/actions/runs/16659363327/job/47152467346)

Also ran one that pulls from arcgis server [here](https://github.com/NYCPlanning/data-engineering/actions/runs/16660097623/job/47154952141) (more wieldy size). pg dump ddl is identical on my dev bucket and in prod