### PR TITLE
Improve error handling for missing file types

### DIFF
--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -196,9 +196,13 @@ def get_preferred_file_type(
     dataset: Dataset | DatasetKey, preferences: list[DatasetType]
 ) -> DatasetType:
     file_types = get_file_types(dataset)
+    if len(file_types) == 0:
+        raise FileNotFoundError(
+            f"No files found for dataset {dataset.id} {dataset.version}."
+        )
     if len(file_types.intersection(preferences)) == 0:
         raise FileNotFoundError(
-            f"Dataset {dataset.id} could not find filetype of any of {preferences}. Found filetypes for {dataset.id}: {file_types}"
+            f"No preferred file types found for dataset {dataset.id} {dataset.version}. Preferred file types: {preferences}. Found filetypes: {file_types}."
         )
     return next(t for t in preferences if t in file_types)
 


### PR DESCRIPTION
related to #1852

PLUTO failed because 25v2.1 isn't archived. The error message could be more helpful.

build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/17192117984/job/48769161524) with new error message