### PR TITLE
implementing template validation util in dcpy

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -238,3 +238,13 @@ jobs:
       env:
         RECIPES_BUCKET: edm-recipes
         PUBLISHING_BUCKET: edm-publishing
+
+  validate-templates:
+    name: Validate ingest templates
+    runs-on: ubuntu-22.04
+    container:
+      image: nycplanning/dev:${{ inputs.image_tag }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Validate all ingest templates
+      run: python -m dcpy.lifecycle.ingest.cli validate ./ingest_templates --strict --report

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -239,12 +239,12 @@ jobs:
         RECIPES_BUCKET: edm-recipes
         PUBLISHING_BUCKET: edm-publishing
 
-  test-helper:
-    name: Run validation tests
+  validate_templates:
+    name: Validate Ingest Templates
     runs-on: ubuntu-22.04
     container:
       image: nycplanning/dev:${{ inputs.image_tag }}
     steps:
     - uses: actions/checkout@v4
-    - name: Run validation tests
+    - name: Validate All Templates
       run: python -m dcpy lifecycle ingest validate_templates ingest_templates

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -247,4 +247,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Validate all ingest templates
-      run: python -m dcpy.lifecycle.ingest.cli validate ./ingest_templates --strict --report
+      run: python -m dcpy.lifecycle.ingest validate ./ingest_templates --strict --report

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -239,12 +239,12 @@ jobs:
         RECIPES_BUCKET: edm-recipes
         PUBLISHING_BUCKET: edm-publishing
 
-  validate-templates:
-    name: Validate ingest templates
+  test-helper:
+    name: Run validation tests
     runs-on: ubuntu-22.04
     container:
       image: nycplanning/dev:${{ inputs.image_tag }}
     steps:
     - uses: actions/checkout@v4
-    - name: Validate all ingest templates
-      run: python -m dcpy.lifecycle.ingest validate ./ingest_templates --strict --report
+    - name: Run validation tests
+      run: python -m dcpy lifecycle ingest validate_templates ingest_templates

--- a/dcpy/lifecycle/_cli.py
+++ b/dcpy/lifecycle/_cli.py
@@ -1,7 +1,7 @@
 import typer
 
 from dcpy.lifecycle.data_loader import app as data_loader_app
-from dcpy.lifecycle.ingest import _cli_wrapper_run as run_ingest
+from dcpy.lifecycle.ingest import app as ingest_app
 from dcpy.lifecycle.builds._cli import app as builds_app
 from dcpy.lifecycle.package._cli import app as package_app
 from dcpy.lifecycle.distribute import _cli as distribute_cli
@@ -15,6 +15,4 @@ app.add_typer(distribute_cli.app, name="distribute")
 app.add_typer(scripts_cli.app, name="scripts")
 app.add_typer(data_loader_app, name="data_loader")
 app.add_typer(connectors_app, name="connectors")
-
-# while there's only one ingest command, add it directly
-app.command(name="ingest")(run_ingest)
+app.add_typer(ingest_app, name="ingest")

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -3,6 +3,7 @@ import typer
 
 from .run import ingest
 from dcpy.configuration import TEMPLATE_DIR
+from . import validate
 
 app = typer.Typer(add_completion=False)
 
@@ -55,11 +56,7 @@ def _cli_wrapper_run(
     )
 
 
-from .validate import validate_template_folder
-from .validate import validate_template_file
-
-
-@app.command("validate")
+@app.command("validate_templates")
 def _cli_wrapper_validate(
     path: Path = typer.Argument(
         help="Path to template file or folder containing template files to validate",
@@ -80,7 +77,7 @@ def _cli_wrapper_validate(
     if path.is_file():
         # Handle single file validation
         try:
-            validate_template_file(path)
+            validate.validate_template_file(path)
             typer.echo("✓ Template file validation passed")
         except Exception as e:
             typer.echo(f"Validation failed: {e}", err=True)
@@ -88,7 +85,7 @@ def _cli_wrapper_validate(
                 raise typer.Exit(1)
     elif path.is_dir():
         # Handle folder validation
-        errors = validate_template_folder(
+        errors = validate.validate_template_folder(
             folder_path=path,
             print_report=print_report,
             raise_on_error=raise_on_error,

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -61,37 +61,19 @@ def _cli_wrapper_validate(
     path: Path = typer.Argument(
         help="Path to template file or folder containing template files to validate",
     ),
-    print_report: bool = typer.Option(
-        True,
-        "--report/--no-report",
-        help="Print validation report",
-    ),
-    raise_on_error: bool = typer.Option(
-        False,
-        "--strict",
-        "-s",
-        help="Raise exception if any validation errors found",
-    ),
 ):
     """Validate template file(s)."""
     if path.is_file():
-        # Handle single file validation
         try:
             validate.validate_template_file(path)
             typer.echo("✓ Template file validation passed")
         except Exception as e:
             typer.echo(f"Validation failed: {e}", err=True)
-            if raise_on_error:
-                raise typer.Exit(1)
-    elif path.is_dir():
-        # Handle folder validation
-        errors = validate.validate_template_folder(
-            folder_path=path,
-            print_report=print_report,
-            raise_on_error=raise_on_error,
-        )
-        if not errors and not print_report:
-            typer.echo("✓ All templates validated successfully")
+            raise typer.Exit(1)
     else:
-        typer.echo(f"Error: Path '{path}' is neither a file nor a directory", err=True)
-        raise typer.Exit(1)
+        errors = validate.validate_template_folder(path)
+        if errors:
+            for error in errors:
+                typer.echo(error, err=True)
+            raise typer.Exit(1)
+        typer.echo("✓ All templates validated successfully")

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -53,3 +53,30 @@ def _cli_wrapper_run(
         template_dir=template_dir,
         overwrite_okay=overwrite,
     )
+
+from .validate import validate_template_folder
+
+@app.command("validate")
+def _cli_wrapper_validate(
+   folder_path: Path = typer.Argument(
+       TEMPLATE_DIR,
+       help="Path to folder containing template files to validate",
+   ),
+   print_report: bool = typer.Option(
+       True,
+       "--report/--no-report",
+       help="Print validation report",
+   ),
+   raise_on_error: bool = typer.Option(
+       False,
+       "--strict",
+       "-s",
+       help="Raise exception if any validation errors found",
+   ),
+):
+   """Validate all template files in a folder."""
+   errors = validate_template_folder(
+       folder_path=folder_path,
+       print_report=print_report,
+       raise_on_error=raise_on_error,
+   )

--- a/dcpy/lifecycle/ingest/__init__.py
+++ b/dcpy/lifecycle/ingest/__init__.py
@@ -54,8 +54,10 @@ def _cli_wrapper_run(
         overwrite_okay=overwrite,
     )
 
+
 from .validate import validate_template_folder
 from .validate import validate_template_file
+
 
 @app.command("validate")
 def _cli_wrapper_validate(

--- a/dcpy/lifecycle/ingest/validate.py
+++ b/dcpy/lifecycle/ingest/validate.py
@@ -51,28 +51,17 @@ def validate_template_file(filepath: Path) -> None:
     )
 
 
-def validate_template_folder(
-    folder_path: Path, print_report: bool = False, raise_on_error: bool = False
-) -> dict[str, str]:
-    """Validate all template files in a folder and return errors as {filename: error_string}."""
+def validate_template_folder(folder_path: Path) -> list[str]:
+    """Validate all template files in a folder and return a list of error messages."""
     if not folder_path.exists():
-        raise FileNotFoundError(f"Template directory '{folder_path}' doesn't exist.")
+        return [f"Template directory '{folder_path}' doesn't exist."]
 
-    errors = {}
+    errors = []
     for file_path in folder_path.glob("*"):
         if file_path.is_file():
             try:
                 validate_template_file(file_path)
             except Exception as e:
-                errors[file_path.name] = str(e)
-
-    if print_report:
-        total = len(list(folder_path.glob("*")))
-        logger.info(f"Validated {total} templates, {len(errors)} failed")
-        for filename, error in errors.items():
-            logger.error(f"  {filename}: {error}")
-
-    if raise_on_error and errors:
-        raise ValueError(f"Validation failed for {len(errors)} template(s)")
+                errors.append(f"{file_path.name}: {str(e)}")
 
     return errors

--- a/dcpy/lifecycle/ingest/validate.py
+++ b/dcpy/lifecycle/ingest/validate.py
@@ -1,9 +1,13 @@
 import pandas as pd
 from pathlib import Path
 from tempfile import TemporaryDirectory
+import yaml
 
 from dcpy.utils.logging import logger
 from dcpy.lifecycle.ingest.connectors import processed_datastore
+from dcpy.models.lifecycle.ingest import Template
+from dcpy.lifecycle.ingest import transform
+
 
 def validate_against_existing_version(ds: str, version: str, filepath: Path) -> None:
     """
@@ -37,10 +41,6 @@ def validate_against_existing_version(ds: str, version: str, filepath: Path) -> 
         )
 
 
-import yaml
-from dcpy.models.lifecycle.ingest import Template
-from dcpy.lifecycle.ingest import transform
-
 def validate_template_file(filepath: Path) -> None:
     """Validate a single template file."""
     with open(filepath, "r") as f:
@@ -50,12 +50,14 @@ def validate_template_file(filepath: Path) -> None:
         template.id, template.ingestion.processing_steps
     )
 
-def validate_template_folder(folder_path: Path, print_report: bool = False, 
-                          raise_on_error: bool = False) -> dict[str, str]:
+
+def validate_template_folder(
+    folder_path: Path, print_report: bool = False, raise_on_error: bool = False
+) -> dict[str, str]:
     """Validate all template files in a folder and return errors as {filename: error_string}."""
     if not folder_path.exists():
         raise FileNotFoundError(f"Template directory '{folder_path}' doesn't exist.")
-    
+
     errors = {}
     for file_path in folder_path.glob("*"):
         if file_path.is_file():
@@ -63,14 +65,14 @@ def validate_template_folder(folder_path: Path, print_report: bool = False,
                 validate_template_file(file_path)
             except Exception as e:
                 errors[file_path.name] = str(e)
-    
+
     if print_report:
         total = len(list(folder_path.glob("*")))
         logger.info(f"Validated {total} templates, {len(errors)} failed")
         for filename, error in errors.items():
             logger.error(f"  {filename}: {error}")
-    
+
     if raise_on_error and errors:
         raise ValueError(f"Validation failed for {len(errors)} template(s)")
-    
-    return errors   
+
+    return errors

--- a/dcpy/test/lifecycle/ingest/test_validate.py
+++ b/dcpy/test/lifecycle/ingest/test_validate.py
@@ -50,10 +50,7 @@ INGEST_TEMPLATES = Path(__file__).parent / "resources" / "templates"
 
 def test_validate_template_file_valid():
     """Test validation of a valid template file."""
-    valid_file = (
-        INGEST_TEMPLATES
-        / "dcpy\test\lifecycle\ingest\resources\templates\dcp_addresspoints.yml"
-    )
+    valid_file = INGEST_TEMPLATES / "dcp_addresspoints.yml"
     validate.validate_template_file(valid_file)
 
 

--- a/dcpy/test/lifecycle/ingest/test_validate.py
+++ b/dcpy/test/lifecycle/ingest/test_validate.py
@@ -1,38 +1,19 @@
 from io import BytesIO
 import json
 import pytest
-import yaml
+from pathlib import Path
 
 from dcpy.test.conftest import RECIPES_BUCKET
-from dcpy.models.lifecycle.ingest import Template
 from dcpy.utils import s3
 from dcpy.connectors.edm import recipes
 from dcpy.lifecycle.ingest.connectors import processed_datastore
-from dcpy.lifecycle.ingest import transform, validate
+from dcpy.lifecycle.ingest import validate
 
 from .shared import (
     TEST_OUTPUT,
     BASIC_CONFIG,
     BASIC_LIBRARY_CONFIG,
-    PROD_TEMPLATE_DIR,
 )
-
-
-def test_template_dir_exists():
-    """Sanity check. It must exist for test below."""
-    assert PROD_TEMPLATE_DIR.exists(), (
-        f"Template directory (production) '{PROD_TEMPLATE_DIR}' doesn't exist."
-    )
-
-
-@pytest.mark.parametrize("dataset", [t.name for t in PROD_TEMPLATE_DIR.glob("*")])
-def test_validate_all_templates(dataset):
-    with open(PROD_TEMPLATE_DIR / dataset, "r") as f:
-        s = yaml.safe_load(f)
-    template = Template(**s)
-    transform.validate_processing_steps(
-        template.id, template.ingestion.processing_steps
-    )
 
 
 class TestValidateAgainstExistingVersion:
@@ -62,3 +43,36 @@ class TestValidateAgainstExistingVersion:
             validate.validate_against_existing_version(
                 ds.id, ds.version, TEST_OUTPUT.parent / "test.parquet"
             )
+
+
+INGEST_TEMPLATES = Path(__file__).parent / "resources" / "templates"
+
+
+def test_validate_template_file_valid():
+    """Test validation of a valid template file."""
+    valid_file = (
+        INGEST_TEMPLATES
+        / "dcpy\test\lifecycle\ingest\resources\templates\dcp_addresspoints.yml"
+    )
+    validate.validate_template_file(valid_file)
+
+
+def test_validate_template_file_invalid():
+    """Test validation of an invalid template file."""
+    invalid_file = INGEST_TEMPLATES / "invalid_template.yml"
+    with pytest.raises(Exception):
+        validate.validate_template_file(invalid_file)
+
+
+def test_validate_template_folder():
+    """Test validation of the ingest_templates folder."""
+    errors = validate.validate_template_folder(INGEST_TEMPLATES)
+    # hypothetically an invalid "invalid_template.yaml" in the folder
+    assert len(errors) == 1
+    assert "invalid_template.yml" in errors
+
+
+def test_validate_template_folder_raise_on_error():
+    """Test validation with raise_on_error=True."""
+    with pytest.raises(ValueError, match="Validation failed"):
+        validate.validate_template_folder(INGEST_TEMPLATES, raise_on_error=True)

--- a/dcpy/test/lifecycle/ingest/test_validate.py
+++ b/dcpy/test/lifecycle/ingest/test_validate.py
@@ -8,7 +8,6 @@ from dcpy.utils import s3
 from dcpy.connectors.edm import recipes
 from dcpy.lifecycle.ingest.connectors import processed_datastore
 from dcpy.lifecycle.ingest import validate
-
 from .shared import (
     TEST_OUTPUT,
     BASIC_CONFIG,
@@ -51,7 +50,7 @@ INGEST_TEMPLATES = Path(__file__).parent / "resources" / "templates"
 def test_validate_template_file_valid():
     """Test validation of a valid template file."""
     valid_file = INGEST_TEMPLATES / "dcp_addresspoints.yml"
-    validate.validate_template_file(valid_file)
+    validate.validate_template_file(valid_file)  # Should not raise
 
 
 def test_validate_template_file_invalid():
@@ -64,12 +63,13 @@ def test_validate_template_file_invalid():
 def test_validate_template_folder():
     """Test validation of the ingest_templates folder."""
     errors = validate.validate_template_folder(INGEST_TEMPLATES)
-    # hypothetically an invalid "invalid_template.yaml" in the folder
+    # hypothetically an invalid "invalid_template.yml" in the folder
     assert len(errors) == 1
-    assert "invalid_template.yml" in errors
+    assert any("invalid_template.yml" in error for error in errors)
 
 
-def test_validate_template_folder_raise_on_error():
-    """Test validation with raise_on_error=True."""
-    with pytest.raises(ValueError, match="Validation failed"):
-        validate.validate_template_folder(INGEST_TEMPLATES, raise_on_error=True)
+def test_validate_template_folder_nonexistent():
+    """Test validation of a non-existent folder."""
+    errors = validate.validate_template_folder(Path("nonexistent"))
+    assert len(errors) == 1
+    assert "doesn't exist" in errors[0]

--- a/ingest_templates/dpr_park_access_zone.yml
+++ b/ingest_templates/dpr_park_access_zone.yml
@@ -8,7 +8,7 @@ attributes:
     spaces, concentrating on areas of the city that are under-resourced and where 
     residents are living further than a walk to a park. NYC Parks calculates the 
     number of New Yorkers within walking distance of a park and reports on this as 
-    part of the Mayor’s Management Report. “Walking distance” is defined as a 1/4-mile 
+    part of the Mayor's Management Report. "Walking distance" is defined as a 1/4-mile 
     or less for sites such as small playgrounds and sitting areas; or a 1/2-mile or 
     less for larger parks that serve a wider region, typically over 8 acres or situated on 
     the waterfront. Certain properties in NYC Parks' portfolio, such as cemeteries, 


### PR DESCRIPTION
This pr is linked to this issue [#1504](https://github.com/NYCPlanning/data-engineering/issues/1504)

modified files:

- dcpy.lifecycle.ingest.validate: added 2 functions: `validate_template_file` and `validate_template_folder` that ingest a path and assess whether the file or folder is a valid template.
- dcpy.lifecycle.ingest init.py: added a wrapper around the validate functions
- dcpy.test.lifecycle.ingest.test_validate: replaced existing hardcoded tests with new tests that invoke the validate functions
- .github/workflows/test_helper.py: added a new job to invoke the CLI target created