### PR TITLE
Fixes BYTES version lookup for housing db + Add integration test

### DIFF
--- a/dcpy/connectors/edm/bytes/_sitemap.py
+++ b/dcpy/connectors/edm/bytes/_sitemap.py
@@ -55,9 +55,24 @@ class _DatasetConfig(BaseModel, extra="forbid"):
     file_resource_override: str | None = None
 
 
-with open(Path(__file__).parent / "site_map.json", "r") as site_map_file:
-    _SiteMap = TypeAdapter(dict[str, dict[str, _DatasetConfig]])
-    SITE_MAP = _SiteMap.validate_python(json.load(site_map_file))
+_site_map_path = Path(__file__).parent / "site_map.json"
+_SiteMap = TypeAdapter(dict[str, dict[str, _DatasetConfig]])
+
+# TODO: everything below should just be a class, and the site_map read into
+# the _connector on init
+
+
+def get_site_map():
+    with open(_site_map_path, "r") as site_map_file:
+        return _SiteMap.validate_python(json.load(site_map_file))
+
+
+SITE_MAP = get_site_map()
+
+
+def reload_site_map():
+    global SITE_MAP
+    SITE_MAP = get_site_map()
 
 
 def get_product_dataset_bytes_resource(product, dataset) -> str:

--- a/dcpy/connectors/edm/bytes/site_map.json
+++ b/dcpy/connectors/edm/bytes/site_map.json
@@ -214,8 +214,11 @@
         }
       }
     },
+
+
     "housing_database_by_2020_census_block": {
-      "bytes_dataset_key": "housing-unit-summary",
+      "bytes_dataset_key": "housing-unit-change-summary",
+      "file_resource_override": "housing-unit-summary",
       "files": {
         "shapefile": {
           "filename": "nychdb_cblock_{v}_shp.zip"
@@ -229,7 +232,8 @@
       }
     },
     "housing_database_by_2020_census_tract": {
-      "bytes_dataset_key": "housing-unit-summary",
+      "bytes_dataset_key": "housing-unit-change-summary",
+      "file_resource_override": "housing-unit-summary",
       "files": {
         "shapefile": {
           "filename": "nychdb_ctract_{v}_shp.zip"
@@ -243,7 +247,8 @@
       }
     },
     "housing_database_by_2020_nta": {
-      "bytes_dataset_key": "housing-unit-summary",
+      "bytes_dataset_key": "housing-unit-change-summary",
+      "file_resource_override": "housing-unit-summary",
       "files": {
         "shapefile": {
           "filename": "nychdb_nta_{v}_shp.zip"
@@ -257,7 +262,8 @@
       }
     },
     "housing_database_by_2020_cdta": {
-      "bytes_dataset_key": "housing-unit-summary",
+      "bytes_dataset_key": "housing-unit-change-summary",
+      "file_resource_override": "housing-unit-summary",
       "files": {
         "shapefile": {
           "filename": "nychdb_cdta_{v}_shp.zip"
@@ -271,7 +277,8 @@
       }
     },
     "housing_database_by_2024_city_council": {
-      "bytes_dataset_key": "housing-unit-summary",
+      "bytes_dataset_key": "housing-unit-change-summary",
+      "file_resource_override": "housing-unit-summary",
       "files": {
         "shapefile": {
           "filename": "nychdb_council_{v}_shp.zip"
@@ -285,7 +292,8 @@
       }
     },
     "housing_database_by_community_district": {
-      "bytes_dataset_key": "housing-unit-summary",
+      "bytes_dataset_key": "housing-unit-change-summary",
+      "file_resource_override": "housing-unit-summary",
       "files": {
         "shapefile": {
           "filename": "nychdb_community_{v}_shp.zip"

--- a/dcpy/test_integration/connectors/edm/test_bytes.py
+++ b/dcpy/test_integration/connectors/edm/test_bytes.py
@@ -1,0 +1,21 @@
+from tabulate import tabulate  # type: ignore
+
+from dcpy.connectors.edm.bytes import BytesConnector
+from dcpy.utils.logging import logger
+
+
+def test_bytes_versions_are_retrieved():
+    versions = BytesConnector().fetch_all_latest_versions_df()
+    with_errors = versions.loc[versions["version_fetch_error"].astype(bool)]
+    if not with_errors.empty:
+        logger.error(
+            tabulate(
+                with_errors[["version_fetch_error"]],
+                headers="keys",
+                tablefmt="presto",
+                maxcolwidths=[40, 40],
+            )
+        )
+    assert with_errors.empty, (
+        f"""No errors should be when fetching versions, however the following datasets have errors: {str(with_errors.index.values)}. See the logs for details"""
+    )


### PR DESCRIPTION
Fixes the version lookup for housing db, while ensuring that file-urls still work via an integration test.

The change to _sitemap is a quality of life hack, so that you can reload the conf. It can be improved (see comment).