### PR TITLE
bump cscl version in recipe

### DIFF
--- a/products/cscl/recipe.yml
+++ b/products/cscl/recipe.yml
@@ -1,6 +1,6 @@
 name: CSCL
 product: cscl
-version: 25c_fixed
+version: 25d
 
 inputs:
   datasets:


### PR DESCRIPTION
this should not be hardcoded but I 1) want this bumped and 2) want to keep the pinning all versions to the same without implementing an actual solution for that right now other than this current implementation