### PR TITLE
lower tolerance for joining nodes

### DIFF
--- a/products/lion/models/intermediate/nodes/int__segments_to_nodes.sql
+++ b/products/lion/models/intermediate/nodes/int__segments_to_nodes.sql
@@ -33,4 +33,4 @@ SELECT
     seg.direction,
     nodes.nodeid
 FROM segment_endpoints AS seg
-INNER JOIN nodes ON st_dwithin(seg.geom, nodes.geom, 0.01)
+INNER JOIN nodes ON st_dwithin(seg.geom, nodes.geom, 0.0025)


### PR DESCRIPTION
Part of #1872. See [this comment](https://github.com/NYCPlanning/data-engineering/issues/1872#issuecomment-3457024135) for screenshots of this issue. Both of the nodes with issues are ~0.005 feet apart. I've contacted GR to see if this is something they want to try to resolve on the data side, but figure we might want to do that more holistically (as in, try to charactarize ALL "too-close" nodes in a report to them rather than just these two cases which popped up in our pipeline with our arbitrary buffer).

In the meantime, figured we could just fix on the pipeline side

after running build, the following queries return no records, meaning all segments have 1 and exactly 1 `from node` and `to node`
```sql

select segmentid from int__segments_to_nodes
	group by segmentid, direction
	having count(*) > 1
	order by segmentid
	
select * from int__lion where to_nodeid is null or from_nodeid is null
```