### PR TITLE
Update CEQR hub urls to old DCP pages

### DIFF
--- a/products/ceqr/seeds/chapter_datasets.csv
+++ b/products/ceqr/seeds/chapter_datasets.csv
@@ -55,7 +55,7 @@ community_facilities,Libraries,Census Tract Boundaries,Establish the study area 
 community_facilities,Public Schools,School District Boundaries,To establish study areas and for location maps
 community_facilities,Public Schools,School Subdistrict Boundaries,To establish study areas and for location maps
 community_facilities,Public and Charter Schools,LCGMS,A reference for school locations
-community_facilities,Public Schools,"Blue Book- Enrollment, Capacity and Utilization Report",Information on school organization and school building utilization to establish existing public school enrollment and capacity data
+community_facilities,Public Schools,"Blue Book - Enrollment, Capacity and Utilization Report",Information on school organization and school building utilization to establish existing public school enrollment and capacity data
 community_facilities,Public Schools,Demographic Enrollment Projection,No-Action public school enrollment
 community_facilities,Public Schools,Projected Housing,No-Action public school enrollment
 community_facilities,Public Schools,School Capacity Projects in Process,No-Action public school capacity

--- a/products/ceqr/seeds/datasets.csv
+++ b/products/ceqr/seeds/datasets.csv
@@ -99,7 +99,7 @@ Stormwater Flood Map - Limited Current Sea Levels,dep_stormwater_limited_current
 Open Sewer Atlas,,webpage,,,https://opendata.cityofnewyork.us/projects/open-sewer-atlas-nyc/
 Water and sewer calculations,,webpage,,,http://www.nyc.gov/html/oec/downloads/pdf/2021_ceqr_tm/2021_ceqr_tm_ch13_water_sewer_infrastructure_flow_calculations_matrix.xls
 Housing Database,dcp_housing,download,shapefile,MULTIPOINT,https://www.nyc.gov/content/planning/pages/resources/datasets/housing-project-level
-"Blue Book- Enrollment, Capacity and Utilization Report",sca_bluebook,download,csv,,
+"Blue Book - Enrollment, Capacity and Utilization Report",sca_bluebook,download,csv,,https://www.nycsca.org/Community/Capital-Plan-Reports-Data#Enrollment-Capacity-Utilization-69
 Early Childcare Capacity and Enrollment,dcp_capacity_and_enrollment,download,excel,,
 ZOLA,,webpage,,,https://zola.planning.nyc.gov/
 FastTracker Application,,webpage,,,https://www.nyc.gov/content/planning/pages/our-work/plans/citywide/green-fast-track-for-housing

--- a/products/ceqr/seeds/datasets.csv
+++ b/products/ceqr/seeds/datasets.csv
@@ -1,41 +1,41 @@
 dataset_name,dataset_id,availability_type,file_type,geometry_type,source_url
-MapPLUTO Shoreline Clipped,dcp_mappluto_clipped,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page
+MapPLUTO Shoreline Clipped,dcp_mappluto_clipped,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/mappluto-pluto-change
 DCP Housing and Population Projections,dcp_population_projects,download,excel,,
-ZAP Projects,dcp_projects,download,csv,,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-zap.page
-Zoning Districts,dcp_zoningdistricts,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page
-Commercial Overlay Districts,dcp_commercialoverlay,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page
-Special Purpose Districts,dcp_specialpurpose,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page
-Limited Height Districts,dcp_limitedheight,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page
-Special Purpose Subdistricts,dcp_specialpurposesubdistricts,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page
-Zoning Map Amendments,dcp_zoningmapamendments,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gis-zoning.page
+ZAP Projects,dcp_projects,download,csv,,https://www.nyc.gov/content/planning/pages/resources/datasets/zoning-application-portal
+Zoning Districts,dcp_zoningdistricts,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/gis-zoning-features
+Commercial Overlay Districts,dcp_commercialoverlay,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/gis-zoning-features
+Special Purpose Districts,dcp_specialpurpose,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/gis-zoning-features
+Limited Height Districts,dcp_limitedheight,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/gis-zoning-features
+Special Purpose Subdistricts,dcp_specialpurposesubdistricts,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/gis-zoning-features
+Zoning Map Amendments,dcp_zoningmapamendments,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/gis-zoning-features
 Preliminary Flood Insurance Rate Maps 2015,dcp_pfirms,download,shapefile,MULTIPOLYGON,https://dcp.maps.arcgis.com/home/item.html?id=1e56cf3d576849d1a6936f9cdcd3511d
 Base Flood Elevation 2015,,webpage,,,https://dcp.maps.arcgis.com/apps/webappviewer/index.html?id=1c37d271fba14163bbb520517153d6d5
 Limit of Moderate Wave Action,dcp_limwa,download,shapefile,MULTILINESTRING,https://dcp.maps.arcgis.com/home/item.html?id=e089b65f8a914c80ab72082a1522c7f2
 Future Floodplain 2050s,dcp_floodplain_2050_100,download,shapefile,MULTIPOLYGON,https://dcp.maps.arcgis.com/home/item.html?id=cc996fdd1a134d18a6ae7e3a1ecfe84b
