### PR TITLE
Implement Bytes Connector pull_versioned Logic

### DIFF
--- a/dcpy/models/connectors/edm/recipes.py
+++ b/dcpy/models/connectors/edm/recipes.py
@@ -25,6 +25,7 @@ class DatasetType(StrEnum):
     parquet = "parquet"
     xlsx = "xlsx"  # needed for a few "legacy" products. Aim to phase out
     json = "json"
+    shapefile = "shapefile"
 
 
 def _type_to_extension(dst: DatasetType) -> str:

--- a/products/template/recipe.yml
+++ b/products/template/recipe.yml
@@ -11,4 +11,8 @@ inputs:
     - name: dpr_parksproperties
     - name: dpr_greenthumb
     - name: lpc_landmarks
+    - name: lion.borough_boundaries
+      source: bytes
+      file_type: shapefile
+      destination: file
   missing_versions_strategy: find_latest


### PR DESCRIPTION
Implements the logic for the Bytes Connector to pull datasets, and adds a Bytes dataset to `template-db` as an integration test for version resolution and pulling. (I'd used LION Borough Boundaries because it's a relatively small file)

If everything looks good, I'll go ahead and fill out the `BYTES_PAGE_CONFIGS` to cover all datasets. This should enable us to remove all BYTES file urls from the metadata repo. 