### PR TITLE
Fix GFT nysparks_parks column

### DIFF
--- a/products/green_fast_track/models/_sources.yml
+++ b/products/green_fast_track/models/_sources.yml
@@ -358,7 +358,7 @@ sources:
     - name: name
       tests:
       - not_null
-    - name: wkb_geometry
+    - name: geometry
       tests:
       - not_null
     tests:

--- a/products/green_fast_track/models/_sources.yml
+++ b/products/green_fast_track/models/_sources.yml
@@ -230,7 +230,7 @@ sources:
 
   - name: nysparks_historicplaces
     columns:
-    - name: wkb_geometry
+    - name: geometry
       tests:
       - not_null
     - name: historicname
@@ -367,7 +367,7 @@ sources:
         combination_of_columns:
         - uid
         - name
-        - wkb_geometry
+        - geometry
         config:
           severity: warn
 

--- a/products/green_fast_track/models/staging/stg__nys_parks_properties.sql
+++ b/products/green_fast_track/models/staging/stg__nys_parks_properties.sql
@@ -9,7 +9,7 @@ filtered AS (
     SELECT
         'nys_parks_properties' AS variable_type,
         COALESCE(uid || '-', '') || name AS variable_id,
-        ST_TRANSFORM(wkb_geometry, 2263) AS raw_geom
+        ST_TRANSFORM(geometry, 2263) AS raw_geom
     FROM source
     WHERE UPPER(county) IN ('BRONX', 'KINGS', 'QUEENS', 'RICHMOND', 'MANHATTAN')
 )

--- a/products/green_fast_track/models/staging/stg__nysparks_historicplaces.sql
+++ b/products/green_fast_track/models/staging/stg__nysparks_historicplaces.sql
@@ -8,7 +8,7 @@ all_historic_places AS (
         historicname,
         countyname,
         citytown,
-        ST_TRANSFORM(wkb_geometry, 2263) AS geom
+        ST_TRANSFORM(geometry, 2263) AS geom
     FROM historic_places
 ),
 


### PR DESCRIPTION
Moving over to ingest spurred some column name changes. This fixes GFT. 

Build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/17277619184/job/49038302442) (it may still be in progress by the time you review, but it's gotten far enough that I *think* it will succeed)