### PR TITLE
cpdb small sql cleanup

### DIFF
--- a/products/cpdb/sql/attributes_maprojid_cd.sql
+++ b/products/cpdb/sql/attributes_maprojid_cd.sql
@@ -1,17 +1,13 @@
 -- create maprojid --> community district relational table
 DROP TABLE IF EXISTS attributes_maprojid_cd;
 -- spatial join
-CREATE TABLE attributes_maprojid_cd AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'commboard'::text AS admin_boundary_type,
-            b.borocd::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_cdboundaries AS b
-        WHERE
-            ST_INTERSECTS(a.geom, b.wkb_geometry)
-            AND ST_GEOMETRYTYPE(b.wkb_geometry) = 'ST_MultiPolygon'
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_cd AS
+SELECT
+    a.maprojid AS feature_id,
+    'commboard'::text AS admin_boundary_type,
+    b.borocd::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_cdboundaries AS b
+WHERE
+    ST_INTERSECTS(a.geom, b.wkb_geometry)
+    AND ST_GEOMETRYTYPE(b.wkb_geometry) = 'ST_MultiPolygon';

--- a/products/cpdb/sql/attributes_maprojid_censustracts.sql
+++ b/products/cpdb/sql/attributes_maprojid_censustracts.sql
@@ -1,37 +1,10 @@
 -- create maprojid --> census tracts, puma, nta, and boro relational table
 DROP TABLE IF EXISTS attributes_maprojid_censustracts;
 -- spatial join
-CREATE TABLE attributes_maprojid_censustracts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'borocode'::text AS admin_boundary_type,
-            b.borocode::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_ct2020 AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS a
-    UNION ALL
-    SELECT b.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'nta'::text AS admin_boundary_type,
-            b.nta2020::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_ct2020 AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS b
-    UNION ALL
-    SELECT d.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'censtract'::text AS admin_boundary_type,
-            b.boroct2020::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_ct2020 AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS d
-);
+CREATE TABLE attributes_maprojid_censustracts AS
+SELECT
+    maprojid AS feature_id,
+    unnest(ARRAY['borocode'::text, 'nta'::text, 'censtract'::text]) AS admin_boundary_type,
+    unnest(ARRAY[borocode::text, nta2020::text, boroct2020::text]) AS admin_boundary_id
+FROM cpdb_dcpattributes AS a
+INNER JOIN dcp_ct2020 AS ct ON st_intersects(a.geom, ct.wkb_geometry);

--- a/products/cpdb/sql/attributes_maprojid_congressionaldistricts.sql
+++ b/products/cpdb/sql/attributes_maprojid_congressionaldistricts.sql
@@ -1,15 +1,11 @@
 -- create maprojid --> congressional districts relational table
 DROP TABLE IF EXISTS attributes_maprojid_congressionaldistricts;
 -- spatial join
-CREATE TABLE attributes_maprojid_congressionaldistricts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'congdist'::text AS admin_boundary_type,
-            b.congdist::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_congressionaldistricts AS b
-        WHERE a.geom && b.wkb_geometry AND ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_congressionaldistricts AS
+SELECT
+    a.maprojid AS feature_id,
+    'congdist'::text AS admin_boundary_type,
+    b.congdist::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_congressionaldistricts AS b
+WHERE a.geom && b.wkb_geometry AND ST_INTERSECTS(a.geom, b.wkb_geometry);

--- a/products/cpdb/sql/attributes_maprojid_councildistricts.sql
+++ b/products/cpdb/sql/attributes_maprojid_councildistricts.sql
@@ -1,15 +1,11 @@
 -- create maprojid --> council districts relational table
 DROP TABLE IF EXISTS attributes_maprojid_councildistricts;
 -- spatial join
-CREATE TABLE attributes_maprojid_councildistricts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'council'::text AS admin_boundary_type,
-            b.coundist::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_councildistricts AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_councildistricts AS
+SELECT
+    a.maprojid AS feature_id,
+    'council'::text AS admin_boundary_type,
+    b.coundist::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_councildistricts AS b
+WHERE ST_INTERSECTS(a.geom, b.wkb_geometry);

--- a/products/cpdb/sql/attributes_maprojid_firecompanies.sql
+++ b/products/cpdb/sql/attributes_maprojid_firecompanies.sql
@@ -1,48 +1,11 @@
 -- create maprojid --> fire companies relational table
 DROP TABLE IF EXISTS attributes_maprojid_firecompanies;
 -- spatial join
