### PR TITLE
Postgres Recipe Caching

### DIFF
--- a/dcpy/test_integration/conftest.py
+++ b/dcpy/test_integration/conftest.py
@@ -1,6 +1,5 @@
-from pathlib import Path
 import os
-
+from pathlib import Path
 
 RESOURCES_DIR = Path(__file__).parent / "resources"
 

--- a/dcpy/test_integration/connectors/edm/test_plan_load.py
+++ b/dcpy/test_integration/connectors/edm/test_plan_load.py
@@ -1,9 +1,9 @@
-from pathlib import Path
 import shutil
+from pathlib import Path
 
-from dcpy.utils import postgres
-from dcpy.lifecycle.builds import plan, load
+from dcpy.lifecycle.builds import load, plan
 from dcpy.models.lifecycle.builds import InputDatasetDestination
+from dcpy.utils import postgres
 
 RESOURCES = Path(__file__).parent / "resources"
 RECIPE_PATH = RESOURCES / "recipe.yml"

--- a/dcpy/test_integration/lifecycle/builds/load/conftest.py
+++ b/dcpy/test_integration/lifecycle/builds/load/conftest.py
@@ -1,0 +1,61 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from dcpy.connectors.registry import VersionedConnector
+from dcpy.lifecycle import connector_registry
+from dcpy.utils import postgres
+
+
+class MockVersionedConnector(VersionedConnector):
+    conn_type: str = "mock_recipes_source"
+    pull_call_count: int = 0
+
+    def reset_mock(self):
+        self.pull_call_count = 0
+
+    def pull_versioned(
+        self, key: str, version: str, destination_path: Path, **kwargs
+    ) -> dict:
+        self.pull_call_count += 1
+        # Copy the mock CSV file to the destination
+        source_file = Path(__file__).parent / "resources" / "test_dataset.csv"
+        destination_file = destination_path / f"{key}.csv"
+        destination_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(source_file, destination_file)
+        return {"path": destination_file}
+
+    def push_versioned(self, key: str, version: str, **kwargs) -> dict:
+        return {"status": "success"}
+
+    def get_latest_version(self, key: str, **kwargs) -> str:
+        return "2025v2"
+
+    def list_versions(self, key: str, **kwargs) -> list[str]:
+        return ["2025v2"]
+
+    def assert_pull_not_called(self):
+        assert self.pull_call_count == 0, (
+            f"Expected pull_versioned not to be called, but it was called {self.pull_call_count} times"
+        )
+
+    def assert_pull_called_once(self):
+        assert self.pull_call_count == 1, (
+            f"Expected pull_versioned to be called once, but it was called {self.pull_call_count} times"
+        )
+
+
+@pytest.fixture
+def setup_mock_connector():
+    mock_connector = MockVersionedConnector()
+    connector_registry.connectors.clear()
+    connector_registry.connectors.register(
+        mock_connector, conn_type="mock_recipes_source"
+    )
+    yield mock_connector
+
+
+@pytest.fixture
+def pg_client():
+    return postgres.PostgresClient(schema="lifecycle_builds_tests")

--- a/dcpy/test_integration/lifecycle/builds/load/resources/recipe.yml.lock
+++ b/dcpy/test_integration/lifecycle/builds/load/resources/recipe.yml.lock
@@ -1,0 +1,10 @@
+product: test
+name: cache_test
+version: 1.0
+inputs:
+  datasets:
+    - id: test_dataset
+      source: mock_recipes_source
+      version: 2025v2
+      file_type: csv
+      destination: postgres

--- a/dcpy/test_integration/lifecycle/builds/load/resources/test_dataset.csv
+++ b/dcpy/test_integration/lifecycle/builds/load/resources/test_dataset.csv
@@ -1,0 +1,3 @@
+name,value
+item1,value_one
+item2,value_two