-Coastal Zone Boundary,dcp_wrp_coastal_zone_boundary,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-wrp.page
-Ecologically Sensistive Maritime and Industrial Area,dcp_wrp_sensitive_maritime_and_industrial_area,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-wrp.page
-Priority Marine Activity Zones,dcp_wrp_priority_marine_activity_zones,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-wrp.page
+Coastal Zone Boundary,dcp_wrp_coastal_zone_boundary,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
+Ecologically Sensistive Maritime and Industrial Area,dcp_wrp_sensitive_maritime_and_industrial_area,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
+Priority Marine Activity Zones,dcp_wrp_priority_marine_activity_zones,download,shapefile,MULTILINESTRING,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
 Recognized Ecological Complexes,dcp_wrp_recognized_ecological_complexes,download,shapefile,MULTIPOINT,
-Significant Maritime and Industrial Area,dcp_wrp_significant_maritime_and_industrial_area,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-wrp.page
+Significant Maritime and Industrial Area,dcp_wrp_significant_maritime_and_industrial_area,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
 Special Natural Waterfront Areas,dcp_wrp_special_natural_waterfront_areas,download,shapefile,MULTIPOLYGON,
 OneNYC,,webpage,,,https://climate.cityofnewyork.us/reports/onenyc-2050/
 Neighborhood Plans,,webpage,,,https://www.nyc.gov/site/hpd/services-and-information/neighborhood-planning.page
 CB Statement of Needs,,webpage,,,https://communityprofiles.planning.nyc.gov/
-Borough and Citywide Initiatives,,webpage,,,https://www.nyc.gov/site/planning/plans/city-wide.page
+Borough and Citywide Initiatives,,webpage,,,https://www.nyc.gov/content/planning/pages/our-work#plans
 EDC Plans,,webpage,,,https://edc.nyc/explore-our-work
-197-a Plans,,webpage,,,https://www.nyc.gov/site/planning/community/community-based-planning.page
+197-a Plans,,webpage,,,https://www.nyc.gov/content/planning/pages/planning/neighborhood-planning#197
 Housing New York,,webpage,,,https://www.nyc.gov/site/housing/index.page
 Where We Live NYC 2025,,webpage,,,https://wherewelive.cityofnewyork.us/
-DCP LION,dcp_lion,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-lion.page
-Borough Boundaries,dcp_boroboundaries,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page
+DCP LION,dcp_lion,download,shapefile,MULTILINESTRING,https://www.nyc.gov/content/planning/pages/resources/datasets/lion
+Borough Boundaries,dcp_boroboundaries,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/borough-boundaries
 DPR Parks Properties,dpr_parksproperties,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/Recreation/Parks-Properties/enfh-gkve/about_data
 Subways,,webpage,,,https://www.mta.info/developers
 Roadbeds,doitt_roadbed,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/Transportation/NYC-Planimetric-Database-Roadbed/i36f-5ih7/about_data
-NYC Waterfront Revitalization Program Overview,,webpage,,,https://www.nyc.gov/site/planning/planning-level/waterfront/wrp/wrp.page
+NYC Waterfront Revitalization Program Overview,,webpage,,,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
 Jamaica Bay Watershed Protection Plan,,webpage,,,https://www.nyc.gov/assets/oec/Jamaica_Bay_Watershed_Protection_Plan.pdf
 WRP Consistency Assessment Form,,webpage,,,https://www.nyc.gov/assets/planning/download/pdf/applicants/wrp/wrpform2016.pdf
-Flood Elevation Worksheet,,webpage,,,https://www.nyc.gov/site/planning/planning-level/waterfront/wrp/wrp.page
-Census Tract Boundaries,dcp_ct2020_wi,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/site/planning/data-maps/open-data/census-download-metadata.page
+Flood Elevation Worksheet,,webpage,,,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
+Census Tract Boundaries,dcp_ct2020_wi,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/census-tracts
 Population Fact Finder,,webpage,,,https://popfactfinder.planning.nyc.gov/
 Rent by AMI,,webpage,,,https://www.nyc.gov/site/hpd/services-and-information/area-median-income.page
 DCP Vulnerable Population Estimate,dcp_vulnerable_population_estimate,download,excel,,https://www.huduser.gov/portal/datasets/cp.html
