### PR TITLE
add Roadbed Pointer List

### DIFF
--- a/.github/workflows/cscl_build.yml
+++ b/.github/workflows/cscl_build.yml
@@ -59,10 +59,10 @@ jobs:
         ./bash/build_env_setup.sh
 
     - name: Plan build
-      run: dcpy lc builds plan ${{ inputs.plan_command }}
+      run: dcpy lifecycle builds plan ${{ inputs.plan_command }}
 
     - name: Dataloading
-      run: dcpy lc builds load load --recipe-path ${{ inputs.recipe_file }}.lock.yml --cache-schema recipe_cache --cached-entity-type view
+      run: dcpy lifecycle builds load load --recipe-path ${{ inputs.recipe_file }}.lock.yml --cache-schema recipe_cache --cached-entity-type view
 
     - name: Build
       run: |
@@ -73,7 +73,7 @@ jobs:
         dbt build --full-refresh
 
     - name: Export
-      run: dcpy lc builds build export --recipe-path ${{ inputs.recipe_file }}.lock.yml
+      run: dcpy lifecycle builds build export --recipe-path ${{ inputs.recipe_file }}.lock.yml
 
     - name: Validate against production outputs
       # TODO - this currently relies on version hard-coded in recipe.yml

--- a/dcpy/__main__.py
+++ b/dcpy/__main__.py
@@ -13,7 +13,6 @@ def cli():
     app = typer.Typer()
 
     app.add_typer(lifecycle.app, name="lifecycle")
-    app.add_typer(lifecycle.app, name="lc")  # alias
     app.add_typer(connectors.app, name="connectors")
     app.add_typer(utils.app, name="utils")
     app()

--- a/products/cscl/dbt_project.yml
+++ b/products/cscl/dbt_project.yml
@@ -16,6 +16,8 @@ models:
       +materialized: view
     product:
       +materialized: table
+    etl_dev_qa:
+      +materialized: table
 
 on-run-start:
 - '{{ create_pg_functions() }}'

--- a/products/cscl/dbt_project.yml
+++ b/products/cscl/dbt_project.yml
@@ -6,7 +6,7 @@ model-paths: [ "models" ]
 
 tests:
   +store_failures: true
-  schema: "_tests"
+  +schema: "_tests"
 
 models:
   cscl:

--- a/products/cscl/models/etl_dev_qa/qa__rpl_order.sql
+++ b/products/cscl/models/etl_dev_qa/qa__rpl_order.sql
@@ -1,0 +1,33 @@
+-- especially concerned about diffs in the order of rows within each generic_segmentid grouping
+{% set old_query %}
+  select
+    ROW_NUMBER() OVER () as row_number,
+    generic_segmentid || '_' || ROW_NUMBER() OVER (
+            PARTITION BY generic_segmentid
+        ) AS rpl_id,
+    *
+  from production_outputs.rpl
+  order by row_number asc
+{% endset %}
+
+{% set new_query %}
+  select
+      ROW_NUMBER() OVER () as row_number,
+      lpad(rpl_id, 9, '0') as rpl_id,
+      generic_segmentid,
+      roadbed_segmentid,
+      roadbed_position_code
+  from {{ ref('rpl_by_field') }}
+  order by row_number asc
+{% endset %}
+
+
+{{ 
+  audit_helper.compare_and_classify_query_results(
+    old_query,
+    new_query,
+    primary_key_columns=['rpl_id'], 
+    columns=['generic_segmentid', 'roadbed_segmentid', 'roadbed_position_code'],
+    sample_limit=50
+  )
+}}

