### PR TITLE
fix int conversion on pluto qa page

### DIFF
--- a/apps/qa/src/pages/pluto/components/outlier_report.py
+++ b/apps/qa/src/pages/pluto/components/outlier_report.py
@@ -85,12 +85,12 @@ class OutlierReport:
 
             # round values to integer in numeric-like columns
             for col in df.columns:
-                if col != "bbl":
+                if col == "bbl":
+                    df["bbl"] = pd.to_numeric(df["bbl"], downcast="integer")
+                elif col != "ownername":
                     df[col] = pd.to_numeric(
                         df[col], errors="coerce", downcast="integer"
-                    )
-                else:
-                    df["bbl"] = pd.to_numeric(df["bbl"], downcast="integer")
+                    ).round()
 
             return df
         else:


### PR DESCRIPTION
Deployed this a month ago, forgot to merge.

Mainly - cant round numbers before they're cast to numbers. Not sure why it used to work (or at least not be noticeable errors)