### PR TITLE
CEQR: use parquet for nysparks

### DIFF
--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -52,7 +52,6 @@ inputs:
     - name: dcp_waterfront_public_access_areas
     - name: dcp_publicly_owned_waterfront
     - name: nysparks_parks
-      file_type: pg_dump
     - name: usnps_parks
       file_type: pg_dump
     - name: dpr_capitalprojects
@@ -64,7 +63,6 @@ inputs:
     - name: nysshpo_historic_buildings_points
     - name: nysshpo_historic_buildings_polygons
     - name: nysparks_historicplaces
-      file_type: pg_dump
     - name: nysdec_freshwater_wetlands
     - name: nysdec_tidal_wetlands
     - name: nysdec_priority_lakes


### PR DESCRIPTION
I moved these over to ingest, and pg_dumps are no longer available