### PR TITLE
Implement Packaging All OTI XLSX files

### DIFF
--- a/dcpy/connectors/hybrid_pathed_storage.py
+++ b/dcpy/connectors/hybrid_pathed_storage.py
@@ -4,10 +4,11 @@ import shutil
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, NotRequired, TypedDict, Unpack
+from typing import Any, Unpack
 
 from cloudpathlib import CloudPath, S3Client
 from cloudpathlib.azure import AzureBlobClient
+from typing_extensions import NotRequired, TypedDict
 
 from dcpy.configuration import DEFAULT_S3_URL
 from dcpy.connectors.registry import Connector

--- a/dcpy/lifecycle/package/_cli.py
+++ b/dcpy/lifecycle/package/_cli.py
@@ -96,25 +96,18 @@ def list_versions(
     ),
 ):
     """List all destination versions as JSON."""
-    import json
+    from dcpy.product_metadata.versions import DestinationVersions
 
     org_md = product_metadata.load(version=version)
-    versions = org_md.get_all_destination_current_versions()
-
-    # Build JSON: {"product.dataset.destination": "version"}
-    versions_dict = {}
-    for line in versions:
-        if "|" in line:
-            dest, ver = line.split("|", 1)
-            versions_dict[dest] = ver
-
-    output = json.dumps(versions_dict, indent=2)
+    dest_versions = DestinationVersions.from_org_metadata(org_md)
 
     if output_file:
-        output_file.write_text(output + "\n")
-        typer.echo(f"Wrote {len(versions_dict)} destination versions to {output_file}")
+        dest_versions.to_json_file(output_file)
+        typer.echo(
+            f"Wrote {len(dest_versions.versions)} destination versions to {output_file}"
+        )
     else:
-        typer.echo(output)
+        typer.echo(dest_versions.to_json_string())
 
 
 @metadata_app.command("diff-versions")
@@ -131,116 +124,34 @@ def diff_versions(
     ),
 ):
     """Compare two destination version files and show changes."""
-    import json
+    from dcpy.product_metadata.versions import DestinationVersions
 
-    # Read JSON versions
-    prev_versions = json.loads(old_file.read_text())
-    curr_versions = json.loads(new_file.read_text())
+    old_versions = DestinationVersions.from_json_file(old_file)
+    new_versions = DestinationVersions.from_json_file(new_file)
 
-    # Categorize changes
-    added = []
-    changed = []
-    removed = []
-
-    for dest, ver in sorted(curr_versions.items()):
-        if dest not in prev_versions:
-            parts = dest.split(".")
-            added.append(
-                {
-                    "destination": dest,
-                    "product": parts[0] if len(parts) >= 1 else "",
-                    "dataset": parts[1] if len(parts) >= 2 else "",
-                    "destination_id": parts[2] if len(parts) >= 3 else "",
-                    "version": ver,
-                }
-            )
-        elif prev_versions[dest] != ver:
-            parts = dest.split(".")
-            changed.append(
-                {
-                    "destination": dest,
-                    "product": parts[0] if len(parts) >= 1 else "",
-                    "dataset": parts[1] if len(parts) >= 2 else "",
-                    "destination_id": parts[2] if len(parts) >= 3 else "",
-                    "old_version": prev_versions[dest],
-                    "new_version": ver,
-                }
-            )
-
-    for dest, ver in sorted(prev_versions.items()):
-        if dest not in curr_versions:
-            parts = dest.split(".")
-            removed.append(
-                {
-                    "destination": dest,
-                    "product": parts[0] if len(parts) >= 1 else "",
-                    "dataset": parts[1] if len(parts) >= 2 else "",
-                    "destination_id": parts[2] if len(parts) >= 3 else "",
-                    "version": ver,
-                }
-            )
+    diff = old_versions.compare(new_versions)
 
     if json_format:
-        # JSON output for machine reading
-        output_data = {
-            "added": added,
-            "changed": changed,
-            "removed": removed,
-            "summary": {
-                "added_count": len(added),
-                "changed_count": len(changed),
-                "removed_count": len(removed),
-            },
-        }
-        output = json.dumps(output_data, indent=2)
-
+        output = diff.model_dump_json(indent=2)
         if output_file:
             output_file.write_text(output + "\n")
             typer.echo(f"JSON diff written to {output_file}")
-            typer.echo(
-                f"Summary: {len(added)} added, {len(changed)} changed, {len(removed)} removed"
-            )
         else:
             typer.echo(output)
     else:
-        # Human-readable text output
-        output_lines = []
-
-        if added:
-            output_lines.append("## Added")
-            output_lines.extend([f"+ {a['destination']}|{a['version']}" for a in added])
-            output_lines.append("")
-
-        if changed:
-            output_lines.append("## Changed")
-            output_lines.extend(
-                [
-                    f"  {c['destination']}|{c['old_version']} -> {c['new_version']}"
-                    for c in changed
-                ]
-            )
-            output_lines.append("")
-
-        if removed:
-            output_lines.append("## Removed")
-            output_lines.extend(
-                [f"- {r['destination']}|{r['version']}" for r in removed]
-            )
-            output_lines.append("")
-
-        if not added and not changed and not removed:
-            output_lines.append("No changes detected.")
-
-        output = "\n".join(output_lines)
-
+        output = diff.to_text()
         if output_file:
             output_file.write_text(output + "\n")
             typer.echo(f"Diff written to {output_file}")
-            typer.echo(
-                f"Summary: {len(added)} added, {len(changed)} changed, {len(removed)} removed"
-            )
         else:
             typer.echo(output)
+
+    # Always print summary
+    typer.echo(
+        f"Summary: {diff.summary['added_count']} added, "
+        f"{diff.summary['changed_count']} changed, "
+        f"{diff.summary['removed_count']} removed"
+    )
 
 
 app.add_typer(metadata_app, name="metadata")

--- a/dcpy/lifecycle/package/_cli.py
+++ b/dcpy/lifecycle/package/_cli.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 
 import typer
+from tabulate import tabulate  # type: ignore
 
+from dcpy.lifecycle import product_metadata
+from dcpy.product_metadata import generate
 from dcpy.product_metadata.writers.oti_xlsx.xlsx_writer import app as xlsx_writer_app
 
 from .assemble import assemble_dataset_package
@@ -14,6 +17,233 @@ app.command(name="validate")(_validate)
 app.add_typer(esri_app, name="esri")
 app.add_typer(xlsx_writer_app, name="oti")
 app.add_typer(shapefile_app, name="shapefile")