--- a/products/cscl/models/etl_dev_qa/qa__rpl_order_diffs.sql
+++ b/products/cscl/models/etl_dev_qa/qa__rpl_order_diffs.sql
@@ -1,0 +1,87 @@
+-- for RPL records rows with diffs in their ordering, get and compare their ordering and along with relevent geometries
+-- rpl_id indicates the order of roadbed_segmentid rows within each generic_segmentid grouping
+WITH
+
+diff_ids AS (
+    SELECT DISTINCT generic_segmentid
+    FROM
+        {{ ref('qa__rpl_order') }}
+    WHERE
+        dbt_audit_row_status = 'modified'
+),
+
+focus_rpl_prod AS (
+    SELECT
+        prod_rpl.generic_segmentid || '_' || ROW_NUMBER() OVER (
+            PARTITION BY prod_rpl.generic_segmentid
+        ) AS rpl_id,
+        prod_rpl.*
+    FROM
+        production_outputs.rpl AS prod_rpl
+    INNER JOIN diff_ids
+        ON
+            prod_rpl.generic_segmentid = diff_ids.generic_segmentid
+),
+focus_rpl AS (
+    SELECT dev_rpl.*
+    FROM
+        {{ ref('int__rpl') }} AS dev_rpl
+    INNER JOIN diff_ids
+        ON
+            LPAD(dev_rpl.generic_segmentid::TEXT, 7, '0') = diff_ids.generic_segmentid
+),
+focus_lion AS (
+    SELECT dev_lion.*
+    FROM
+        {{ ref('int__lion') }} AS dev_lion
+    INNER JOIN diff_ids
+        ON
+            LPAD(dev_lion.segmentid::TEXT, 7, '0') = diff_ids.generic_segmentid
+),
+
+all_segments AS (
+    SELECT
+        focus_rpl.generic_segmentid,
+        focus_rpl.roadbed_segmentid,
+        LPAD(focus_rpl.rpl_id::TEXT, 7, '0') AS rpl_id_dev,
+        focus_rpl_prod.rpl_id AS rpl_id_prod,
+        focus_rpl.roadbed_position_code,
+        focus_rpl.generic_segmenttype,
+        ST_TRANSFORM(focus_rpl.midpoint, 4326) AS midpoint,
+        ST_TRANSFORM(focus_rpl.geom, 4326) AS geom,
+        null AS midpoint_generic,
+        null AS geom_generic
+    FROM
+        focus_rpl
+    LEFT JOIN focus_rpl_prod
+        ON
+            LPAD(focus_rpl.generic_segmentid::TEXT, 7, '0') = focus_rpl_prod.generic_segmentid
+            AND LPAD(focus_rpl.roadbed_segmentid::TEXT, 7, '0') = focus_rpl_prod.roadbed_segmentid
+    UNION ALL
+    SELECT
+        segmentid AS generic_segmentid,
+        null AS roadbed_segmentid,
+        null AS rpl_id_dev,
+        null AS rpl_id_prod,
+        null AS roadbed_position_code,
+        null AS generic_segmenttype,
+        null AS midpoint,
+        null AS geom,
+        ST_TRANSFORM(midpoint, 4326) AS midpoint_generic,
+        ST_TRANSFORM(geom, 4326) AS geom_generic
+    FROM
+        focus_lion
+),
+
+final_cte AS (
+    SELECT *
+    FROM
+        all_segments
+    ORDER BY
+        generic_segmentid ASC,
+        rpl_id_dev ASC
+)
+
+SELECT *
+FROM
+    final_cte

--- a/products/cscl/models/etl_dev_qa/qa__rpl_values.sql
+++ b/products/cscl/models/etl_dev_qa/qa__rpl_values.sql
@@ -1,0 +1,18 @@
+-- ignoring the order of rows within each generic_segmentid grouping to focus on testing for diffs in their values
+{% set old_relation = adapter.get_relation(
+    database = "db-cscl",
+    schema = "production_outputs",
+    identifier = "rpl"
+) -%}
+
+{% set dbt_relation = ref('rpl_by_field') %}
+
+{%- if execute -%}
+  {{ audit_helper.compare_and_classify_relation_rows(
+      a_relation = old_relation,
+      b_relation = dbt_relation,
+      primary_key_columns=['generic_segmentid', 'roadbed_segmentid'], 
+      columns = None,
+      sample_limit=50
+  ) }}
+{%- endif -%}

--- a/products/cscl/models/intermediate/int__lion.sql
+++ b/products/cscl/models/intermediate/int__lion.sql
@@ -255,6 +255,7 @@ SELECT
     segments.feature_type_description,
     segments.source_table,
     segments.geom,
+    segments.midpoint,
     segments.globalid,
     CASE
         WHEN segments.source_table = 'centerline' THEN centerline.include_in_geosupport_lion

--- a/products/cscl/models/intermediate/rpl/_int__rpl.yml
+++ b/products/cscl/models/intermediate/rpl/_int__rpl.yml
@@ -1,0 +1,7 @@
+version: 2
+
+models:
+- name: int__rpl
+  columns:
+  - name: rpl_id
+    tests: [ unique, not_null ]