-CREATE TABLE attributes_maprojid_firecompanies AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'fireconum'::text AS admin_boundary_type,
-            b.fireconum::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_firecompanies AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS a
-    UNION ALL
-    SELECT b.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'firecotype'::text AS admin_boundary_type,
-            b.firecotype::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_firecompanies AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS b
-    UNION ALL
-    SELECT c.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'firebn'::text AS admin_boundary_type,
-            b.firebn::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_firecompanies AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS c
-    UNION ALL
-    SELECT d.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'firediv'::text AS admin_boundary_type,
-            b.firediv::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_firecompanies AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS d
-);
+CREATE TABLE attributes_maprojid_firecompanies AS
+SELECT
+    maprojid AS feature_id,
+    unnest(ARRAY['fireconum'::text, 'firecotype'::text, 'firebn'::text, 'firediv'::text]) AS admin_boundary_type,
+    unnest(ARRAY[fireconum::text, firecotype::text, firebn::text, firediv::text]) AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_firecompanies AS b
+WHERE st_intersects(a.geom, b.wkb_geometry);

--- a/products/cpdb/sql/attributes_maprojid_municipalcourtdistricts.sql
+++ b/products/cpdb/sql/attributes_maprojid_municipalcourtdistricts.sql
@@ -1,15 +1,11 @@
 -- create maprojid --> municipal courtdistricts relational table
 DROP TABLE IF EXISTS attributes_maprojid_municipalcourtdistricts;
 -- spatial join
-CREATE TABLE attributes_maprojid_municipalcourtdistricts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'municourt'::text AS admin_boundary_type,
-            b.municourt::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_municipalcourtdistricts AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_municipalcourtdistricts AS
+SELECT
+    a.maprojid AS feature_id,
+    'municourt'::text AS admin_boundary_type,
+    b.municourt::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_municipalcourtdistricts AS b
+WHERE ST_INTERSECTS(a.geom, b.wkb_geometry);

--- a/products/cpdb/sql/attributes_maprojid_parkid.sql
+++ b/products/cpdb/sql/attributes_maprojid_parkid.sql
@@ -9,28 +9,24 @@ SET wkb_geometry = ST_MAKEVALID(wkb_geometry);
 UPDATE cpdb_dcpattributes
 SET geom = ST_MAKEVALID(geom);
 
-CREATE TABLE attributes_maprojid_parkid AS (
-    SELECT *
-    FROM (
-        SELECT
-            REPLACE(fmsid, ' ', '') AS maprojid,
-            park_id AS parkid
-        FROM dpr_capitalprojects_fms_parkid
-        UNION
-        SELECT
-            maprojid,
-            REGEXP_REPLACE(
-                REGEXP_MATCHES(description, '[BMQRX][0-9][0-9][0-9]')::text, '[^0-9a-zA-Z]+', '', 'g'
-            )::text AS parkid
-        FROM cpdb_dcpattributes
-        WHERE magencyacro = 'DPR'
-        UNION
-        SELECT
-            a.maprojid,
-            b.gispropnum AS parkid
-        FROM cpdb_dcpattributes AS a,
-            dpr_parksproperties AS b
-        WHERE ST_WITHIN(a.geom, b.wkb_geometry) AND ST_ISVALID(a.geom)
-    ) AS a
-    ORDER BY maprojid
-);
+CREATE TABLE attributes_maprojid_parkid AS
+SELECT
+    REPLACE(fmsid, ' ', '') AS maprojid,
+    park_id AS parkid
+FROM dpr_capitalprojects_fms_parkid
+UNION
+SELECT
+    maprojid,
+    REGEXP_REPLACE(
+        REGEXP_MATCHES(description, '[BMQRX][0-9][0-9][0-9]')::text, '[^0-9a-zA-Z]+', '', 'g'
+    )::text AS parkid
+FROM cpdb_dcpattributes
+WHERE magencyacro = 'DPR'
+UNION
+SELECT
+    a.maprojid,
+    b.gispropnum AS parkid
+FROM cpdb_dcpattributes AS a,
+    dpr_parksproperties AS b
+WHERE ST_WITHIN(a.geom, b.wkb_geometry) AND ST_ISVALID(a.geom)
+ORDER BY maprojid;

--- a/products/cpdb/sql/attributes_maprojid_policeprecincts.sql
+++ b/products/cpdb/sql/attributes_maprojid_policeprecincts.sql
@@ -1,17 +1,13 @@
 -- create maprojid --> police precincts relational table
 DROP TABLE IF EXISTS attributes_maprojid_policeprecincts;
 -- spatial join
-CREATE TABLE attributes_maprojid_policeprecincts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'policeprecinct'::text AS admin_boundary_type,
-            b.precinct::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_policeprecincts AS b
-        WHERE
-            ST_INTERSECTS(a.geom, b.wkb_geometry)
-            AND ST_GEOMETRYTYPE(b.wkb_geometry) = 'ST_MultiPolygon'
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_policeprecincts AS
+SELECT
+    a.maprojid AS feature_id,
+    'policeprecinct'::text AS admin_boundary_type,
+    b.precinct::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_policeprecincts AS b
+WHERE
+    ST_INTERSECTS(a.geom, b.wkb_geometry)
+    AND ST_GEOMETRYTYPE(b.wkb_geometry) = 'ST_MultiPolygon';

