### PR TITLE
FacDB: fix bpl libraries locations ingest template

### DIFF
--- a/ingest_templates/bpl_libraries.yml
+++ b/ingest_templates/bpl_libraries.yml
@@ -8,14 +8,13 @@ attributes:
 ingestion:
   source:
     type: api
-    endpoint: https://www.bklynlibrary.org/locations/json
+    endpoint: https://www.bklynlibrary.org/api/locations/v1/map
     format: json
   file_format:
     type: json
     json_read_fn: normalize
-    json_read_kwargs: { "record_path": [ "locations" ] }
     geometry:
-      geom_column: data.position
+      geom_column: position
       crs: EPSG:4326
       format:
         point_xy_str: "y, x"


### PR DESCRIPTION
I sniffed around in the Browser network requests and found this endpoint. The schema is mostly the same, with some unimportant columns missing from the new version. Since there are other recipe inputs that are erroring out in `load`, I tested this by commenting out all the recipe inputs except bpl_libraries and running [a job](https://github.com/NYCPlanning/data-engineering/actions/runs/16580399199/job/46894946339). The new version loads just fine, so I think this solves our problem.

I also submitted a dataset error to OpenData so they can fix the pointer on the Socrata page.