### PR TITLE
expand default request header

### DIFF
--- a/dcpy/connectors/web.py
+++ b/dcpy/connectors/web.py
@@ -7,8 +7,11 @@ from dcpy.connectors.registry import Pull
 
 def download_file(url: str, path: Path) -> None:
     """Simple wrapper to download a file using requests.get."""
+    # browser-like headers since some servers block non-browser requests
     default_headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36",
+        "Accept": "application/json, text/javascript, */*; q=0.01",
+        "Referer": "https://www.nycgovparks.org/",
     }
     logger.info(f"downloading {url} to {path}")
     response = requests.get(url, headers=default_headers)


### PR DESCRIPTION
[ingest runs](https://github.com/NYCPlanning/data-engineering/actions/workflows/ingest_single.yml?query=branch%3Adm-fix-web-dpr) on this branch

ingest of `dpr_capitalprojects` is failing with `403 Client Error: Forbidden for url`

but clicking the url [https://www.nycgovparks.org/bigapps/DPR_CapitalProjectTracker_001.json](https://www.nycgovparks.org/bigapps/DPR_CapitalProjectTracker_001.json) downloads the file

also these curl runs from my terminal worked:
```bash
curl 'https://www.nycgovparks.org/bigapps/DPR_CapitalProjectTracker_001.json'

curl -i -L \
  -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36" \
  -H "Accept: application/json, text/javascript, */*; q=0.01" \
  -H "Referer: https://www.nycgovparks.org/" \
  'https://www.nycgovparks.org/bigapps/DPR_CapitalProjectTracker_001.json'
```