@@ -51,7 +51,7 @@ School Seats Lost,,webpage,,,https://www.nycsca.org/Community/Capital-Plan-Repor
 School Seats Gained or To Be Created,,webpage,,,https://www.nycsca.org/Community/Capital-Plan-Reports-Data#Local-Law-167-Reports-352
 All School Proposals,,webpage,,,https://www.nycsca.org/Community/Capital-Plan-Reports-Data#Housing-Projections-70
 Projected Public School Ratio,,webpage,,,https://www.nycsca.org/Community/Capital-Plan-Reports-Data#Housing-Projections-70
-Facilities Database,dcp_facilities,download,shapefile,MULTIPOINT,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-selfac.page
+Facilities Database,dcp_facilities,download,shapefile,MULTIPOINT,https://www.nyc.gov/content/planning/pages/resources/datasets/facilities
 POPS,dcp_pops,download,shapefile,MULTIPOINT,https://data.cityofnewyork.us/City-Government/Privately-Owned-Public-Spaces-POPS-/rvih-nhyn/about_data
 Plazas,dot_pedplazas,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/Transportation/NYC-DOT-Pedestrian-Plazas/k5k6-6jex/about_data
 Waterfront Public Access Areas,dcp_waterfront_public_access_areas,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-waterfront-access-map
@@ -61,7 +61,7 @@ Federal Parks,usnps_parks,download,shapefile,MULTIPOLYGON,https://nps.maps.arcgi
 NYC Parks Active and Passive Recreation,dpr_active_passive_recreation,download,csv,,https://data.cityofnewyork.us/Recreation/NYC-Parks-Active-and-Passive-Recreation/kcqe-vnci/about_data
 Parks Capital Projects Tracker,dpr_capitalprojects,download,shapefile,MULTIPOINT,https://www.nycgovparks.org/planning-and-building/capital-project-tracker/upcoming
 Walk to a Park Service Area,dpr_walk_to_a_park,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/dataset/Walk-to-a-Park-Service-Area-for-CEQR-Open-Space-As/k66c-pzws/about_data
-2014 3D Model,,webpage,,,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-nyc-3d-model-download.page
+2014 3D Model,,webpage,,,https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-3d-model
 Building Heights,,webpage,,,https://data.cityofnewyork.us/Housing-Development/Building-Heights/pffy-49n3
 Building Footprints,,webpage,,,https://data.cityofnewyork.us/City-Government/Building-Footprints-Map-/3g6p-4u5s
 Historic Building (NYC),lpc_landmarks,download,shapefile,MULTIPOINT,https://data.cityofnewyork.us/Housing-Development/Designated-and-Calendared-Buildings-and-Sites/ncre-qhxs/about_data
@@ -132,6 +132,6 @@ CATS Permits,dep_cats_permits,download,csv,,https://gisservices.dec.ny.gov/gis/d
 DEC State Facilities,nysdec_state_facility_permits,download,csv,,https://gisservices.dec.ny.gov/gis/dil/
 Title V Permits,nysdec_title_v_facility_permits,download,csv,,https://gisservices.dec.ny.gov/gis/dil/
 Vent Tower Data,dcp_air_quality_vent_towers,download,shapefile,MULTIPOLYGON,
-Arterial Highways,dcm_arterial_highways,download,shapefile,MULTILINESTRING,https://www.nyc.gov/site/planning/data-maps/open-data/dwn-digital-city-map.page
+Arterial Highways,dcm_arterial_highways,download,shapefile,MULTILINESTRING,https://nyc.gov/content/planning/pages/resources/datasets/digital-city-map
 RWCDS Analysis Framework Table,,webpage,,,https://www.nyc.gov/assets/planning/downloads/excel/applicants/preparing-application/part2-rwcds-analysis-framework-table.xlsx
 RWCDS Analysis Spreadsheet,,webpage,,,https://www.nyc.gov/assets/planning/downloads/excel/applicants/preparing-application/part3-rwcds-analysis-framework-spreadsheet.xlsx


### PR DESCRIPTION
closes #1904, closes #1900

all builds on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-ceqr-bytes)

I added URL validation but I'm getting erroneous 403 status codes for URLs that seem fine (see failed builds linked above). Added TODOs and changed error raising to logging for now so we can get this merged before redirects stop working.

Definitely open to suggestions for renaming `utils/http.py` (web? network?).