### PR TITLE
add distribution page to QA app

### DIFF
--- a/.github/workflows/qa_deploy.yml
+++ b/.github/workflows/qa_deploy.yml
@@ -37,8 +37,12 @@ jobs:
       
       DOCKER_IMAGE_NAME: nycplanning/qa-streamlit:latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        
+      - uses: actions/checkout@v4
+        with:
+          repository: NYCPlanning/product-metadata
+          path: product-metadata
 
       - name: Load Secrets
         uses: 1password/load-secrets-action@v1
@@ -51,6 +55,9 @@ jobs:
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
           BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
           GHP_TOKEN: "op://Data Engineering/GITHUB_TOKENS/de_qa_app"
+          PRODUCT_METADATA_REPO_PATH: "../product-metadata"
+          SOCRATA_USER: "op://Data Engineering/DCP_OpenData/username"
+          SOCRATA_PASSWORD: "op://Data Engineering/DCP_OpenData/password"
 
       - name: Deploy docker image
         run: apps/qa/bash/docker_deploy.sh

--- a/apps/qa/bash/docker_deploy.sh
+++ b/apps/qa/bash/docker_deploy.sh
@@ -39,4 +39,8 @@ ssh qa "\
         -e GHP_TOKEN=$GHP_TOKEN\
         -e PUBLISHING_BUCKET=edm-publishing\
         -e RECIPES_BUCKET=edm-recipes\
+        -e RECIPES_BUCKET=edm-recipes\
+        -e PRODUCT_METADATA_REPO_PATH=$PRODUCT_METADATA_REPO_PATH\
+        -e SOCRATA_USER=$SOCRATA_USER\
+        -e SOCRATA_PASSWORD=$SOCRATA_PASSWORD\
         $DOCKER_IMAGE_NAME"

--- a/apps/qa/src/index.py
+++ b/apps/qa/src/index.py
@@ -19,7 +19,7 @@ def run():
         unsafe_allow_html=True,
     )
 
-    datasets_list = list(PAGES.keys())
+    page_list = list(PAGES.keys())
     query_params = st.query_params.to_dict()
 
     if query_params:
@@ -28,11 +28,11 @@ def run():
         name = "Home"
 
     name = st.sidebar.selectbox(
-        "Select a dataset for qaqc", datasets_list, index=datasets_list.index(name)
+        "Select a page to naviagte to", page_list, index=page_list.index(name)
     )
     st.sidebar.divider()
 
-    st.query_params["page"] = datasets_list[datasets_list.index(name)]
+    st.query_params["page"] = page_list[page_list.index(name)]
 
     dataset_module = importlib.import_module(f"pages.{PAGES[name]}.{PAGES[name]}")
     dataset_page = getattr(dataset_module, PAGES[name])

--- a/apps/qa/src/pages/distribution/distribution.py
+++ b/apps/qa/src/pages/distribution/distribution.py
@@ -1,0 +1,58 @@
+def distribution():
+    import streamlit as st
+
+    from . import helpers
+
+    st.subheader("Version comparison between Bytes and Open Data")
+    st.markdown(
+        body="""
+        This table shows the latest versions of datasets on Bytes and Open Data, along with links to them.
+        
+        The "up to date" column indicates whether the latest version on Open Data is probably the same as the latest version on Bytes, based on a fuzzy comparison of version strings.
+    """
+    )
+    button_get_versions = st.sidebar.button(
+        label="Get versions",
+        help="Clear local cache and get versions.",
+        use_container_width=True,
+    )
+    button_get_cached_versions = st.sidebar.button(
+        "Get cached versions",
+        help="Get cached versions (if available) to avoid long-running operation.",
+        use_container_width=True,
+    )
+    if button_get_versions:
+        with st.spinner("Getting versions from Bytes and Open Data ..."):
+            versions = helpers.get_versions()
+        st.cache_data.clear()
+
+    if button_get_cached_versions:
+        with st.spinner(
+            "Getting cached versions (if available) from Bytes and Open Data ..."
+        ):
+            versions = helpers.get_versions()
+        st.dataframe(
+            versions.reset_index(),
+            width="stretch",
+            hide_index=True,
+            column_config={
+                "bytes_url": st.column_config.LinkColumn(
+                    "Bytes URL", display_text="URL"
+                ),
+                "open_data_url": st.column_config.LinkColumn(
+                    "Open Data URL", display_text="URL"
+                ),
+            },
+        )
+
+    if not button_get_versions and not button_get_cached_versions:
+        st.info("Click a button on the left to fetch and display versions.")
+
+    st.subheader("Helpful links")
+    st.markdown(
+        body="""
+        - Github action to distribute from Bytes to Open Data: https://github.com/NYCPlanning/data-engineering/actions/workflows/distribute_socrata_from_bytes.yml
+        - Open Data page to sign in and publish revisions: https://opendata.cityofnewyork.us/
+        - Product Metadata repo: https://github.com/NYCPlanning/product-metadata
+    """
+    )

--- a/apps/qa/src/pages/distribution/helpers.py
+++ b/apps/qa/src/pages/distribution/helpers.py
@@ -1,0 +1,9 @@
+import streamlit as st
+
+
+@st.cache_data(show_spinner=False, persist=True)
+def get_versions():
+    from dcpy.lifecycle.scripts import version_compare
+
+    versions = version_compare.run()
+    return versions

--- a/apps/qa/src/shared/constants.py
+++ b/apps/qa/src/shared/constants.py
@@ -23,6 +23,7 @@ PAGES = {
     "Source Data": "source_data",
     "Checkbook": "checkbook",
     "Data Ingestion": "ingest",
+    "Data Distribution": "distribution",
 }
 
 DATASET_NAMES = {


### PR DESCRIPTION
adds a page to the QA app to show a table of current versions on Bytes and Open Data

having a button to get cached versions may only be useful for local dev work but would like to keep it for now to see if it's needed in the deployed app (e.g. "if I refresh the page, I don't necessarily want to fetch versions again")

## screenshots from local app

<img width="1440" height="640" alt="Screenshot 2026-04-08 at 4 26 25 PM" src="https://github.com/user-attachments/assets/fb1776d4-1af6-42d0-9d1f-0f05cf27e663" />

<img width="1440" height="578" alt="Screenshot 2026-04-08 at 4 46 22 PM" src="https://github.com/user-attachments/assets/bd7923e8-fcb4-4d3e-a8b7-45ffabbbe8b4" />

<img width="1439" height="772" alt="Screenshot 2026-04-08 at 4 56 16 PM" src="https://github.com/user-attachments/assets/87b8e811-b8bb-470a-bdc5-01360e0e0644" />

