### PR TITLE
OpenData: Add 2 mins of sleep on publish

### DIFF
--- a/dcpy/connectors/edm/open_data_nyc.py
+++ b/dcpy/connectors/edm/open_data_nyc.py
@@ -137,6 +137,7 @@ class OpenDataConnector(VersionedConnector):
             return result
         else:
             logger.info("Publishing")
+            time.sleep(120)  # random time to let the file fully upload
             rev.apply()
             logger.info(
                 "Revision Applied. Polling for publication completion (this can take minutes)."


### PR DESCRIPTION
This is a dirty hack to allows us to publish revisions in GHA. We really should poll Socrata that the dataset upload has finished processing, but I don't have the time/motivation to work on that right now.