### PR TITLE
use issue types in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -1,7 +1,7 @@
 name: Project
 description: Scope and track a multi-issue project
 title: "PROJECT TITLE"
-labels: ["project"]
+type: Project
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/scheduled_action_failure.md
+++ b/.github/ISSUE_TEMPLATE/scheduled_action_failure.md
@@ -2,6 +2,7 @@
 name: "Scheduled Action Failure"
 about: Notification For failed attempt of scheduled github action
 title: "Scheduled Action Failure - {{ env.ACTION }}"
+type: Bug
 assignees: []
 
 ---


### PR DESCRIPTION
for certain attributes of an issue, giving it a type is better than giving it labels