### PR TITLE
Proto Connector Piping

### DIFF
--- a/dcpy/connectors/chain.py
+++ b/dcpy/connectors/chain.py
@@ -1,0 +1,208 @@
+"""
+Connector chaining and resource transfer abstractions.
+
+Enables elegant syntax for transferring resources between connectors:
+    builds_conn.resource(key="pluto", build_note="my-build") >> drafts_conn.resource(key="pluto", version="25v1")
+
+The system automatically chooses the most efficient transfer method:
+- If both connectors are PathedStorageConnectors on the same cloud: direct copy
+- Otherwise: fallback to pull-temp-push pattern
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+
+from dcpy.utils.logging import logger
+
+if TYPE_CHECKING:
+    from dcpy.connectors.base import Connector
+    from dcpy.connectors.pathed_storage import PathedStorageConnector
+
+
+class Resource:
+    """
+    Represents a resource within a connector that can be transferred to another connector.
+
+    Examples:
+        builds_conn.resource(key="pluto", build_note="my-build")
+        drafts_conn.resource(key="pluto", version="25v1", acl="public-read")
+        local_conn.resource(path="/tmp/data")
+    """
+
+    def __init__(self, connector: "Connector", **resource_spec):
+        """
+        Initialize a Resource.
+
+        Args:
+            connector: The connector containing this resource
+            **resource_spec: Connector-specific resource specification (key, version, etc.)
+        """
+        self.connector = connector
+        self.resource_spec = resource_spec
+
+    def __rshift__(self, destination: "Resource") -> "Resource":
+        """
+        Transfer this resource to another resource using >> operator.
+
+        Args:
+            destination: Target resource to transfer to
+
+        Returns:
+            The destination resource for chaining
+        """
+        return transfer_resource(self, destination)
+
+    def __or__(self, destination: "Resource") -> "Resource":
+        """
+        Transfer this resource to another resource using | operator.
+
+        Args:
+            destination: Target resource to transfer to
+
+        Returns:
+            The destination resource for chaining
+        """
+        return transfer_resource(self, destination)
+
+    def __repr__(self) -> str:
+        spec_str = ", ".join(f"{k}={v}" for k, v in self.resource_spec.items())
+        return f"{self.connector.__class__.__name__}.resource({spec_str})"
+
+
+class TransferStrategy(ABC):
+    """Abstract base class for resource transfer strategies."""
+
+    @abstractmethod
+    def can_handle(self, source: Resource, destination: Resource) -> bool:
+        """Check if this strategy can handle the transfer."""
+        pass
+
+    @abstractmethod
+    def transfer(self, source: Resource, destination: Resource) -> Resource:
+        """Execute the transfer."""
+        pass
+
+
+class OptimizedCloudTransfer(TransferStrategy):
+    """
+    Optimized transfer strategy for connectors that support direct transfers.
+
+    Delegates to connector-specific optimization logic rather than making assumptions
+    about connector internals.
+    """
+
+    def can_handle(self, source: Resource, destination: Resource) -> bool:
+        """Check if source connector can optimize transfer to destination connector."""
+        source_conn = source.connector
+        dest_conn = destination.connector
+
+        # Delegate to connector to determine if it can optimize to the destination
+        return hasattr(
+            source_conn, "can_optimize_transfer_to"
+        ) and source_conn.can_optimize_transfer_to(dest_conn)
+
+    def transfer(self, source: Resource, destination: Resource) -> Resource:
+        """Execute optimized transfer via source connector."""
+        logger.info(f"Using optimized transfer: {source} -> {destination}")
+
+        # Delegate the actual transfer to the source connector
+        source.connector.optimized_transfer_to(
+            dest_connector=destination.connector,
+            source_spec=source.resource_spec,
+            dest_spec=destination.resource_spec,
+        )
+
+        logger.info(f"Optimized transfer complete: {source} -> {destination}")
+        return destination
+
+
+class FallbackTempTransfer(TransferStrategy):
+    """
+    Fallback transfer strategy using temporary directory.
+
+    Downloads from source to temp dir, then uploads to destination.
+    Works with any connector types.
+    """
+
+    def can_handle(self, source: Resource, destination: Resource) -> bool:
+        """This strategy can handle any transfer."""
+        return True
+
+    def transfer(self, source: Resource, destination: Resource) -> Resource:
+        """Execute fallback temp directory transfer."""
+        logger.info(f"Using fallback temp transfer: {source} -> {destination}")
+
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Pull from source to temp
+            source.connector.pull(destination_path=temp_path, **source.resource_spec)
+
+            # Push from temp to destination
+            destination.connector.push(
+                source_path=str(temp_path), **destination.resource_spec
+            )
+
+        logger.info(f"Fallback transfer complete: {source} -> {destination}")
+        return destination
+
+
+# Registry of transfer strategies, ordered by preference
+TRANSFER_STRATEGIES = [
+    OptimizedCloudTransfer(),
+    FallbackTempTransfer(),  # Always handles as fallback
+]
+
+
+def transfer_resource(source: Resource, destination: Resource) -> Resource:
+    """
+    Transfer a resource from source to destination using the best available strategy.
+
+    Args:
+        source: Source resource to transfer from
+        destination: Destination resource to transfer to
+
+    Returns:
+        The destination resource for chaining
+    """
+    # Find the first strategy that can handle this transfer
+    for strategy in TRANSFER_STRATEGIES:
+        if strategy.can_handle(source, destination):
+            return strategy.transfer(source, destination)
+
+    # This should never happen since FallbackTempTransfer always handles
+    raise RuntimeError(f"No transfer strategy available for {source} -> {destination}")
+
+
+def register_transfer_strategy(strategy: TransferStrategy, priority: int = 0):
+    """
+    Register a new transfer strategy.
+
+    Args:
+        strategy: The transfer strategy to register
+        priority: Priority (lower = higher priority, 0 = highest)
+    """
+    TRANSFER_STRATEGIES.insert(priority, strategy)
+
+
+# Mixin for connectors to add .resource() method
+class ResourceMixin:
+    """Mixin to add resource() method to connectors."""
+
+    def resource(self, **resource_spec) -> Resource:
+        """
+        Create a Resource object for this connector.
+
+        Args:
+            **resource_spec: Connector-specific resource specification
+
+        Returns:
+            Resource object that can be used in transfer chains
+
+        Examples:
+            builds_conn.resource(key="pluto", build_note="my-build")
+            drafts_conn.resource(key="pluto", version="25v1", acl="public-read")
+        """
+        return Resource(self, **resource_spec)

--- a/dcpy/connectors/registry.py
+++ b/dcpy/connectors/registry.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any, Callable, Generic, TypeVar, overload
+
 from pydantic import BaseModel
-from typing import Any, TypeVar, Generic, overload, Callable
 
 from dcpy.utils.logging import logger
 
@@ -54,6 +56,22 @@ class Pull(GenericConnector, ABC):
 
 class Connector(Push, Pull, ABC):
     """A connector that does not version datasets but only stores the "current" or "latest" versions"""
+
+    def can_optimize_transfer_to(self, other_connector: "Connector") -> bool:
+        """
+        Check if this connector can optimize transfers to another connector.
+        Default implementation returns False - subclasses override for optimization.
+        """
+        return False
+
+    def optimized_transfer_to(
+        self, dest_connector: "Connector", source_spec: dict, dest_spec: dict
+    ) -> None:
+        """
+        Execute optimized transfer to another connector.
+        Only called if can_optimize_transfer_to returned True.
+        """
+        raise NotImplementedError("Connector does not support optimized transfers")
 
 
 class VersionedConnector(Connector, VersionSearch, ABC):

--- a/dcpy/test/connectors/test_chaining.py
+++ b/dcpy/test/connectors/test_chaining.py
@@ -1,0 +1,310 @@
+"""
+Unit tests for connector chaining and resource transfer optimization.
+
+Tests the automatic optimization of transfers between connectors when they
+share the same cloud provider or storage backend.
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from dcpy.connectors.chain import (
+    FallbackTempTransfer,
+    OptimizedCloudTransfer,
+    Resource,
+    ResourceMixin,
+    transfer_resource,
+)
+from dcpy.connectors.registry import Connector
+
+
+class MockOptimizedConnector(Connector, ResourceMixin):
+    """Mock connector that supports optimized transfers."""
+
+    def __init__(self, name: str, can_optimize: bool = True):
+        super().__init__(conn_type="mock")
+        self.name = name
+        self._can_optimize = can_optimize
+        self.optimized_transfer_called = False
+        self.pull_called = False
+        self.push_called = False
+
+    def can_optimize_transfer_to(self, other_connector: "Connector") -> bool:
+        """Mock optimization capability."""
+        return (
+            self._can_optimize
+            and isinstance(other_connector, MockOptimizedConnector)
+            and other_connector._can_optimize
+        )
+
+    def optimized_transfer_to(
+        self, dest_connector: "Connector", source_spec: dict, dest_spec: dict
+    ) -> None:
+        """Mock optimized transfer."""
+        self.optimized_transfer_called = True
+        self.last_optimized_call = {
+            "dest_connector": dest_connector,
+            "source_spec": source_spec,
+            "dest_spec": dest_spec,
+        }
+
+    def pull(self, destination_path: Path, **kwargs) -> dict:
+        """Mock pull method."""
+        self.pull_called = True
+        self.last_pull_call = {"destination_path": destination_path, "kwargs": kwargs}
+        return {"path": destination_path / "mock_file"}
+
+    def push(self, source_path: str, **kwargs) -> dict:
+        """Mock push method."""
+        self.push_called = True
+        self.last_push_call = {"source_path": source_path, "kwargs": kwargs}
+        return {"success": True}
+
+    def __repr__(self):
+        return f"MockOptimizedConnector({self.name})"
+
+
+class MockBasicConnector(Connector, ResourceMixin):
+    """Mock connector that does not support optimization."""
+
+    def __init__(self, name: str):
+        super().__init__(conn_type="mock_basic")
+        self.name = name
+        self.pull_called = False
+        self.push_called = False
+
+    def pull(self, destination_path: Path, **kwargs) -> dict:
+        """Mock pull method."""
+        self.pull_called = True
+        self.last_pull_call = {"destination_path": destination_path, "kwargs": kwargs}
+        return {"path": destination_path / "mock_file"}
+
+    def push(self, source_path: str, **kwargs) -> dict:
+        """Mock push method."""
+        self.push_called = True
+        self.last_push_call = {"source_path": source_path, "kwargs": kwargs}
+        return {"success": True}
+
+    def __repr__(self):
+        return f"MockBasicConnector({self.name})"
+
+
+class TestResourceTransfer:
+    """Test resource transfer between connectors."""
+
+    def test_optimized_transfer_is_used(self):
+        """Test that optimized transfer is used when both connectors support it."""
+        # Setup
+        source_conn = MockOptimizedConnector("source", can_optimize=True)
+        dest_conn = MockOptimizedConnector("dest", can_optimize=True)
+
+        source_resource = source_conn.resource(
+            key="test_product", build_note="my_build"
+        )
+        dest_resource = dest_conn.resource(
+            key="test_product", version="1.0", acl="public-read"
+        )
+
+        # Execute transfer
+        result = source_resource >> dest_resource
+
+        # Verify optimized transfer was used
+        assert source_conn.optimized_transfer_called, (
+            "Optimized transfer should have been called"
+        )
+        assert not source_conn.pull_called, (
+            "Pull should not have been called for optimized transfer"
+        )
+        assert not dest_conn.push_called, (
+            "Push should not have been called for optimized transfer"
+        )
+
+        # Verify correct parameters were passed
+        assert source_conn.last_optimized_call["dest_connector"] is dest_conn
+        assert source_conn.last_optimized_call["source_spec"] == {
+            "key": "test_product",
+            "build_note": "my_build",
+        }
+        assert source_conn.last_optimized_call["dest_spec"] == {
+            "key": "test_product",
+            "version": "1.0",
+            "acl": "public-read",
+        }
+
+        # Verify return value for chaining
+        assert result is dest_resource
+
+    def test_fallback_transfer_is_used(self):
+        """Test that fallback transfer is used when optimization is not available."""
+        # Setup
+        source_conn = MockBasicConnector("source")
+        dest_conn = MockBasicConnector("dest")
+
+        source_resource = source_conn.resource(
+            key="test_product", build_note="my_build"
+        )
+        dest_resource = dest_conn.resource(key="test_product", version="1.0")
+
+        # Execute transfer with mocked temp directory
+        with patch("dcpy.connectors.chain.TemporaryDirectory") as mock_temp_dir:
+            mock_temp_dir.return_value.__enter__.return_value = "/tmp/mock_temp"
+            mock_temp_dir.return_value.__exit__.return_value = None
+
+            result = source_resource >> dest_resource
+
+        # Verify fallback transfer was used
+        assert source_conn.pull_called, (
+            "Pull should have been called for fallback transfer"
+        )
+        assert dest_conn.push_called, (
+            "Push should have been called for fallback transfer"
+        )
+
+        # Verify correct parameters were passed
+        assert source_conn.last_pull_call["kwargs"] == {
+            "key": "test_product",
+            "build_note": "my_build",
+        }
+        assert dest_conn.last_push_call["kwargs"] == {
+            "key": "test_product",
+            "version": "1.0",
+        }
+
+        # Verify return value for chaining
+        assert result is dest_resource
+
+    def test_mixed_connectors_use_fallback(self):
+        """Test that fallback is used when only one connector supports optimization."""
+        # Setup
+        source_conn = MockOptimizedConnector("source", can_optimize=True)
+        dest_conn = MockBasicConnector("dest")  # No optimization
+
+        source_resource = source_conn.resource(key="test_product")
+        dest_resource = dest_conn.resource(key="test_product", version="1.0")
+
+        # Execute transfer
+        with patch("dcpy.connectors.chain.TemporaryDirectory") as mock_temp_dir:
+            mock_temp_dir.return_value.__enter__.return_value = "/tmp/mock_temp"
+            mock_temp_dir.return_value.__exit__.return_value = None
+
+            result = source_resource >> dest_resource
+
+        # Verify fallback was used (not optimization)
+        assert not source_conn.optimized_transfer_called, (
+            "Optimized transfer should not be called"
+        )
+        assert source_conn.pull_called, "Pull should have been called for fallback"
+        assert dest_conn.push_called, "Push should have been called for fallback"
+
+    def test_chaining_multiple_transfers(self):
+        """Test chaining multiple transfers together."""
+        # Setup
+        conn_a = MockOptimizedConnector("a", can_optimize=True)
+        conn_b = MockOptimizedConnector("b", can_optimize=True)
+        conn_c = MockOptimizedConnector("c", can_optimize=True)
+
+        resource_a = conn_a.resource(key="test", version="1.0")
+        resource_b = conn_b.resource(key="test", version="2.0")
+        resource_c = conn_c.resource(key="test", version="3.0")
+
+        # Execute chained transfers
+        result = resource_a >> resource_b >> resource_c
+
+        # Verify both transfers used optimization
+        assert conn_a.optimized_transfer_called, (
+            "First transfer should use optimization"
+        )
+        assert conn_b.optimized_transfer_called, (
+            "Second transfer should use optimization"
+        )
+
+        # Verify final result
+        assert result is resource_c
+
+    def test_pipe_operator_works(self):
+        """Test that | operator works the same as >>."""
+        # Setup
+        source_conn = MockOptimizedConnector("source", can_optimize=True)
+        dest_conn = MockOptimizedConnector("dest", can_optimize=True)
+
+        source_resource = source_conn.resource(key="test")
+        dest_resource = dest_conn.resource(key="test", version="1.0")
+
+        # Execute transfer with | operator
+        result = source_resource | dest_resource
+
+        # Verify optimized transfer was used
+        assert source_conn.optimized_transfer_called, (
+            "Optimized transfer should work with | operator"
+        )
+        assert result is dest_resource
+
+    def test_resource_representation(self):
+        """Test that Resource objects have useful string representations."""
+        conn = MockOptimizedConnector("test")
+        resource = conn.resource(
+            key="my_product", version="1.0", build_note="test_build"
+        )
+
+        repr_str = repr(resource)
+
+        # Should include connector class name and resource spec
+        assert "MockOptimizedConnector" in repr_str
+        assert "key=my_product" in repr_str
+        assert "version=1.0" in repr_str
+        assert "build_note=test_build" in repr_str
+
+
+class TestTransferStrategies:
+    """Test individual transfer strategies."""
+
+    def test_optimized_strategy_can_handle(self):
+        """Test OptimizedCloudTransfer strategy detection."""
+        strategy = OptimizedCloudTransfer()
+
+        # Setup connectors
+        optimized_a = MockOptimizedConnector("a", can_optimize=True)
+        optimized_b = MockOptimizedConnector("b", can_optimize=True)
+        basic_c = MockBasicConnector("c")
+
+        resource_a = optimized_a.resource(key="test")
+        resource_b = optimized_b.resource(key="test")
+        resource_c = basic_c.resource(key="test")
+
+        # Test strategy detection
+        assert strategy.can_handle(resource_a, resource_b), (
+            "Should handle optimized-to-optimized"
+        )
+        assert not strategy.can_handle(resource_a, resource_c), (
+            "Should not handle optimized-to-basic"
+        )
+        assert not strategy.can_handle(resource_c, resource_a), (
+            "Should not handle basic-to-optimized"
+        )
+        assert not strategy.can_handle(resource_c, resource_c), (
+            "Should not handle basic-to-basic"
+        )
+
+    def test_fallback_strategy_handles_everything(self):
+        """Test that FallbackTempTransfer handles any connector combination."""
+        strategy = FallbackTempTransfer()
+
+        # Setup various connector combinations
+        optimized_a = MockOptimizedConnector("a")
+        basic_b = MockBasicConnector("b")
+
+        resource_a = optimized_a.resource(key="test")
+        resource_b = basic_b.resource(key="test")
+
+        # Test that fallback handles everything
+        assert strategy.can_handle(resource_a, resource_b)
+        assert strategy.can_handle(resource_b, resource_a)
+        assert strategy.can_handle(resource_a, resource_a)
+        assert strategy.can_handle(resource_b, resource_b)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
```python
    with TemporaryDirectory() as temp_dir:
        temp_path = Path(temp_dir)

        # Pull entire draft folder to temp
        drafts_conn.pull_versioned(
            key=product, version=draft_version_revision, destination_path=temp_path
        )

        # Push entire folder to published
        published_conn.push_versioned(
            key=product, version=publish_version, source_path=str(temp_path), acl=acl
        )
```

