### PR TITLE
drop type from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -1,7 +1,6 @@
 name: Project
 description: Scope and track a multi-issue project
 title: "PROJECT TITLE"
-type: Project
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/scheduled_action_failure.md
+++ b/.github/ISSUE_TEMPLATE/scheduled_action_failure.md
@@ -2,7 +2,6 @@
 name: "Scheduled Action Failure"
 about: Notification For failed attempt of scheduled github action
 title: "Scheduled Action Failure - {{ env.ACTION }}"
-type: Bug
 assignees: []
 
 ---


### PR DESCRIPTION
follow up to #2053

this feature doesn't work like I thought it would and nightly QA [failed to create an issue](https://github.com/NYCPlanning/data-engineering/actions/runs/19454877870/job/55685597674)