### PR TITLE
fix missed test file

### DIFF
--- a/dcpy/test/models/test_lifecycle.py
+++ b/dcpy/test/models/test_lifecycle.py
@@ -41,7 +41,12 @@ class TestIngestSparseConfig:
                     },
                     "extraction_details": {"timestamp": timestamp_str},
                 },
-                {"id": ds, "version": version, "run_timestamp": timestamp},
+                {
+                    "id": ds,
+                    "version": version,
+                    "run_timestamp": None,
+                    "extraction_details": {"timestamp": timestamp_str},
+                },
             ),
         ],
     )


### PR DESCRIPTION
see lack of `test/models/lifecycle.py` in logs of [latest tests on main](https://github.com/NYCPlanning/data-engineering/actions/runs/21081490699/job/60636046468)

see [failed test](https://github.com/NYCPlanning/data-engineering/actions/runs/21118280541/job/60727114455#step:6:746), the library case for the `SparseConfig` model test was wrong 