We end up doing this type of tying all over the code base, namely:
1. Pull the connector to a local location
2. Push to the destination

This is a bummer, because it's verbose, and it's wasteful - we often don't need to pull the files. E.g. in the case above, if we're on S3, we should just use a S3 copy method. This would short-circuit the download. There's got to be a better way...

This begins implementing the following:
```python
drafts_conn.resource("db-pluto", "my-build") \
  >> published_conn.resource("db-pluto", "25v4") \
  >> published_conn.resource("db-pluto", "latest")
```
Where >> is a chain - basically an optimized pull and push combo.

And in this case, `published_conn` basically will say "hey, drafts_conn is also using CloudPathLib on the same cloud, so let's just use the copy method under the hood." 

It'd be a really easy shorthand for something like 
```python
published_conn.resource("db-pluto", "25v4") >> edm_postgres.resource("my-build-db")
```

### Thinking further
One could envision something like the following... 

multi-to-one
```python
Resources[recipes_conn.resource("recipe_a", "v1"), recipes_conn.resource("recipe_b", "v2")]  >> edm_postgres.resource("my-build-db")
```

Or inserting "operation" connectors, e.g. 

```python
drafts_conn.resource("db-pluto", "my-build") \
  >> generate_metadata.resource() \
  >> published_conn.resource("db-pluto", "25v4")
```

I'm going to let this percolate a little. The last example is very compelling, I think. 