### PR TITLE
add fiscal year versioning

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -197,19 +197,19 @@ jobs:
     - name: dcpy main pytests
       run: |
         docker exec -u 0 de \
-        python3 -m pytest dcpy/test --ignore dcpy/test/library -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml
+        python3 -m pytest dcpy/test --ignore dcpy/test/library -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=term --cov-report=xml
 
     # separate because of issues w/ gdal and pyarrow
     # errors occur when writing/reading parquet files after importing gdal
     - name: dcpy library pytests
       run: |
         docker exec -u 0 de \
-        python3 -m pytest dcpy/test/library -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
+        python3 -m pytest dcpy/test/library -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=term --cov-report=xml --cov-append
 
     - name: dcpy integration pytests
       run: |
         docker exec -u 0 de \
-        python3 -m pytest dcpy/test_integration -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
+        python3 -m pytest dcpy/test_integration -svv --cov-config=pyproject.toml --cov=dcpy --cov-report=term --cov-report=xml --cov-append
 
     - name: Upload dcpy test coverage to Codecov
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
related to #1895 

CBBR publish runs were [failing](https://github.com/NYCPlanning/data-engineering/actions/workflows/publish.yml) because versions like FY2026 aren't supported/parseable

successful publish run [here](https://github.com/NYCPlanning/data-engineering/actions/runs/16920979285)

I added the printing of test coverage details to (in the future) help something like copilot suggest tests to cover changes. Might be better to do that all locally and feed it something like an XML file but this seemed harmless enough to add first.