### PR TITLE
LION ETL: Address non-centerline Coincident Segment Count

### DIFF
--- a/products/lion/models/intermediate/coincident_segments/int__noncenterline_coincident_segment_count.sql
+++ b/products/lion/models/intermediate/coincident_segments/int__noncenterline_coincident_segment_count.sql
@@ -10,18 +10,24 @@ WITH spatial_matches AS (
         segmentid,
         COUNT(*) AS sm_count
     FROM {{ ref('int__noncenterline_coincident_segments') }}
-    WHERE distance < 1
+    -- Note: this distance is somewhat arbitrary, but through trial and error it seems
+    -- to be about the sweet spot where decreasing it results in our missing matches,
+    -- and vice-versa.
+    WHERE distance < .001
     GROUP BY segmentid
 ),
 proto_segments AS (
     SELECT
         segmentid,
         COUNT(*) AS ps_count
-    FROM {{ ref('stg__altsegmentdata_proto') }}
+    FROM {{ source('recipe_sources', 'dcp_cscl_altsegmentdata') }}
+    WHERE segmentid NOT IN (SELECT segmentid FROM {{ ref('int__underground_rail') }})
+    --    WHERE alt_segdata_type <> 'S' TODO - this is behavior described in docs
+    --                                  but C# code does not filter on this
     GROUP BY segmentid
 )
 SELECT
-    sm.segmentid,
+    COALESCE(sm.segmentid, ps.segmentid) AS segmentid,
     COALESCE(sm_count, 1) + COALESCE(ps_count, 0) AS coincident_seg_count
 FROM spatial_matches AS sm
 FULL JOIN proto_segments AS ps ON sm.segmentid = ps.segmentid

--- a/products/lion/models/intermediate/coincident_segments/int__noncenterline_coincident_segments.sql
+++ b/products/lion/models/intermediate/coincident_segments/int__noncenterline_coincident_segments.sql
@@ -1,6 +1,7 @@
--- Potential Spatial Matches between centerlines and underground trains (subways + rail)
--- Leaving this separate from the counts, for diagnostic/exporatory purposes.
--- NOTE the current approach may cause issues with proto-segment coincident counts
+-- Spatial matches for non-centerline segments.
+-- The current ETL logic (which differs from the legacy ETL docs...) is:
+-- 1. match non-centerline segments to their own type (e.g. shorelines with shorelines)
+-- 2. then match them to centerlines (except when they're subeterranean rail)
 
 {{ config(
     materialized = 'table',
@@ -9,36 +10,24 @@
     ]
 ) }}
 
--- Exact matches catch all but ~50 or so
-WITH exact_matches AS (
-    SELECT
-        s.segmentid,
-        r.segmentid AS joined_segment_id,
-        r.feature_type AS joined_segment_feature_type,
-        'exact' AS match_type,
-        0 AS distance
-    FROM {{ ref('int__primary_segments') }} AS s
-    INNER JOIN {{ ref('int__primary_segments') }} AS r ON ST_EQUALS(r.geom, s.geom)
-    WHERE s.feature_type NOT IN ('centerline', 'nonstreetfeatures')
-),
-fuzzy_matches AS (
-    SELECT
-        s.segmentid,
-        r.segmentid AS joined_segment_id,
-        r.feature_type AS joined_segment_feature_type,
-        'fuzzy' AS match_type,
-        ST_DISTANCE(r.midpoint, s.midpoint) AS distance
-    FROM {{ ref('int__primary_segments') }} AS s
-    INNER JOIN {{ ref('int__primary_segments') }} AS r
-        -- 2.5 is probably too wide, but convenient for diagnostic/exporatory purposes
-        ON ST_DWITHIN(r.midpoint, s.midpoint, 2.5)
-    -- `WHERE NOT...` below shaves off a few seconds from the more conventional:
-    -- WHERE r.segmentid NOT IN (SELECT trains_segment_id FROM exact_matches)
-    WHERE s.feature_type NOT IN ('centerline', 'nonstreetfeatures') AND NOT EXISTS (
-        SELECT 1 FROM exact_matches AS em
-        WHERE em.joined_segment_id = r.segmentid
-    )
-)
-SELECT * FROM exact_matches
-UNION ALL
-SELECT * FROM fuzzy_matches
+--
+SELECT
+    s.segmentid,
+    coinc.segmentid AS coinc_segment_id,
+    coinc.feature_type AS coinc_segment_feature_type,
+    'fuzzy' AS match_type,
+    ST_DISTANCE(s.midpoint, coinc.midpoint) AS distance
+FROM {{ ref('int__primary_segments') }} AS s
+INNER JOIN {{ ref('int__primary_segments') }} AS coinc
+    ON
+        ST_DWITHIN(s.midpoint, coinc.midpoint, 2.5)
+        AND
+        (
+            s.feature_type = coinc.feature_type  -- match to segments of same type
+            OR
+            (
+                coinc.feature_type = 'centerline'
+                AND s.segmentid NOT IN (SELECT segmentid FROM {{ ref('int__underground_rail') }})  -- to centerlines without underground rail
+            )
+        )
+WHERE s.feature_type <> 'centerline'


### PR DESCRIPTION
This brings us down to just a handful of non-centerline coincident segments that differ from the prod ETL. I've emailed GR a list of segments that should probably be consolidated (redrawn) in CSCL - they're nearly identical geometrically, but nonequal, and they cause an issue with prod. 

| segment id | matched segment id |
|---|---|
| 257795 | 288944 |
| 281438 | 281437 |
| 329244 | 125345 |
| 329038 | 123124 |
| 8104016 | 352007 |

So after we merge this, we can wait and see if the next CSCL dump fixes these. 

### Worth flagging
1. t looks like there are still a number of centerline segments with differing coincident segment counts - we'll need to address that.
2. We should note somewhere that the docs are quite a ways off from what the C# ETL was doing. @fvankrieken thoughts on where? Also, that the C# ETL wasn't implementing this: `alt_segdata_type <> 'S'` (nor are we, here)
