### PR TITLE
properly rename fields when geom type is NONE

### DIFF
--- a/dcpy/library/ingest.py
+++ b/dcpy/library/ingest.py
@@ -159,11 +159,15 @@ def translator(func):
             else None
         )
 
+        has_geom = (
+            dataset.source.geometry is not None
+            and dataset.source.geometry.type != "NONE"
+        )
         sql = format_field_names(
             srcDS,
             dataset.destination.fields,
             dataset.destination.sql,
-            dataset.source.geometry is not None,
+            has_geom,
             output_format,
             csv_geom_fields=csv_geom_names,
         )


### PR DESCRIPTION
closes #1906 - fallout from #1847 (an oversight by me - I used presence of the `geometry` field as an indicator of whether there was a geom or not, but many templates have explicit `geometry: {type: None}`).

Though also shocked about how it was handled - double quotes in this gdal sqlite flavor is a column identifier... but apparently if that column is missing it's treated as a string literal. Unhinged behavior.