### PR TITLE
fix git-related github action issue

### DIFF
--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -192,24 +192,18 @@ jobs:
         docker compose -f .devcontainer/docker-compose.yml up -d --wait de postgis sftp-server
 
     - name: Run Container Setup
-      run: docker exec --user root de ./bash/docker_container_setup.sh
+      run: ./bash/docker_container_setup.sh
 
     - name: dcpy main pytests
-      run: |
-        docker exec --user root de \
-        python3 -m pytest dcpy/test --ignore dcpy/test/library -vv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml
+      run: python3 -m pytest dcpy/test --ignore dcpy/test/library -vv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml
 
     # separate because of issues w/ gdal and pyarrow
     # errors occur when writing/reading parquet files after importing gdal
     - name: dcpy library pytests
-      run: |
-        docker exec --user root de \
-        python3 -m pytest dcpy/test/library -vv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
+      run: python3 -m pytest dcpy/test/library -vv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
 
     - name: dcpy integration pytests
-      run: |
-        docker exec --user root de \
-        python3 -m pytest dcpy/test_integration -vv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
+      run: python3 -m pytest dcpy/test_integration -vv --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
       env:
         RECIPES_BUCKET: "test-recipes"
 


### PR DESCRIPTION
getting error "could not lock config file /home/runner/.gitconfig: No such file or directory"

resolves failing dcpy test job on other open PRs