+
+# Metadata commands
+metadata_app = typer.Typer()
+
+
+@metadata_app.command("generate")
+def generate_metadata(
+    dataset_paths: list[str] = typer.Argument(
+        None,
+        help="Dataset paths in format product.dataset. If not provided, generates for all datasets.",
+    ),
+    output_dir: Path = typer.Option(
+        ..., "--output-dir", "-o", help="Output directory for generated files"
+    ),
+    version: str = typer.Option(
+        ..., "--version", "-v", help="Product metadata version"
+    ),
+):
+    """Generate metadata for datasets. If no datasets provided, generates for all."""
+    org_md = product_metadata.load(version=version)
+
+    # If no datasets provided, get all datasets
+    if not dataset_paths:
+        dataset_paths = []
+        for product_name in org_md.metadata.products:
+            try:
+                product = org_md.product(product_name)
+                for ds_id in product.metadata.datasets:
+                    dataset_paths.append(f"{product_name}.{ds_id}")
+            except Exception:
+                pass
+
+        typer.echo(
+            f"No datasets specified, generating for all {len(dataset_paths)} datasets..."
+        )
+
+    results = generate.generate_metadata_assets(
+        org_metadata=org_md,
+        dataset_paths=dataset_paths,
+        output_dir=output_dir,
+    )
+
+    # Display results table
+    table_data = [
+        [
+            f"{r.product}.{r.dataset}",
+            "✓" if r.success else "✗",
+            ", ".join(r.files_generated) if r.files_generated else "-",
+            r.error_message or "",
+        ]
+        for r in results
+    ]
+
+    table = tabulate(
+        table_data,
+        headers=["Dataset", "Success", "Files Generated", "Error"],
+        tablefmt="simple",
+    )
+    typer.echo(table)
+
+    # Raise exception if any failures
+    failures = [r for r in results if not r.success]
+    if failures:
+        typer.echo(f"\n{len(failures)} dataset(s) failed", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(f"\nSuccessfully generated metadata for {len(results)} dataset(s)")
+
+
+@metadata_app.command("list-versions")
+def list_versions(
+    version: str = typer.Option(
+        ..., "--version", "-v", help="Product metadata version"
+    ),
+    output_file: Path = typer.Option(
+        None, "--output", "-o", help="Output file (default: stdout)"
+    ),
+):
+    """List all destination versions as JSON."""
+    import json
+
+    org_md = product_metadata.load(version=version)
+    versions = org_md.get_all_destination_current_versions()
+
+    # Build JSON: {"product.dataset.destination": "version"}
+    versions_dict = {}
+    for line in versions:
+        if "|" in line:
+            dest, ver = line.split("|", 1)
+            versions_dict[dest] = ver
+
+    output = json.dumps(versions_dict, indent=2)
+
+    if output_file:
+        output_file.write_text(output + "\n")
+        typer.echo(f"Wrote {len(versions_dict)} destination versions to {output_file}")
+    else:
+        typer.echo(output)
+
+
+@metadata_app.command("diff-versions")
+def diff_versions(
+    old_file: Path = typer.Argument(
+        ..., help="Previous destination_versions.json file"
+    ),
+    new_file: Path = typer.Argument(..., help="Current destination_versions.json file"),
+    output_file: Path = typer.Option(
+        None, "--output", "-o", help="Output file (default: stdout)"
+    ),
+    json_format: bool = typer.Option(
+        False, "--json", help="Output as JSON for machine reading"
+    ),
+):
+    """Compare two destination version files and show changes."""
+    import json
+
+    # Read JSON versions
+    prev_versions = json.loads(old_file.read_text())
+    curr_versions = json.loads(new_file.read_text())
+
+    # Categorize changes
+    added = []
+    changed = []
+    removed = []
+
+    for dest, ver in sorted(curr_versions.items()):
+        if dest not in prev_versions:
+            parts = dest.split(".")
+            added.append(
+                {
+                    "destination": dest,
+                    "product": parts[0] if len(parts) >= 1 else "",
+                    "dataset": parts[1] if len(parts) >= 2 else "",
+                    "destination_id": parts[2] if len(parts) >= 3 else "",
+                    "version": ver,
+                }
+            )
+        elif prev_versions[dest] != ver:
+            parts = dest.split(".")
+            changed.append(
+                {
+                    "destination": dest,
+                    "product": parts[0] if len(parts) >= 1 else "",
+                    "dataset": parts[1] if len(parts) >= 2 else "",
+                    "destination_id": parts[2] if len(parts) >= 3 else "",
+                    "old_version": prev_versions[dest],
+                    "new_version": ver,
+                }
+            )
+
+    for dest, ver in sorted(prev_versions.items()):
+        if dest not in curr_versions:
+            parts = dest.split(".")
+            removed.append(
+                {
+                    "destination": dest,
+                    "product": parts[0] if len(parts) >= 1 else "",
+                    "dataset": parts[1] if len(parts) >= 2 else "",
+                    "destination_id": parts[2] if len(parts) >= 3 else "",
+                    "version": ver,
+                }
+            )
+
+    if json_format:
+        # JSON output for machine reading
+        output_data = {
+            "added": added,
+            "changed": changed,
+            "removed": removed,
+            "summary": {
+                "added_count": len(added),
+                "changed_count": len(changed),
+                "removed_count": len(removed),
+            },
+        }
+        output = json.dumps(output_data, indent=2)
+
+        if output_file:
+            output_file.write_text(output + "\n")
+            typer.echo(f"JSON diff written to {output_file}")
+            typer.echo(
+                f"Summary: {len(added)} added, {len(changed)} changed, {len(removed)} removed"
+            )
+        else:
+            typer.echo(output)
+    else:
+        # Human-readable text output
+        output_lines = []
+
+        if added:
+            output_lines.append("## Added")
+            output_lines.extend([f"+ {a['destination']}|{a['version']}" for a in added])
+            output_lines.append("")
+
+        if changed:
+            output_lines.append("## Changed")
+            output_lines.extend(
+                [
+                    f"  {c['destination']}|{c['old_version']} -> {c['new_version']}"
+                    for c in changed
+                ]
+            )
+            output_lines.append("")
+
+        if removed:
+            output_lines.append("## Removed")
+            output_lines.extend(
+                [f"- {r['destination']}|{r['version']}" for r in removed]
+            )
+            output_lines.append("")
+
+        if not added and not changed and not removed:
+            output_lines.append("No changes detected.")
+
+        output = "\n".join(output_lines)
+
+        if output_file:
+            output_file.write_text(output + "\n")
+            typer.echo(f"Diff written to {output_file}")
+            typer.echo(
+                f"Summary: {len(added)} added, {len(changed)} changed, {len(removed)} removed"
+            )
+        else:
+            typer.echo(output)
+
+
+app.add_typer(metadata_app, name="metadata")
 
 
 @app.command()

--- a/dcpy/product_metadata/generate.py
+++ b/dcpy/product_metadata/generate.py
@@ -1,0 +1,183 @@
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from dcpy.product_metadata.models.metadata.org import OrgMetadata
+from dcpy.product_metadata.models.metadata.product import (
+    DestinationPackageMetadata,
+    File,
+    Package,
+)
+from dcpy.product_metadata.writers.oti_xlsx.xlsx_writer import (
+    EXCEL_DATA_DICT_METADATA_FILE_TYPE,
+    write_xlsx,
+)
+from dcpy.utils.logging import logger
+
+
+class GenerateResult(BaseModel):
+    product: str
+    dataset: str
+    success: bool
+    files_generated: list[str] = []
+    error_message: str | None = None
+
+
+def generate_metadata_assets(
+    org_metadata: OrgMetadata,
+    dataset_paths: list[str],
+    output_dir: Path,
+) -> list[GenerateResult]:
+    """Generate metadata assets for dataset paths.
+
+    For each dataset path (product.dataset):
+    - Query all dataset files where is_metadata=True
+    - Generate XLSX for files with type=oti_data_dictionary
+    - Save to {output_dir}/{product}/{dataset}/
+
+    Returns list of results (success/failure per dataset).
+    """
+    results = []
+
+    for dataset_path in dataset_paths:
+        try:
+            parts = dataset_path.split(".")
+            if len(parts) != 2:
+                raise ValueError(
+                    f"Invalid dataset path format: {dataset_path}. Expected format: product.dataset"
+                )
+
+            product, dataset = parts
+            logger.info(f"Generating metadata assets for {dataset_path}")
+
+            product_md = org_metadata.product(product)
+            dataset_md = product_md.dataset(dataset)
+
+            files_generated = []
+            dataset_output_dir = output_dir / product / dataset
+            dataset_output_dir.mkdir(parents=True, exist_ok=True)
+
+            # Create files subfolder for generated metadata files
+            files_dir = dataset_output_dir / "files"
+            files_dir.mkdir(parents=True, exist_ok=True)
+
+            # Create destinations subfolder for serialized metadata
+            destinations_dir = dataset_output_dir / "destinations"
+            destinations_dir.mkdir(parents=True, exist_ok=True)
+
+            # Generate metadata files (e.g., XLSX data dictionaries)
+            for file_and_overrides in dataset_md.files:
+                file_obj = file_and_overrides.file
+                if not file_obj.is_metadata:
+                    continue
+
+                if file_obj.type == EXCEL_DATA_DICT_METADATA_FILE_TYPE:
+                    logger.info(
+                        f"Generating XLSX for {dataset_path}: {file_obj.filename}"
+                    )
+                    output_path = files_dir / file_obj.filename
+                    write_xlsx(
+                        org_md=org_metadata,
+                        product=product,
+                        dataset=dataset,
+                        output_path=output_path,
+                    )
+                    files_generated.append(file_obj.filename)
+                else:
+                    logger.warning(
+                        f"Cannot generate metadata file {file_obj.filename} of type '{file_obj.type}' for {dataset_path}"
+                    )
+
+            # Serialize destination metadata for each destination
+            for destination in dataset_md.destinations:
+                dest_id = destination.id
+                dest_metadata_dir = destinations_dir / dest_id
+                dest_metadata_dir.mkdir(parents=True, exist_ok=True)
+
+                # Build sets for quick lookup
+                file_ids = {f.file.id for f in dataset_md.files}
+                assembly_ids = {a.id for a in dataset_md.assembly}
+
+                # Find dataset files (not metadata files) to generate metadata for
+                dataset_files = []
+                for dest_file in destination.files:
+                    if dest_file.id in assembly_ids:
+                        # It's a package/assembly, include it
+                        dataset_files.append(dest_file.id)
+                    elif dest_file.id in file_ids:
+                        # It's a file, check if it's metadata
+                        file_obj = dataset_md.get_file_and_overrides(dest_file.id).file
+                        if not file_obj.is_metadata:
+                            dataset_files.append(dest_file.id)
+
+                # Collect ALL files for this destination (with overrides applied)
+                all_files: list[File | Package] = []
+                for dest_file in destination.files:
+                    if dest_file.id in file_ids:
+                        # It's a file - calculate metadata with overrides
+                        file_metadata = dataset_md.calculate_destination_metadata(
+                            file_id=dest_file.id, destination_id=dest_id
+                        )
+                        all_files.append(file_metadata.file)
+                    elif dest_file.id in assembly_ids:
+                        # It's a package/assembly - add the package itself
+                        package = dataset_md.get_package(dest_file.id)
+                        all_files.append(package)
+
+                # For each dataset file, create metadata that includes ALL files for this destination
+                for dataset_file_id in dataset_files:
+                    if dataset_file_id in assembly_ids:
+                        # Skip assemblies for now - they need special handling
+                        logger.debug(
+                            f"Skipping assembly {dataset_file_id} for destination {dest_id}"
+                        )
+                        continue
+
+                    # Get the dataset metadata for this specific dataset file
+                    primary_file_metadata = dataset_md.calculate_destination_metadata(
+                        file_id=dataset_file_id, destination_id=dest_id
+                    )
+
+                    # Create package metadata with all files
+                    package_metadata = DestinationPackageMetadata(
+                        dataset=primary_file_metadata.dataset,
+                        destination=primary_file_metadata.destination,
+                        files=all_files,
+                    )
+
+                    # Serialize to YAML (one per dataset file)
+                    file_metadata_dir = dest_metadata_dir / dataset_file_id
+                    file_metadata_dir.mkdir(parents=True, exist_ok=True)
+                    output_yaml_path = file_metadata_dir / "metadata.yml"
+                    package_metadata.write_to_yaml(output_yaml_path)
+                    logger.info(
+                        f"Serialized metadata for {dataset_path}.{dest_id}.{dataset_file_id} (with {len(all_files)} files)"
+                    )
+
+            results.append(
+                GenerateResult(
+                    product=product,
+                    dataset=dataset,
+                    success=True,
+                    files_generated=files_generated,
+                )
+            )
+
+        except Exception as e:
+            logger.error(f"Error generating metadata for {dataset_path}: {e}")
+            # Parse as much as we can for the error result
+            try:
+                product, dataset = dataset_path.split(".")
+            except ValueError:
+                product, dataset = dataset_path, ""
+
+            results.append(
+                GenerateResult(
+                    product=product,
+                    dataset=dataset,
+                    success=False,
+                    error_message=str(e),
+                )
+            )
+
+    return results

--- a/dcpy/product_metadata/keys.py
+++ b/dcpy/product_metadata/keys.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel
+
+
+class DestinationKey(BaseModel):
+    """Parsed destination identifier: product.dataset.destination_id."""
+
+    product: str
+    dataset: str
+    destination_id: str
+
+    @classmethod
+    def from_path_str(cls, path: str) -> "DestinationKey":
+        """Parse product.dataset.destination_id string into components.
+
+        Args:
+            path: Destination path like "product.dataset.destination_id"
+
+        Returns:
+            DestinationKey instance
+        """
+        parts = path.split(".")
+        return cls(
+            product=parts[0] if len(parts) >= 1 else "",
+            dataset=parts[1] if len(parts) >= 2 else "",
+            destination_id=parts[2] if len(parts) >= 3 else "",
+        )
+
+    @property
+    def path_str(self) -> str:
+        """Return the full path: product.dataset.destination_id."""
+        return f"{self.product}.{self.dataset}.{self.destination_id}"
+
+    def __str__(self) -> str:
+        return self.path_str

--- a/dcpy/product_metadata/models/metadata/product.py
+++ b/dcpy/product_metadata/models/metadata/product.py
@@ -193,7 +193,7 @@ class Revision(CustomizableBase):
     notes: str
 
 
-class Dataset(CustomizableBase):
+class Dataset(CustomizableBase, YamlWriter):
     columns: list[DatasetColumn]
     attributes: DatasetAttributes
     revisions: list[Revision] = []
@@ -242,10 +242,18 @@ class DestinationFile(CustomizableBase):
     file_overrides: FileOverrides = FileOverrides()
 
 
-class DestinationMetadata(SortedSerializedBase):
+class DestinationMetadata(SortedSerializedBase, YamlWriter):
     dataset: Dataset
     destination: Destination
     file: File
+
+
+class DestinationPackageMetadata(SortedSerializedBase, YamlWriter):
+    """Metadata for a dataset file and all associated files for distribution."""
+
+    dataset: Dataset
+    destination: Destination
+    files: List[File | Package]
 
 
 class Metadata(CustomizableBase, YamlWriter, TemplatedYamlReader):

--- a/dcpy/product_metadata/versions.py
+++ b/dcpy/product_metadata/versions.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from dcpy.product_metadata.keys import DestinationKey
+
+
+class DestinationVersion(BaseModel):
+    """Single destination with its version."""
+
+    key: DestinationKey
+    version: str
+
+    @classmethod
+    def from_path(cls, destination_path: str, version: str) -> "DestinationVersion":
+        """Parse product.dataset.destination_id and create instance."""
+        return cls(
+            key=DestinationKey.from_path_str(destination_path),
+            version=version,
+        )
+
+
+class VersionChange(BaseModel):
+    """Represents a version change for a destination."""
+
+    key: DestinationKey
+    old_version: str
+    new_version: str
+
+
+class VersionDiff(BaseModel):
+    """Comparison between two DestinationVersions instances."""
+
+    added: list[DestinationVersion] = []
+    changed: list[VersionChange] = []
+    removed: list[DestinationVersion] = []
+
+    @property
+    def summary(self) -> dict[str, int]:
+        return {
+            "added_count": len(self.added),
+            "changed_count": len(self.changed),
+            "removed_count": len(self.removed),
+        }
+
+    def to_text(self) -> str:
+        """Generate human-readable text output."""
+        lines = []
+
+        if self.added:
+            lines.append("## Added")
+            lines.extend([f"+ {a.key.path_str}|{a.version}" for a in self.added])
+            lines.append("")
+
+        if self.changed:
+            lines.append("## Changed")
+            lines.extend(
+                [
+                    f"  {c.key.path_str}|{c.old_version} -> {c.new_version}"
+                    for c in self.changed
+                ]
+            )
+            lines.append("")
+
+        if self.removed:
+            lines.append("## Removed")
+            lines.extend([f"- {r.key.path_str}|{r.version}" for r in self.removed])
+            lines.append("")
+
+        if not (self.added or self.changed or self.removed):
+            lines.append("No changes detected.")
+
+        return "\n".join(lines)
+
+
+class DestinationVersions(BaseModel):
+    """Collection of destination versions with comparison capabilities."""
+
+    # Use dict for efficient lookup: {"product.dataset.destination": "version"}
+    versions: dict[str, str]
+
+    @classmethod
+    def from_org_metadata(cls, org_metadata) -> "DestinationVersions":
+        """Build from OrgMetadata instance."""
+        version_list = org_metadata.get_all_destination_current_versions()
+        versions_dict = {}
+        for line in version_list:
+            if "|" in line:
+                dest, ver = line.split("|", 1)
+                versions_dict[dest] = ver
+        return cls(versions=versions_dict)
+
+    @classmethod
+    def from_json_file(cls, path: Path) -> "DestinationVersions":
+        """Load from JSON file."""
+        import json
+
+        return cls(versions=json.loads(path.read_text()))
+
+    def to_json_file(self, path: Path) -> None:
+        """Write to JSON file."""
+        import json
+
+        path.write_text(json.dumps(self.versions, indent=2) + "\n")
+
+    def to_json_string(self) -> str:
+        """Export as JSON string."""
+        import json
+
+        return json.dumps(self.versions, indent=2)
+
+    def compare(self, other: "DestinationVersions") -> VersionDiff:
+        """Compare this version snapshot to another.
+
+        Args:
+            other: The newer version to compare against
+
+        Returns:
+            VersionDiff with added, changed, and removed destinations
+        """
+        added = []
+        changed = []
+        removed = []
+
+        # Find added and changed
+        for dest, new_ver in sorted(other.versions.items()):
+            if dest not in self.versions:
+                added.append(DestinationVersion.from_path(dest, new_ver))
+            elif self.versions[dest] != new_ver:
+                changed.append(
+                    VersionChange(
+                        key=DestinationKey.from_path_str(dest),
+                        old_version=self.versions[dest],
+                        new_version=new_ver,
+                    )
+                )
+
+        # Find removed
+        for dest, old_ver in sorted(self.versions.items()):
+            if dest not in other.versions:
+                removed.append(DestinationVersion.from_path(dest, old_ver))
+
+        return VersionDiff(added=added, changed=changed, removed=removed)


### PR DESCRIPTION
Enables packaging metadata assets and overridden metadata. 

Still TODO: I'm going to wait to hook this up to distribution until we implement packaging. There's just too much going on in the scripts currently, and the whole packaging + distribution flow would take a fair bit of manual testing.

### Assets
Currently just creates all OTI Excel data dictionaries... there are about ~50 of them

### Product Metadata
Computes the metadata for all destination datasests, e.g. "the PLUTO shapefile that that goes to OpenData"

### Overall 
For PLUTO, it looks like this:
<img width="693" height="357" alt="image" src="https://github.com/user-attachments/assets/2c3e4faa-5c9c-4976-9be2-d4116318a7db" />


We can run this in PMD on merge to main to create a release. Then we when we distribute, we can pull the zip grab the relevant files.

1. Generate metadata for individual dataset (in this example, just zap.bbls)
```
    python -m dcpy lifecycle package metadata generate zap.bbls \
    --output-dir richey_stuff/metadata_outputs \
    --version 26v1

Result:

    - Generated 1 file: zapprojects_datadictionary.xlsx
    - Output location: richey_stuff/metadata_outputs/zap/bbls/zapprojects_datadictionary.xlsx
```

2. Generate metadata for all datasets (no arguments)
```
    python -m dcpy lifecycle package metadata generate \
    --output-dir richey_stuff/metadata_outputs \
    --version 26v1

Result:

    - Auto-discovered 45 datasets with XLSX metadata
    - Generated 47 XLSX files across those 45 datasets
    - Only generates files for datasets with is_metadata=True and type=oti_data_dictionary
    - Output structure: {product}/{dataset}/{filename}.xlsxx
```