--- a/products/cscl/models/intermediate/rpl/int__rpl.sql
+++ b/products/cscl/models/intermediate/rpl/int__rpl.sql
@@ -1,0 +1,126 @@
+WITH lion AS (
+    SELECT DISTINCT ON (segmentid)
+        segmentid,
+        segment_type,
+        from_nodeid,
+        to_nodeid,
+        geom,
+        midpoint
+    FROM {{ ref("int__lion") }}
+    ORDER BY segmentid
+),
+
+cscl_rpl AS (SELECT * FROM {{ source("recipe_sources", "dcp_cscl_roadbed_pointer_list") }}),
+
+generic_attributes AS (
+    SELECT
+        cscl_rpl.generic_segmentid,
+        lion.segment_type AS generic_segmenttype,
+        cscl_rpl.roadbed_segmentid,
+        cscl_rpl.roadbed_position_code,
+        'B' AS node_correspondence_indicator, -- all records are 'B' in production, but the docs say it should be node_correspondence_ind
+        -- cscl_rpl.node_correspondence_ind AS node_correspondence_indicator,
+        chr(64 + cscl_rpl.from_node_level_coincident_rb) AS from_node_level_code_of_coincident_roadbed_segment,
+        chr(64 + cscl_rpl.to_node_level_coincident_rb) AS to_node_level_code_of_coincident_roadbed_segment,
+        lion.from_nodeid AS from_nodeid_of_generic_segment,
+        lion.to_nodeid AS to_nodeid_of_generic_segment,
+        lion.geom AS generic_geom
+    FROM cscl_rpl
+    LEFT JOIN lion
+        ON cscl_rpl.generic_segmentid = lion.segmentid
+),
+
+roadbed_attributes AS (
+    SELECT
+        generic_attributes.*,
+        lion.from_nodeid AS from_nodeid_of_roadbed_segment,
+        lion.to_nodeid AS to_nodeid_of_roadbed_segment,
+        lion.geom,
+        lion.midpoint
+    FROM generic_attributes
+    LEFT JOIN lion
+        ON generic_attributes.roadbed_segmentid = lion.segmentid
+),
+
+-- Compute the cross product for every row and attach the R outermost's cross product
+-- as a per-group sign reference. Comparing signs (rather than using the raw sign of
+-- the cross product alone) means side determination is correct regardless of the
+-- direction of the generic segment geometry.
+side_reference AS (
+    SELECT
+        *,
+        (
+            (st_x(st_endpoint(generic_geom)) - st_x(st_startpoint(generic_geom)))
+            * (st_y(midpoint) - st_y(st_startpoint(generic_geom)))
+            - (st_y(st_endpoint(generic_geom)) - st_y(st_startpoint(generic_geom)))
+            * (st_x(midpoint) - st_x(st_startpoint(generic_geom)))
+        ) AS cross_product,
+        first_value(
+            (st_x(st_endpoint(generic_geom)) - st_x(st_startpoint(generic_geom)))
+            * (st_y(midpoint) - st_y(st_startpoint(generic_geom)))
+            - (st_y(st_endpoint(generic_geom)) - st_y(st_startpoint(generic_geom)))
+            * (st_x(midpoint) - st_x(st_startpoint(generic_geom)))
+        ) OVER (
+            PARTITION BY generic_segmentid
+            ORDER BY (roadbed_position_code = 'R') DESC
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS r_cross_product
+    FROM roadbed_attributes
+),
+
+-- Ordering:
+--   1. 'R' outermost
+--   2. Right-side 'I' segments, from outermost to innermost
+--   3. 'L' outermost
+--   4. Left-side 'I' segments, from outermost to innermost
+--
+-- For 'I' segments, side is determined by whether the row's cross product has the
+-- same sign as the R outermost's cross product for that generic segment.
+-- Within a side, rows are ordered by descending perpendicular distance from the
+-- generic segment (outermost first).
+add_group_order_id AS (
+    SELECT
+        *,
+        row_number() OVER (
+            PARTITION BY generic_segmentid
+            ORDER BY
+                CASE
+                    WHEN roadbed_position_code = 'R' THEN 1
+                    WHEN
+                        roadbed_position_code = 'I'
+                        AND sign(cross_product) = sign(r_cross_product) THEN 2
+                    WHEN roadbed_position_code = 'L' THEN 3
+                    ELSE 4  -- left-side 'I' segments
+                END,
+                -- Negate so outermost (largest perpendicular distance) sorts first
+                CASE
+                    WHEN roadbed_position_code = 'I'
+                        THEN -st_distance(midpoint, generic_geom)
+                    ELSE 0
+                END
+        ) AS group_order_id
+    FROM side_reference
+),
+
+final AS (
+    SELECT
+        generic_segmentid || '_' || group_order_id AS rpl_id,
+        generic_segmentid,
+        generic_segmenttype,
+        roadbed_segmentid,
+        group_order_id,
+        roadbed_position_code,
+        node_correspondence_indicator,
+        from_node_level_code_of_coincident_roadbed_segment,
+        to_node_level_code_of_coincident_roadbed_segment,
+        from_nodeid_of_roadbed_segment,
+        from_nodeid_of_generic_segment,
+        to_nodeid_of_roadbed_segment,
+        to_nodeid_of_generic_segment,
+        midpoint,
+        geom
+    FROM add_group_order_id
+    ORDER BY rpl_id
+)
+
+SELECT * FROM final

--- a/products/cscl/models/product/rpl/_rpl.yml
+++ b/products/cscl/models/product/rpl/_rpl.yml
@@ -1,0 +1,63 @@
+version: 2
+
+models:
+- name: rpl_by_field
+  config:
+    contract:
+      enforced: true
+  columns:
+  - name: generic_segmentid
+    data_type: string
+  - name: generic_segmenttype
+    data_type: string
+  - name: roadbed_segmentid
+    data_type: string
+  - name: filler_rpl3
+    data_type: string
+  - name: roadbed_position_code
+    data_type: string
+  - name: filler_rpl4
+    data_type: string
+  - name: node_correspondence_indicator
+    data_type: string
+  - name: filler_rpl5
+    data_type: string
+  - name: from_node_level_code_of_coincident_roadbed_segment
+    data_type: string
+  - name: filler_rpl6
+    data_type: string
+  - name: to_node_level_code_of_coincident_roadbed_segment
+    data_type: string
+  - name: filler_rpl7
+    data_type: string
+  - name: from_nodeid_of_roadbed_segment
+    data_type: string
+  - name: filler_rpl8
+    data_type: string
+  - name: from_nodeid_of_generic_segment
+    data_type: string
+  - name: filler_rpl9
+    data_type: string
+  - name: to_nodeid_of_roadbed_segment
+    data_type: string
+  - name: filler_rpl10
+    data_type: string
+  - name: to_nodeid_of_generic_segment
+    data_type: string
+data_tests:
+- test_name: dbt_utils.unique_combination_of_columns
+  arguments:
+    combination_of_columns:
+    - generic_segmentid
+    - roadbed_segmentid
+
+- name: rpl
+  config:
+    contract:
+      enforced: true
+  columns:
+  - name: dat_column
+    data_type: string
+    tests:
+      - dbt_expectations.expect_column_value_lengths_to_equal:
+          arguments: { value: 59 }

--- a/products/cscl/models/product/rpl/_rpl.yml
+++ b/products/cscl/models/product/rpl/_rpl.yml
@@ -6,6 +6,8 @@ models:
     contract:
       enforced: true
   columns:
+  - name: rpl_id
+    data_type: string
   - name: generic_segmentid
     data_type: string
   - name: generic_segmenttype
@@ -44,12 +46,12 @@ models:
     data_type: string
   - name: to_nodeid_of_generic_segment
     data_type: string
-data_tests:
-- test_name: dbt_utils.unique_combination_of_columns
-  arguments:
-    combination_of_columns:
-    - generic_segmentid
-    - roadbed_segmentid
+  data_tests:
+  - test_name: dbt_utils.unique_combination_of_columns
+    arguments:
+      combination_of_columns:
+      - generic_segmentid
+      - roadbed_segmentid
 
 - name: rpl
   config:

--- a/products/cscl/models/product/rpl/rpl.sql
+++ b/products/cscl/models/product/rpl/rpl.sql
@@ -1,1 +1,1 @@
-{{ select_rows_as_text(model='rpl_by_field') }}
+{{ select_rows_as_text(model='rpl_by_field', exclude=['rpl_id']) }}

--- a/products/cscl/models/product/rpl/rpl.sql
+++ b/products/cscl/models/product/rpl/rpl.sql
@@ -1,0 +1,1 @@
+{{ select_rows_as_text(model='rpl_by_field') }}

--- a/products/cscl/models/product/rpl/rpl_by_field.sql
+++ b/products/cscl/models/product/rpl/rpl_by_field.sql
@@ -1,3 +1,5 @@
 SELECT
+    rpl_id,
     {{ apply_text_formatting_from_seed('text_formatting__rpl') }}
 FROM {{ ref("int__rpl") }}
+ORDER BY rpl_id ASC

--- a/products/cscl/models/product/rpl/rpl_by_field.sql
+++ b/products/cscl/models/product/rpl/rpl_by_field.sql
@@ -1,0 +1,3 @@
+SELECT
+    {{ apply_text_formatting_from_seed('text_formatting__rpl') }}
+FROM {{ ref("int__rpl") }}

--- a/products/cscl/models/staging/_stg.yml
+++ b/products/cscl/models/staging/_stg.yml
@@ -33,8 +33,9 @@ models:
   - name: b7sc
     tests:
     - unique:
-        config: { where: "b7sc IS NOT NULL" }
-        error_if: "> 1"
+        arguments:
+          config: { where: "b7sc IS NOT NULL" }
+          error_if: "> 1"
   - name: lookup_key
   - name: face_code
 

--- a/products/cscl/packages.yml
+++ b/products/cscl/packages.yml
@@ -1,5 +1,7 @@
 packages:
 - package: dbt-labs/dbt_utils
   version: 1.3.2
+- package: dbt-labs/audit_helper
+  version: 0.13.0
 - package: metaplane/dbt_expectations
   version: 0.10.9

--- a/products/cscl/poc_validation/prod_data_loader.py
+++ b/products/cscl/poc_validation/prod_data_loader.py
@@ -3,6 +3,8 @@ This script is for parsing a lion.dat file into its individual fields
 and loading the result into a postgres table
 
 This is done ad-hoc and not on an operational basis
+
+It assumes that production outputs are specified as exports in recipe.yml
 """
 
 from dataclasses import dataclass

--- a/products/cscl/poc_validation/prod_data_loader.py
+++ b/products/cscl/poc_validation/prod_data_loader.py
@@ -16,7 +16,7 @@ from dcpy.lifecycle.builds import plan
 from dcpy.utils import postgres, s3
 
 CLIENT = postgres.PostgresClient(database="db-cscl", schema="production_outputs")
-LOAD_FOLDER = Path("prod")
+LOAD_FOLDER = Path(".data/prod")
 
 version: str | None = None
 datasets_by_name = {}

--- a/products/cscl/poc_validation/validate_outputs.sh
+++ b/products/cscl/poc_validation/validate_outputs.sh
@@ -2,14 +2,14 @@
 
 # Expects two folders in current directory
 #  output - contains outputs of build
-#  prod - contains "production" 25a (or whatever version) for comparison
-mkdir validation_output
+#  .data/prod - contains "production" 25a (or whatever version) for comparison
+mkdir output/validation_output
 
 total_records=0
 total_mismatched=0
 for filepath in output/*; do
     file=$(basename "$filepath")
-    if [[ "$file" =~ "zip" ]]; then
+    if [[ "$file" =~ "zip" ]] || [[ -d "$filepath" ]]; then
         continue
     fi
     echo "Validating $file"
@@ -17,7 +17,7 @@ for filepath in output/*; do
     n_records="$(cat output/$file | wc -l |  awk '{print $1}')"
     echo "Total records:      $n_records"
     total_records=$(($total_records + $n_records))
-    mismatched_rows=$(comm -23 <(sort output/$file) <(sort prod/$file))
+    mismatched_rows=$(comm -23 <(sort output/$file) <(sort .data/prod/$file))
     
     if [ -z "$mismatched_rows" ]; then
         n_mismatched=0
@@ -27,7 +27,7 @@ for filepath in output/*; do
     echo "Mismatched records: $n_mismatched"
     total_mismatched=$(($total_mismatched + $n_mismatched))
 
-    echo -e "$mismatched_rows" > validation_output/$file
+    echo -e "$mismatched_rows" > output/validation_output/$file
     echo ""
 done
 

--- a/products/cscl/recipe.yml
+++ b/products/cscl/recipe.yml
@@ -251,3 +251,9 @@ exports:
     filename: StatenIslandFace.txt
     format: dat
     custom: { formatting: face_code }
+
+  # Other
+  - name: rpl
+    filename: RPL.txt
+    format: dat
+    custom: { formatting: rpl }

--- a/products/cscl/seeds/text_formatting/text_formatting__rpl.csv
+++ b/products/cscl/seeds/text_formatting/text_formatting__rpl.csv
@@ -1,0 +1,20 @@
+fic,field_name,field_label,field_length,start_index,end_index,justify_and_fill,blank_if_none
+RPL1,generic_segmentid,Generic SEGMENTID,7,1,7,RJZF,FALSE
+RPL2,generic_segmenttype,Segment Type of Generic Segment,1,8,8,RJSF,FALSE
+RPL3,roadbed_segmentid,Roadbed SEGMENTID,7,9,15,RJZF,FALSE
+,filler_rpl3,Filler,1,16,16,RJSF,FALSE
+RPL4,roadbed_position_code,Roadbed Position Code,1,17,17,RJSF,FALSE
+,filler_rpl4,Filler,1,18,18,RJSF,FALSE
+RPL5,node_correspondence_indicator,Node Correspondence Indicator,1,19,19,RJSF,FALSE
+,filler_rpl5,Filler,3,20,22,RJSF,FALSE
+RPL6,from_node_level_code_of_coincident_roadbed_segment,From Node Level Code of Coincident Roadbed Segment (if any),1,23,23,RJSF,FALSE
+,filler_rpl6,Filler,3,24,26,RJSF,FALSE
+RPL7,to_node_level_code_of_coincident_roadbed_segment,To Node Level Code of Coincident Roadbed Segment (if any),1,27,27,RJSF,FALSE
+,filler_rpl7,Filler,1,28,28,RJSF,FALSE
+RPL8,from_nodeid_of_roadbed_segment,From NODEID of Roadbed Segment,7,29,35,RJZF,FALSE
+,filler_rpl8,Filler,1,36,36,RJSF,FALSE
+RPL9,from_nodeid_of_generic_segment,From NODEID of Generic Segment,7,37,43,RJZF,FALSE
+,filler_rpl9,Filler,1,44,44,RJSF,FALSE
+RPL10,to_nodeid_of_roadbed_segment,To NODEID of Roadbed Segment,7,45,51,RJZF,FALSE
+,filler_rpl10,Filler,1,52,52,RJSF,FALSE
+RPL11,to_nodeid_of_generic_segment,To NODEID of Generic Segment,7,53,59,RJZF,FALSE


### PR DESCRIPTION
resolves #1839 

[all builds on this branch](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Afvk-rpl)

## dev vs prod

HTML map of a correct dev example attached to [this github comment](https://github.com/NYCPlanning/data-engineering/issues/1839#issuecomment-4019355573)

row counts:
- 10 more rows in dev (29,181 vs 29,171)
- 29 rows in dev that aren't in prod
- 19 rows in prod that aren't in dev

row order within groups with the same `generic_segmentid`:
- 278 diffs in row ordering
- apparent causes (from manually reviewing diffs, haven't looked at all of them):
  - wrong order in prod (e.g. L roadbed before R)
  - source records not having an R roadbed in their group

values:
- 3 diffs in values
- all related to `to_`/`from_` `nodeid_` values

### new qa approach

added and using the [`dbt-audit-helper`](https://github.com/dbt-labs/dbt-audit-helper) dbt package in the new qa rpl models

the new qa models use macros like [`compare_and_classify_query_results`](https://github.com/dbt-labs/dbt-audit-helper?tab=readme-ov-file#compare_and_classify_query_results-source) to generate row-by-row comparisons and summary stats of added/removed/identical/modified records

to qa the ordering of records, I had to incorporate prod row orders into a `rpl_id` key using `ROW_NUMBER() OVER (PARTITION BY generic_segmentid)`. this is the same key generated in `int__rpl`

summary of results from `qa__rpl_order` showing counts of diffs (aka "modified"):

|dbt_audit_row_status|dbt_audit_num_rows_in_status|
|--------------------|----------------------------|
|added|29|
|identical|28874|
|modified|278|
|removed|19|


### notes

Checking ordering within groups of 5 roadbed records surfaced a bug that is now resolved and those groups appear to have the right ordering now.

The bug in some of the large groups was caused by the logic assuming that an innermost segment would be closer to it's side's outermost segment than that of the other side. So if an innermost segment on the right side was so close to the central generic that the distance to the outermost left is less than the distance to the outermost right, then the ordering was incorrect because the logic presumed it was to the left of the central generic.
