### PR TITLE
fix pathing issue in pull

### DIFF
--- a/dcpy/connectors/ingest_datastore.py
+++ b/dcpy/connectors/ingest_datastore.py
@@ -81,7 +81,7 @@ class Connector(VersionedConnector, arbitrary_types_allowed=True):
         )
         return self.storage.pull(
             f"{key}/{version}/{filename}",
-            destination_path,
+            destination_path / filename,
         )
 
     def list_versions(self, key: str, *, sort_desc: bool = True, **kwargs) -> list[str]:


### PR DESCRIPTION
See https://github.com/NYCPlanning/data-engineering/actions/runs/18988480535/job/54237887693?pr=2038#step:9:30 - current implementation pulls instead to the folder name. So a parquet file named "25v3" instead of "25v3/ds_id.parquet".