### PR TITLE
Add Geosupport version to geocoding summary

### DIFF
--- a/dcpy/geosupport/pluto.py
+++ b/dcpy/geosupport/pluto.py
@@ -1,7 +1,18 @@
+import os
+import re
+
 from geosupport import Geosupport, GeosupportError
 import pandas as pd
 
 g = Geosupport()
+
+
+def geosupport_version() -> str | None:
+    geofiles = os.environ.get("GEOFILES")
+    if not geofiles:
+        return None
+    match = re.search(r"version-(\d+[a-zA-Z])", geofiles)
+    return match.group(1) if match else None
 
 
 ####### NUMBLDGS ###########################

--- a/dcpy/lifecycle/ingest/transform.py
+++ b/dcpy/lifecycle/ingest/transform.py
@@ -547,6 +547,7 @@ class ProcessingFunctions:
             custom={
                 "rows_geocoded": int(transformed["latitude"].notna().sum()),
                 "total_rows": len(transformed),
+                "geosupport_version": geosupport_pluto.geosupport_version(),
             },
         )
         return ProcessingResult(df=transformed, summary=summary)


### PR DESCRIPTION
I was trying to figure out which geosupport version was used in pluto_input_geocodes, and aside from inspecting the container used to run the job... didn't seem like there was a way.

Using the GEOFILES env var seems not entirely ideal, but I couldn't find another way to do this. The geosupport bindings in python don't seem to expose a version, nor do the underlying functions (at least not that I could see). Happy for there to be a better way!

I've tested the outputs ([job here](https://github.com/NYCPlanning/data-engineering/actions/runs/20932277465/job/60145933506)) in a dev bucket, and the output in the config.json is
```
                "custom": {
                    "rows_geocoded": 1158870,
                    "total_rows": 1161951,
                    "geosupport_version": "25d"
                }
```