### PR TITLE
fix DevDB data sync action

### DIFF
--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Load to Database
         run: |
-          ./devdb_datasync.sh import hpd_hny_units_by_building ${{ github.event.inputs.version }}
+          ./devdb_datasync.sh import hpd_hny_units_by_building
           ./devdb_datasync.sh import hpd_historical_units_by_building
 
       - name: Geocode

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   sync:
-    name: Sync HPD Data, DOB BIS Applications
+    name: Sync DOB BIS and HPD HNY
     runs-on: ubuntu-22.04
     container:
       image: nycplanning/build-geosupport:latest
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         dataset:
-          - dob_permitissuance
-          - dob_jobapplications
+          - dob_bis_permits
+          - dob_bis_applications
           - hpd_hny_units_by_building
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Library Archive
-        run: library archive --name ${{ matrix.dataset }} --latest --s3
+        run: python3 -m dcpy lifecycle ingest ingest ${{ matrix.dataset }} --latest --push
 
   geocode:
     name: Geocode HPD Data

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Finish container setup ...
         run: ./bash/docker_container_setup.sh
 
-      - name: Library Archive
+      - name: Ingest dataset
         run: python3 -m dcpy lifecycle ingest ingest ${{ matrix.dataset }} --latest --push
 
   geocode:

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -42,15 +42,7 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Ingest dataset
-        if: matrix.dataset != 'hpd_hny_units_by_building'
         run: python3 -m dcpy lifecycle ingest ingest ${{ matrix.dataset }} --latest --push
-
-      # hpd_hny_units_by_building is still consumed downstream via the library
-      # `import_recipe` path (.sql pgdump), so keep it on `library archive` until
-      # that consumer is migrated to ingest
-      - name: Library Archive
-        if: matrix.dataset == 'hpd_hny_units_by_building'
-        run: library archive --name ${{ matrix.dataset }} --latest --s3
 
   geocode:
     name: Geocode HPD Data
@@ -96,8 +88,10 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Load to Database
+        env:
+          BUILD_ENGINE_SERVER: postgresql://postgres:postgres@postgis:5432
         run: |
-          ./devdb_datasync.sh import hpd_hny_units_by_building
+          ./devdb_datasync.sh import_ingest hpd_hny_units_by_building
           ./devdb_datasync.sh import hpd_historical_units_by_building
 
       - name: Geocode

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -42,7 +42,15 @@ jobs:
         run: ./bash/docker_container_setup.sh
 
       - name: Ingest dataset
+        if: matrix.dataset != 'hpd_hny_units_by_building'
         run: python3 -m dcpy lifecycle ingest ingest ${{ matrix.dataset }} --latest --push
+
+      # hpd_hny_units_by_building is still consumed downstream via the library
+      # `import_recipe` path (.sql pgdump), so keep it on `library archive` until
+      # that consumer is migrated to ingest
+      - name: Library Archive
+        if: matrix.dataset == 'hpd_hny_units_by_building'
+        run: library archive --name ${{ matrix.dataset }} --latest --s3
 
   geocode:
     name: Geocode HPD Data

--- a/bash/utils.sh
+++ b/bash/utils.sh
@@ -37,6 +37,15 @@ function set_error_traps {
 }
 
 
+function install_minio {
+    # Use -o to force the downloaded binary filename
+    curl -fL https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2020-04-19T19-17-53Z -o mc
+    chmod +x mc
+    sudo mv ./mc /usr/bin
+    mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
+}
+
+
 function run_sql_file {
     psql ${BUILD_ENGINE} --set ON_ERROR_STOP=1 --single-transaction --quiet --file "$@"
 }

--- a/products/developments/devdb_datasync.sh
+++ b/products/developments/devdb_datasync.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source ../../bash/utils.sh
 set_error_traps
+install_minio
 
 function library_archive {
     set_error_traps

--- a/products/developments/devdb_datasync.sh
+++ b/products/developments/devdb_datasync.sh
@@ -5,10 +5,11 @@ install_minio
 
 function library_archive {
     set_error_traps
-    local latest_version=$(get_version ${2})
+    local ref_dataset=${2}
+    local latest_version=$(python3 -c "from dcpy.lifecycle.connector_registry import connectors; print(connectors.versioned['edm.recipes.datasets'].get_latest_version('$ref_dataset'))")
     local version=${3:-$latest_version}
     echo "version of ${1} is ${version}"
-    
+
     library archive -f templates/$1.yml -s -l -v $version
 }
 
@@ -16,6 +17,12 @@ function import {
     dataset=$1
     version=${2:-latest}
     import_recipe $dataset $version false
+}
+
+function import_ingest {
+    local dataset=$1
+    local version=$(python3 -c "from dcpy.lifecycle.connector_registry import connectors; print(connectors.versioned['edm.recipes.datasets'].get_latest_version('$dataset'))")
+    python3 -m dcpy lifecycle data_loader import -n $dataset -v "$version" -s public -d postgres
 }
 
 function output {
@@ -32,6 +39,6 @@ command="$1"
 shift
 
 case "${command}" in
-    import | output | library_archive) ${command} $@ ;;
+    import | import_ingest | output | library_archive) ${command} $@ ;;
     *) echo "${command} not found" ;;
 esac


### PR DESCRIPTION
resolves #2208, resolves #2441
related to #1267

successful [action run here](https://github.com/NYCPlanning/data-engineering/actions/workflows/developments_datasync.yml?query=branch%3Adm-devdb-sync)

fixes the weekly scheduled action again (it's been failing on the `library archive` step)

## changes

Migrates the DevDB datasync github action from `library` to `ingest` and switches the DOB BIS datasets to their ingest names:
- `dob_permitissuance` → `dob_bis_permits`
- `dob_jobapplications` → `dob_bis_applications`

## follow-up

the DevDB build still reads the old DOB BIS dataset names via `products/developments/recipe.yml`, `models/sources.yml`, and `sql/_bis.sql` / `sql/_status_q.sql`. Those need migrating to the new ingest names (and likely SQL column-name updates, since ingest lowercases/cleans columns). tracking under #1267.

`dob_jobapplications_parkingspaces` is a pinned static input (`version: 20240603`) and doesn't need to be migrated here