### PR TITLE
fix ZTL data loading action

### DIFF
--- a/.github/workflows/zoningtaxlots_dataloading.yml
+++ b/.github/workflows/zoningtaxlots_dataloading.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         dataset:
-        - dcp_mih
+        - dcp_gis_mandatory_inclusionary_housing
         - dcp_edesignation
         - dcp_commercialoverlay
         - dcp_limitedheight

--- a/ingest_templates/dof_condo.yml
+++ b/ingest_templates/dof_condo.yml
@@ -18,7 +18,6 @@ ingestion:
     args:
       column_types:
         {
-          "oid_": "string",
           "condo_base_boro": "string",
           "condo_base_block": "string",
           "condo_base_lot": "string",
@@ -35,8 +34,6 @@ ingestion:
         }
 
 columns:
-- id: oid_
-  data_type: text
 - id: condo_base_boro
   data_type: text
 - id: condo_base_block


### PR DESCRIPTION
[failed action run](https://github.com/NYCPlanning/data-engineering/actions/runs/24250952127/job/70809855862#step:6:137)

[all ZTL action runs on this branch](https://github.com/NYCPlanning/data-engineering/actions/workflows/zoningtaxlots_dataloading.yml?query=branch%3Adm-fix-ztl)

this fixes the data loading steps of the job. the ZTL build fails because the previous version of `dcp_zoningtaxlots` (`2026-03-01`) needs to be archived (and has been with [this action run](https://github.com/NYCPlanning/data-engineering/actions/runs/24358333957))