### PR TITLE
fix facdb gdb layer name

### DIFF
--- a/products/facilities/facdb/bash/export.sh
+++ b/products/facilities/facdb/bash/export.sh
@@ -23,7 +23,7 @@ mkdir -p output && (
     # csv_export geo_rejects &
     # csv_export geo_result &
     shp_export facdb_export POINT -f facilities -t_srs "EPSG:2263"
-    fgdb_export facdb_export POINT facilities
+    fgdb_export facdb_export POINT facilities EPSG:2263 facdb
     wait
     echo "export complete"
 )


### PR DESCRIPTION
build repeated [here](https://github.com/NYCPlanning/data-engineering/actions/runs/18199195595/job/51813467076). In #1965 I changed the name of the final facdb table because it was annoying that it dropped it and recreated with new column names at the end, but forgot that as written it would then export with the new table name as its layer name.

```
finnvankrieken@DCP-APPLE-2153 Downloads % ogrinfo facilities.gdb.zip -ro
INFO: Open of `facilities.gdb.zip'
      using driver `OpenFileGDB' successful.
Layer: facdb (Point)
finnvankrieken@DCP-APPLE-2153 Downloads % 
```
