### PR TITLE
dashboard for distributing

### DIFF
--- a/apps/qa/src/pages/dashboard/dashboard.py
+++ b/apps/qa/src/pages/dashboard/dashboard.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import streamlit as st
+
+# from dcpy.utils.git import github
+from dcpy.lifecycle.scripts.version_compare import run as compare_versions
+## from src.shared.components.github import dispatch_workflow_button
+
+
+def show_versions_streamlit_table(df: pd.DataFrame) -> None:
+    st.write("## Distribution Status")
+
+    for (product, dataset), row in df.iterrows():
+        dataset_name = f"{product}.{dataset}"
+        bytes_version = row["bytes_version"]
+        open_version = row["open_data_versions"]
+
+        cols = st.columns([4, 2, 3, 1, 1])
+        cols[0].markdown(f"**{dataset_name}**")
+        cols[1].write(bytes_version)
+        cols[2].write(open_version)
+        if bytes_version == open_version:
+            cols[3].markdown(
+                "<span style='color:green;font-size:20px'>&#10004;</span>",
+                unsafe_allow_html=True,
+            )
+        else:
+            cols[3].markdown(
+                "<span style='color:red;font-size:20px'>&#10008;</span>",
+                unsafe_allow_html=True,
+            )
+        # button doesn't do anything for now
+        cols[4].button("Action", key=f"action_{row}")
+
+
+def dashboard():
+    show_versions_streamlit_table(compare_versions())

--- a/apps/qa/src/shared/constants.py
+++ b/apps/qa/src/shared/constants.py
@@ -10,6 +10,7 @@ SQL_FILE_DIRECTORY = Path().absolute() / ".data/sql"
 PAGES = {
     "Home": "home",
     "Capital Projects DB": "cpdb",
+    "Distribution Dashboard": "dashboard",
     "City Owned and Leased Properties": "colp",
     "Developments DB": "devdb",
     "Equitable Development Data Explorer": "edde",


### PR DESCRIPTION
Wanted to play around and then realized I really should be doing other things

Opening this PR as an open invitation for anyone to contribute when they feel like it. Vision here being a dashboard where you can
1. see status of all datasets to distribute
2. hit a button to distribute them

<img width="1047" height="239" alt="image" src="https://github.com/user-attachments/assets/2f6586ae-bb52-411b-87f3-1e2d306b169a" />

currently missing
- the button actually doing anything. see GRU pages for example of how to trigger ghas from the app
- grouping/filtering by product?
- halfway decent formatting
- handling of errors that are stored as strings in the lifecycle script
- better display of what is "good" or not. check marks and x's are fine, but looks a little silly