--- a/dcpy/test_integration/lifecycle/builds/load/test_load_cache.py
+++ b/dcpy/test_integration/lifecycle/builds/load/test_load_cache.py
@@ -1,0 +1,152 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from dcpy.lifecycle.builds.load import (
+    CachedEntityType,
+    load_source_data_from_resolved_recipe,
+)
+from dcpy.utils import postgres
+
+RECIPE_PATH = Path(__file__).parent / "resources" / "recipe.yml.lock"
+RECIPE_CACHE_SCHEMA = "test_cache_schema"
+BUILD_SCHEMA = "test_build_schema"
+build_pg_client = postgres.PostgresClient(schema=BUILD_SCHEMA)
+
+# Load expected data from test CSV
+TEST_DATA = pd.read_csv(Path(__file__).parent / "resources" / "test_dataset.csv")
+
+
+@pytest.fixture
+def setup_cache_schema(pg_client, setup_mock_connector):
+    """Create cache schema using target_schema parameter"""
+
+    # Load data into the cache
+    load_source_data_from_resolved_recipe(
+        RECIPE_PATH,
+        clear_pg_schema=True,
+        target_schema=RECIPE_CACHE_SCHEMA,
+        _write_metadata_file=False,
+    )
+
+    setup_mock_connector.reset_mock()
+    yield
+
+    # Cleanup cache schema
+    cache_pg_client = postgres.PostgresClient(schema=RECIPE_CACHE_SCHEMA)
+    cache_pg_client.drop_schema()
+
+
+@pytest.mark.parametrize(
+    "cached_entity_type",
+    [CachedEntityType.view, CachedEntityType.copy],
+)
+def test_builds_load_source_data_caching(
+    pg_client, setup_mock_connector, setup_cache_schema, cached_entity_type
+):
+    mock_connector = setup_mock_connector
+
+    load_source_data_from_resolved_recipe(
+        RECIPE_PATH,
+        cache_schema=RECIPE_CACHE_SCHEMA,
+        cached_entity_type=cached_entity_type,
+        clear_pg_schema=True,
+        target_schema=BUILD_SCHEMA,
+        _write_metadata_file=False,
+    )
+
+    assert mock_connector.pull_call_count == 0, (
+        "The mock connector's pull method should NOT have been called (cache hit)"
+    )
+
+    # Assert data was created in build schema
+    data = build_pg_client.execute_select_query(
+        'SELECT name, value FROM "test_dataset" ORDER BY name'
+    )
+    pd.testing.assert_frame_equal(
+        data.reset_index(drop=True),
+        TEST_DATA.sort_values("name").reset_index(drop=True),
+    )
+
+    expected_is_view = cached_entity_type == CachedEntityType.view
+    assert build_pg_client.is_view("test_dataset") is expected_is_view, (
+        "The created entity type should match expectations (table or view)"
+    )
+
+
+def test_builds_load_source_data_caching__cache_miss_wrong_version(
+    pg_client, setup_mock_connector, setup_cache_schema, tmp_path
+):
+    """Test that loading proceeds as normal when the cached data version is different."""
+    mock_connector = setup_mock_connector
+
+    # Create a temporary recipe with different version (different from cache) and load it.
+    with open(RECIPE_PATH, "r") as f:
+        recipe_data = yaml.safe_load(f)
+    recipe_data["inputs"]["datasets"][0]["version"] = "1999v1"
+    temp_recipe_path = tmp_path / "temp_recipe.yml.lock"
+    with open(temp_recipe_path, "w") as f:
+        yaml.dump(recipe_data, f)
+
+    load_source_data_from_resolved_recipe(
+        temp_recipe_path,
+        cache_schema=RECIPE_CACHE_SCHEMA,
+        cached_entity_type=CachedEntityType.view,
+        clear_pg_schema=True,
+        target_schema=BUILD_SCHEMA,
+        _write_metadata_file=False,
+    )
+
+    assert mock_connector.pull_call_count == 1, (
+        "The mock connector should have been called (cache miss due to version mismatch)"
+    )
+
+    table_data = build_pg_client.execute_select_query(
+        'SELECT name, value FROM "test_dataset" ORDER BY name'
+    )
+    pd.testing.assert_frame_equal(
+        table_data.reset_index(drop=True),
+        TEST_DATA.sort_values("name").reset_index(drop=True),
+    )
+    assert build_pg_client.is_view("test_dataset") is False
+
+
+@pytest.mark.parametrize(
+    "cached_entity_type",
+    [CachedEntityType.view, CachedEntityType.copy],
+)
+def test_builds_load_source_data_caching__different_import_as_name(
+    pg_client, setup_mock_connector, setup_cache_schema, tmp_path, cached_entity_type
+):
+    """Test that loading from cache works when the import_as name is different."""
+    target_entity_name = "renamed_dataset"
+    # Rename the cache dataset to match import_as
+    cache_pg_client = postgres.PostgresClient(schema=RECIPE_CACHE_SCHEMA)
+    cache_pg_client.rename_table(old_name="test_dataset", new_name=target_entity_name)
+
+    # Create a temporary recipe with an overridden import_as name
+    with open(RECIPE_PATH, "r") as f:
+        recipe_data = yaml.safe_load(f)
+    recipe_data["inputs"]["datasets"][0]["import_as"] = target_entity_name
+    temp_recipe_path = tmp_path / "temp_recipe.yml.lock"
+    with open(temp_recipe_path, "w") as f:
+        yaml.dump(recipe_data, f)
+
+    load_source_data_from_resolved_recipe(
+        temp_recipe_path,
+        cache_schema=RECIPE_CACHE_SCHEMA,
+        cached_entity_type=cached_entity_type,
+        clear_pg_schema=True,
+        target_schema=BUILD_SCHEMA,
+        _write_metadata_file=False,
+    )
+
+    expected_is_view = cached_entity_type == CachedEntityType.view
+    assert build_pg_client.is_view(target_entity_name) is expected_is_view, (
+        "The created entity type should match expectations (table or view)"
+    )
+    assert not build_pg_client.table_or_view_exists("test_dataset"), (
+        "The original dataset name should not exist in the build schema"
+    )

