### PR TITLE
add FacDB agencies to agency source dataset

### DIFF
--- a/ingest_templates/dcp_managing_agencies_lookup.yml
+++ b/ingest_templates/dcp_managing_agencies_lookup.yml
@@ -13,7 +13,7 @@ attributes:
     in agency code mappings. To address this, DCP Data Engineering and Application Engineering teams developed a unified 
     mapping by combining data from Checkbook NYC "Agency Codes List" (link: https://www.checkbooknyc.com/agency_codes/newwindow) 
     with additional information provided by OMB via email in summer 2025. DCP then manually refined the mappings, including 
-    updates to agency names and abbreviations where appropriate (for example, changing "DOITT" to "OTI"). 
+    updates to agency names and abbreviations where appropriate (e.g. changing "DOITT" to "OTI"). 
     The final mapping was reviewed and approved by the CAPS team and GDE leadership.
 
     Some codes in the dataset are mapped to "Unknown." This was an intentional choice by DCP, as these codes typically represent 
@@ -21,7 +21,7 @@ attributes:
     to support abbreviation-to-name mapping but are not intended for use in mapping codes to names.
 
     In addition to supporting CPDB and CBBR, this dataset may also be used as a reference for agency names and abbreviations across 
-    other DCP data products. 
+    other DCP data products (e.g. the Application Engineering team's APIs).
     
     It is not expected to change often. A full review may occur annually, using updated information from Checkbook NYC and, 
     if available, refreshed data from OMB.
@@ -36,11 +36,19 @@ ingestion:
     dtype: str
 
 columns:
-- id: agency_code
-  data_type: text
-- id: source
-  data_type: text
 - id: managing_agency_acronym
   data_type: text
 - id: managing_agency
+  data_type: text
+- id: manages_capital_projects
+  data_type: bool
+- id: operates_facilities
+  data_type: bool
+- id: source
+  data_type: text
+- id: agency_code
+  data_type: text
+- id: overlevel
+  data_type: text
+- id: optype
   data_type: text


### PR DESCRIPTION
resolves #2216

all action runs on this branch [here](https://github.com/NYCPlanning/data-engineering/actions?query=branch%3Adm-facdb-agency)

it seemed good to add two columns so that the records can be filtered for their different uses (in CPDB now and in FacDB later):
- `manages_capital_projects`
- `operates_facilities`

these two boolean columns technically denote where the record came from, but they seem to actually represent if an agency manages capital projects and/or operates facilities

I combined the two csv (via a throwaway python script) and resolved duplications by erring on the side of the CPDB values when there was a difference. these were the only duplicates:

```
Duplicate managing_agency_acronym values: ['BPL', 'CUNY', 'FDNY', 'NYCHA', 'NYCOA', 'NYPD', 'NYPL', 'QPL']
Duplicate managing_agency values: ['Brooklyn Public Library', 'City University of New York', 'New York Public Library']
```

since CPDB uses this by joining on `agency_code` and none of the new records from FacDB have one, there's no need to change CPDB code

## concern

I checked for true duplicates but I should check for near duplicates (different acronym and name, but same agency). by design, there are apparent duplicates from the original CPDB list because of variations in `agency_code`

if there are any, near-duplicates won't cause any issues in CPDB and maybe shouldn't be modified until AE or DE has an issue related to FacDB usage of the table

## tests

ran ingest on the new file I put in `edm-recipes/inbox`, ran CPDB on this branch, and compared two relevant tables to nightly QA and their identical: `ccp_projects` being the only table this source data is used in and `cpdb_projects` being one of the primary final tables

```
# edited for brevity
❯ python3 -m dcpy lifecycle scripts compare_build_tables compare db-cpdb dm_facdb_agency ccp_projects
22:35:03 INFO:dcpy:Comparing dm_facdb_agency.ccp_projects (left) to nightly_qa.ccp_projects (right) ...
________________________________________________________________________________
tables
    left: ccp_projects
    right: ccp_projects
________________________________________________________________________________
row_count
    left: 11884
    right: 11884
________________________________________________________________________________
column_comparison
    both
        ccpversion
        ...
        projectid
    left_only: None
    right_only: None
    type_differences: None
________________________________________________________________________________
data_comparison
    compared_columns
        ccpversion
        ...
        projectid
    ignored_columns: None
    columns_coerced_to_numeric: None
    left_only
        Empty DataFrame
        Columns: [maprojid, plannedcommit_nccfederal, magencyname, plannedcommit_ccexempt, plannedcommit_ccnonexempt, plannedcommit_citycost, plannedcommit_nccstate, plannedcommit_noncitycost, plannedcommit_nccother, magency, magencyacro, description, projectid, ccpversion, plannedcommit_total, row_hash, match_count, dev_count, prod_count]
        Index: []
    right_only
        Empty DataFrame
        Columns: [maprojid, plannedcommit_nccfederal, magencyname, plannedcommit_ccexempt, plannedcommit_ccnonexempt, plannedcommit_citycost, plannedcommit_nccstate, plannedcommit_noncitycost, plannedcommit_nccother, magency, magencyacro, description, projectid, ccpversion, plannedcommit_total, row_hash, match_count, dev_count, prod_count]
        Index: []
    are_equal: True


❯ python3 -m dcpy lifecycle scripts compare_build_tables compare db-cpdb dm_facdb_agency cpdb_projects
22:23:42 INFO:dcpy:Comparing dm_facdb_agency.cpdb_projects (left) to nightly_qa.cpdb_projects (right) ...
________________________________________________________________________________
tables
    left: cpdb_projects
    right: cpdb_projects
________________________________________________________________________________
row_count
    left: 11884
    right: 11884
________________________________________________________________________________
column_comparison
    both
        adopt_ccexempt
        ...
        typecategory
    left_only: None
    right_only: None
    type_differences: None
________________________________________________________________________________
data_comparison
    compared_columns
        adopt_ccexempt
        ...
        typecategory
    ignored_columns: None
    columns_coerced_to_numeric: None
    left_only
        Empty DataFrame
        Columns: [description, spent_ccexempt, ccpversion, spent_total, adopt_nccstate, commit_total, plannedcommit_total, spent_nccstate, spent_nccfederal, plannedcommit_ccnonexempt, plannedcommit_noncitycost, maxdate, spent_nccother, magencyname, spent_noncitycost, adopt_ccnonexempt, spent_ccnonexempt, adopt_noncitycost, plannedcommit_nccother, commit_noncitycost, adopt_nccother, allocate_total, adopt_citycost, plannedcommit_citycost, allocate_ccnonexempt, typecategory, magency, spent_total_checkbooknyc, spent_citycost, allocate_ccexempt, allocate_citycost, adopt_nccfederal, allocate_nccother, commit_ccexempt, maprojid, mindate, plannedcommit_nccfederal, plannedcommit_ccexempt, adopt_total, commit_ccnonexempt, plannedcommit_nccstate, allocate_nccstate, commit_nccother, projectid, magencyacro, commit_nccstate, allocate_noncitycost, commit_citycost, allocate_nccfederal, adopt_ccexempt, commit_nccfederal, row_hash, match_count, dev_count, prod_count]
        Index: []
    right_only
        Empty DataFrame
        Columns: [description, spent_ccexempt, ccpversion, spent_total, adopt_nccstate, commit_total, plannedcommit_total, spent_nccstate, spent_nccfederal, plannedcommit_ccnonexempt, plannedcommit_noncitycost, maxdate, spent_nccother, magencyname, spent_noncitycost, adopt_ccnonexempt, spent_ccnonexempt, adopt_noncitycost, plannedcommit_nccother, commit_noncitycost, adopt_nccother, allocate_total, adopt_citycost, plannedcommit_citycost, allocate_ccnonexempt, typecategory, magency, spent_total_checkbooknyc, spent_citycost, allocate_ccexempt, allocate_citycost, adopt_nccfederal, allocate_nccother, commit_ccexempt, maprojid, mindate, plannedcommit_nccfederal, plannedcommit_ccexempt, adopt_total, commit_ccnonexempt, plannedcommit_nccstate, allocate_nccstate, commit_nccother, projectid, magencyacro, commit_nccstate, allocate_noncitycost, commit_citycost, allocate_nccfederal, adopt_ccexempt, commit_nccfederal, row_hash, match_count, dev_count, prod_count]
        Index: []
    are_equal: True
```