--- a/products/cpdb/sql/attributes_maprojid_schooldistricts.sql
+++ b/products/cpdb/sql/attributes_maprojid_schooldistricts.sql
@@ -1,15 +1,11 @@
 -- create maprojid --> school districts relational table
 DROP TABLE IF EXISTS attributes_maprojid_schooldistricts;
 -- spatial join
-CREATE TABLE attributes_maprojid_schooldistricts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'schooldistrict'::text AS admin_boundary_type,
-            b.schooldist::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_school_districts AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_schooldistricts AS
+SELECT
+    a.maprojid AS feature_id,
+    'schooldistrict'::text AS admin_boundary_type,
+    b.schooldist::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_school_districts AS b
+WHERE ST_INTERSECTS(a.geom, b.wkb_geometry);

--- a/products/cpdb/sql/attributes_maprojid_stateassemblydistricts.sql
+++ b/products/cpdb/sql/attributes_maprojid_stateassemblydistricts.sql
@@ -1,17 +1,13 @@
 -- create maprojid --> state assembly districts relational table
 DROP TABLE IF EXISTS attributes_maprojid_stateassemblydistricts;
 -- spatial join
-CREATE TABLE attributes_maprojid_stateassemblydistricts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'stateassembly'::text AS admin_boundary_type,
-            b.assemdist::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_stateassemblydistricts AS b
-        WHERE
-            ST_INTERSECTS(a.geom, b.wkb_geometry)
-            AND ST_GEOMETRYTYPE(b.wkb_geometry) = 'ST_MultiPolygon'
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_stateassemblydistricts AS
+SELECT
+    a.maprojid AS feature_id,
+    'stateassembly'::text AS admin_boundary_type,
+    b.assemdist::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_stateassemblydistricts AS b
+WHERE
+    ST_INTERSECTS(a.geom, b.wkb_geometry)
+    AND ST_GEOMETRYTYPE(b.wkb_geometry) = 'ST_MultiPolygon';

--- a/products/cpdb/sql/attributes_maprojid_statesenatedistricts.sql
+++ b/products/cpdb/sql/attributes_maprojid_statesenatedistricts.sql
@@ -1,15 +1,11 @@
 -- create maprojid --> state senate districts relational table
 DROP TABLE IF EXISTS attributes_maprojid_statesenatedistricts;
 -- spatial join
-CREATE TABLE attributes_maprojid_statesenatedistricts AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'statesenate'::text AS admin_boundary_type,
-            b.stsendist::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_statesenatedistricts AS b
-        WHERE ST_INTERSECTS(a.geom, b.wkb_geometry)
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_statesenatedistricts AS
+SELECT
+    a.maprojid AS feature_id,
+    'statesenate'::text AS admin_boundary_type,
+    b.stsendist::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_statesenatedistricts AS b
+WHERE ST_INTERSECTS(a.geom, b.wkb_geometry);

--- a/products/cpdb/sql/attributes_maprojid_trafficanalysiszones.sql
+++ b/products/cpdb/sql/attributes_maprojid_trafficanalysiszones.sql
@@ -1,15 +1,11 @@
 -- create maprojid --> traffic analysis zones relational table
 DROP TABLE IF EXISTS attributes_maprojid_trafficanalysiszones;
 -- spatial join
-CREATE TABLE attributes_maprojid_trafficanalysiszones AS (
-    SELECT a.*
-    FROM (
-        SELECT
-            a.maprojid AS feature_id,
-            'taz'::text AS admin_boundary_type,
-            b.geoid10::text AS admin_boundary_id
-        FROM cpdb_dcpattributes AS a,
-            dcp_trafficanalysiszones AS b
-        WHERE ST_INTERSECTS(a.geom, ST_SETSRID(b.wkb_geometry, 4326))
-    ) AS a
-);
+CREATE TABLE attributes_maprojid_trafficanalysiszones AS
+SELECT
+    a.maprojid AS feature_id,
+    'taz'::text AS admin_boundary_type,
+    b.geoid10::text AS admin_boundary_id
+FROM cpdb_dcpattributes AS a,
+    dcp_trafficanalysiszones AS b
+WHERE ST_INTERSECTS(a.geom, ST_SETSRID(b.wkb_geometry, 4326));


### PR DESCRIPTION
Had started this a year ago and dropped it, meant to dbtify. But this seemed like a nice QOL to get merged since the branch was hanging around. Just a refactor

Build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/21839246622/job/63018774762)

data comp between this and nightly qa just with
```sql
select * from nightly_qa.cpdb_projects_geom
except
select * from fvk_cpdb_refactor.cpdb_projects_geom

select * from fvk_cpdb_refactor.cpdb_projects_geom
except
select * from nightly_qa.cpdb_projects_geom
```

They're identical. Also checked `adminbounds` table which unions most of the tables changed in queries, also identical