--- a/dcpy/test_integration/utils/postgres/conftest.py
+++ b/dcpy/test_integration/utils/postgres/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+
+from dcpy.utils import postgres
+from dcpy.utils.logging import logger
+
+BUILD_ENGINE_SCHEMA = "lifecycle_builds_tests"
+
+
+@pytest.fixture
+def pg_client():
+    """Create a PostgresClient for testing with an isolated schema."""
+    return postgres.PostgresClient(schema=BUILD_ENGINE_SCHEMA)
+
+
+@pytest.fixture
+def clean_build_engine(pg_client):
+    """Clean the build engine schema before and after each test."""
+    logger.info("Fixture - pre-test - cleaning build engine schema")
+    pg_client.drop_schema()
+    yield pg_client
+    logger.info("Fixture - post-test - cleaned build engine schema")
+    pg_client.drop_schema()

--- a/dcpy/test_integration/utils/postgres/test_postgres.py
+++ b/dcpy/test_integration/utils/postgres/test_postgres.py
@@ -1,0 +1,65 @@
+import uuid
+
+import pandas as pd
+import pytest
+
+SAMPLE_TABLE_NAME = "test_table"
+TEST_DATA = pd.DataFrame(
+    {"name": ["test1", "test2", "test3"], "value": [100, 200, 300]}
+)
+
+
+@pytest.fixture
+def source_schema_with_sample_table(pg_client):
+    test_schema = f"test_source_schema_{uuid.uuid4().hex[:8]}"
+
+    pg_client.execute_query(f'CREATE SCHEMA IF NOT EXISTS "{test_schema}"')
+    pg_client.execute_query(f'''
+        CREATE TABLE "{test_schema}"."{SAMPLE_TABLE_NAME}" (
+            id SERIAL PRIMARY KEY,
+            name TEXT,
+            value INTEGER
+        )
+    ''')
+
+    pg_client.insert_dataframe(TEST_DATA, SAMPLE_TABLE_NAME, schema=test_schema)
+
+    yield test_schema
+
+    pg_client.execute_query(f'DROP SCHEMA IF EXISTS "{test_schema}" CASCADE')
+
+
+def test_creating_a_view_from_another_schema(
+    pg_client, source_schema_with_sample_table
+):
+    result_table_name = pg_client.create_view(
+        SAMPLE_TABLE_NAME, source_schema_with_sample_table
+    )
+    assert pg_client.is_view(SAMPLE_TABLE_NAME), "The created entity should be a view."
+    assert result_table_name == SAMPLE_TABLE_NAME, (
+        "The table's name should match the source table."
+    )
+
+    view_data = pg_client.execute_select_query(
+        f'SELECT name, value FROM "{SAMPLE_TABLE_NAME}" ORDER BY name'
+    ).reset_index(drop=True)
+    pd.testing.assert_frame_equal(view_data, TEST_DATA)
+
+
+def test_copying_a_table_from_another_schema(
+    pg_client, source_schema_with_sample_table
+):
+    result_table_name = pg_client.copy_table(
+        SAMPLE_TABLE_NAME, source_schema_with_sample_table
+    )
+    assert not pg_client.is_view(SAMPLE_TABLE_NAME), (
+        "The created entity should be a table."
+    )
+    assert result_table_name == SAMPLE_TABLE_NAME, (
+        "The view's name should match the source table."
+    )
+
+    view_data = pg_client.execute_select_query(
+        f'SELECT name, value FROM "{SAMPLE_TABLE_NAME}" ORDER BY name'
+    ).reset_index(drop=True)
+    pd.testing.assert_frame_equal(view_data, TEST_DATA)


### PR DESCRIPTION
We've discussed this before when looking at our networking bill, but most of our dataloading in builds could be eliminated. Additionally, we could save same database space by not duplicating data. Also, there's the build-time consideration: Dataloading in pluto currently takes 6-7 minutes, and we can eliminate most of that. 

There are two approaches here:

### For products where immutability is assumed (ie our DBT projects), 
we can specify a schema to act as a cache, and if that schema contains a recipe input (matched on dataset name, version, and file-type) **create a view** in our build-schema targeting that table. There should be no query performance penalty for this. "Dataloading" would take a second or two when all tables were cached.

### Otherwise (no immutability) 
Unfortunately, in products like PLUTO the first thing we do is modify tables from the recipe. So for these cases, we need a cache with unmodified tables, and sadly, we need to copy them into the target schema. There's a performance penalty for this, but it does reduce PLUTO dataloading from 6 mins to 1.


### Maintaining the Cache
We'd also need to maintain a cache. Maybe something like this for PLUTO:
<img width="293" height="250" alt="image" src="https://github.com/user-attachments/assets/80f229bc-70e2-4082-934c-e95a0b749efb" />

Maybe we just hook into the nightly QA builds: perhaps we add a step to modify the cache. So the cache would always represent what's pulled in by `main` 

### What we'd need to do
1. dcpy recipes: add a load command to refresh the cache. It should just upload the datasets that need to be updated, rather than pushing everything.
2. Add that to step to nightly builds
3. modify database cleanup scripts to not delete the recipes-cache schema
~~4. Additional code here: integration tests for postgres utils and cache interactions.~~

### In the Wild
[Here's](https://github.com/NYCPlanning/data-engineering/actions/runs/20359175815/job/58501000813) a PLUTO build with the reduced dataloading time - it's still a whole minute because of the full table copying from the cache.