### PR TITLE
string matching tweak for lpc

### DIFF
--- a/products/pluto/pluto_build/sql/lpc.sql
+++ b/products/pluto/pluto_build/sql/lpc.sql
@@ -44,7 +44,7 @@ WITH histdistricts AS (
         FROM lpc_historic_districts
         WHERE
             hist_dist != '0'
-            AND hist_dist != 'Individual Landmarks'
+            AND hist_dist NOT LIKE 'Individual Landmark%'
     ) AS x
     WHERE x.row_number = 1
 )


### PR DESCRIPTION
closes #1882 

This maybe should wait until the current minor gets built? We could always build major from a ref other than main, but I don't know if we want a fix/tweak like this going out on a minor