### PR TITLE
fix use of ingest `doe_school_subdistricts`

### DIFF
--- a/ingest_templates/doe_school_subdistricts.yml
+++ b/ingest_templates/doe_school_subdistricts.yml
@@ -26,6 +26,12 @@ ingestion:
           "zone": "subdistrict",
           "subdist": "name"
         }
+  - name: coerce_column_types
+    args:
+      column_types:
+        {
+          "district": "string"
+        }
 
 columns:
 - id: district

--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -43,7 +43,6 @@ inputs:
     - name: dcp_ct2020_wi
     - name: dcp_school_districts
     - name: doe_school_subdistricts
-      file_type: pg_dump
     - name: dcp_facilities
       file_type: pg_dump
     - name: dcp_pops


### PR DESCRIPTION
closes 2 out of 3 of https://github.com/NYCPlanning/data-engineering/issues/1975

successful builds of CEQR and KPDB: [all builds](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-fix-subdistricts) on this branch