### PR TITLE
Scaffold some notebooks

### DIFF
--- a/notebooks/marimo/admin/version_comparison.py
+++ b/notebooks/marimo/admin/version_comparison.py
@@ -1,0 +1,1 @@
+# We'll implement the little dashboard here for bytes <> socrata version comparison

--- a/notebooks/marimo/products/pluto/far.py
+++ b/notebooks/marimo/products/pluto/far.py
@@ -1,0 +1,1 @@
+# This is where I'll put my FAR comparison stuff for PLUTO


### PR DESCRIPTION
Talking to @damonmcc about this, and I'd love to have the my QA for dataset modifications result in something a little less throwaway - ie instead of slopping some queries into DBeaver, it'd be nice to make a durable, reusable little notebook instead. 

The main reason for centralizing them in one top-level folder is that a little further down the road we can have a marimo notebook server in the `apps/` folder, which we can bundle up with dcpy in Docker, and deploy to Azure as a companion to the QA/AC app. It'd be nice to have a single folder to point at, as opposed to having notebooks scattered around the repo (e.g. in products/pluto/my_notebook.py). 

I mostly want input before I add my notebook for PLUTO