### PR TITLE
PLUTO 26v1 Post QA Fixes

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Terse reference for agents working in this codebase.
 
 ### dbt
 - [dbt project conventions](./dbt/project_conventions.md)
+- **If adding a dbt model, read the conventions doc above first**
 
 ### Frontend/Products
 - [apps, glossary, and environment setup](./products/README.md)

--- a/docs/dbt/project_conventions.md
+++ b/docs/dbt/project_conventions.md
@@ -1,3 +1,4 @@
+
 # DBT Project Conventions
 
 Standard conventions for all dbt projects in this repository.
@@ -20,6 +21,9 @@ Core business logic and transformations:
 Final tables ready for export.
 
 ## Model Configuration
+
+## Adding New Models
+When adding a new .sql file, also check whether you need to add an accompanying models yml file.
 
 ### Materialization
 - `staging/`: `view` (default) unless indexes are required

--- a/products/pluto/models/intermediate/transitzone/_transitzone_models.yml
+++ b/products/pluto/models/intermediate/transitzone/_transitzone_models.yml
@@ -4,6 +4,9 @@ models:
   - name: int_tz__atomic_geoms
     description: Decomposed transit zone multipolygons into atomic parts for performance
     
+  - name: int_tz__union_coverage
+    description: Union of all transit zones (excluding Beyond the Greater Transit Zone) for identifying lots outside coverage
+    
   - name: int_tz__tax_blocks
     description: Tax blocks split into sub-blocks with BBL assignments
     

--- a/products/pluto/models/intermediate/transitzone/int_pluto__transitzone.sql
+++ b/products/pluto/models/intermediate/transitzone/int_pluto__transitzone.sql
@@ -8,6 +8,7 @@
 
 -- Final transit zone assignment per BBL
 -- Uses block-level for unambiguous blocks, lot-level for ambiguous ones
+-- Nulls out transit zones for lots in water (outside all transit zone coverage)
 
 WITH assignments AS (
     -- Block-level assignments for non-ambiguous blocks
@@ -35,9 +36,20 @@ WITH assignments AS (
         transit_zone
     FROM {{ ref('int_tz__bbl_to_tz_ranked') }}
     WHERE tz_rank = 1
+),
+
+lots_in_coverage AS (
+    SELECT p.bbl
+    FROM {{ target.schema }}.pluto AS p
+    INNER JOIN {{ ref('int_tz__union_coverage') }} AS tz
+        ON ST_INTERSECTS(p.geom, tz.geom)
 )
 
 SELECT
-    bbl,
-    transit_zone AS trnstzone
-FROM assignments
+    a.bbl,
+    CASE
+        WHEN lic.bbl IS NOT NULL THEN a.transit_zone
+        ELSE NULL
+    END AS trnstzone
+FROM assignments AS a
+LEFT JOIN lots_in_coverage AS lic ON a.bbl = lic.bbl

--- a/products/pluto/models/intermediate/transitzone/int_pluto__transitzone.sql
+++ b/products/pluto/models/intermediate/transitzone/int_pluto__transitzone.sql
@@ -49,7 +49,6 @@ SELECT
     a.bbl,
     CASE
         WHEN lic.bbl IS NOT NULL THEN a.transit_zone
-        ELSE NULL
     END AS trnstzone
 FROM assignments AS a
 LEFT JOIN lots_in_coverage AS lic ON a.bbl = lic.bbl

--- a/products/pluto/models/intermediate/transitzone/int_tz__union_coverage.sql
+++ b/products/pluto/models/intermediate/transitzone/int_tz__union_coverage.sql
@@ -1,0 +1,14 @@
+{{
+    config(
+        materialized='table',
+        indexes=[{'columns': ['geom'], 'type': 'gist'}],
+        tags=['pluto_enrichment']
+    )
+}}
+
+-- Union of all transit zones to identify land coverage
+-- Lots outside this union are in water and should have NULL transit zones
+
+SELECT
+    ST_UNION(geom) AS geom
+FROM {{ ref('stg__dcp_transit_zones') }}

--- a/products/pluto/models/intermediate/transitzone/int_tz__union_coverage.sql
+++ b/products/pluto/models/intermediate/transitzone/int_tz__union_coverage.sql
@@ -9,6 +9,5 @@
 -- Union of all transit zones to identify land coverage
 -- Lots outside this union are in water and should have NULL transit zones
 
-SELECT
-    ST_UNION(geom) AS geom
+SELECT ST_UNION(geom) AS geom
 FROM {{ ref('stg__dcp_transit_zones') }}

--- a/products/pluto/pluto_build/sql/export_mappluto_gdb.sql
+++ b/products/pluto/pluto_build/sql/export_mappluto_gdb.sql
@@ -92,8 +92,6 @@ SELECT
     a.latitude AS "Latitude",
     a.longitude AS "Longitude",
     a.notes AS "Notes",
-    round(st_length(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Leng",
-    round(st_area(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Area",
     st_makevalid(b.:GEOM) AS geom,
     a.mih_opt1 AS "MIHOption1",
     a.mih_opt2 AS "MIHOption2",
@@ -101,7 +99,9 @@ SELECT
     a.mih_opt4 AS "MIHOption4",
     a.trnstzone AS "TrnstZone",
     a.affresfar AS "AffResFAR",
-    a.mnffar AS "ManuFAR"
+    a.mnffar AS "ManuFAR",
+    round(st_length(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Leng",
+    round(st_area(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Area"
 INTO :TABLE
 FROM export_pluto AS a, pluto_geom AS b
 WHERE

--- a/products/pluto/pluto_build/sql/export_mappluto_shp.sql
+++ b/products/pluto/pluto_build/sql/export_mappluto_shp.sql
@@ -92,8 +92,6 @@ SELECT
     a.latitude AS "Latitude",
     a.longitude AS "Longitude",
     a.notes AS "Notes",
-    round(st_length(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Leng",
-    round(st_area(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Area",
     st_makevalid(b.:GEOM) AS geom,
     a.mih_opt1 AS "MIHOption1",
     a.mih_opt2 AS "MIHOption2",
@@ -101,7 +99,9 @@ SELECT
     a.mih_opt4 AS "MIHOption4",
     a.trnstzone AS "TrnstZone",
     a.affresfar AS "AffResFAR",
-    a.mnffar AS "ManuFAR"
+    a.mnffar AS "ManuFAR",
+    round(st_length(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Leng",
+    round(st_area(b.:GEOM)::numeric, 11)::numeric(19, 7) AS "Shape_Area"
 INTO :TABLE
 FROM export_pluto AS a, pluto_geom AS b
 WHERE

--- a/products/pluto/recipe.yml
+++ b/products/pluto/recipe.yml
@@ -43,6 +43,10 @@ inputs:
     - name: lpc_historic_districts
     - name: lpc_landmarks
     - name: pluto_input_cama_dof
+      version: 20260302
     - name: pluto_input_geocodes
+      version: 20260330
     - name: pluto_input_numbldgs
+      version: 20260329
     - name: pluto_pts
+      version: 20260330

--- a/products/pluto/seeds/pluto_input_research.csv
+++ b/products/pluto/seeds/pluto_input_research.csv
@@ -27526,3 +27526,10 @@ bbl,field,old_value,new_value,Type,reason,version
 4033307501,unitstotal,135,40,2,PTS error - units,26v1
 2028507501,unitsres,31,103,2,pluto_rpad_geo,26v1
 2028507501,unitstotal,32,104,2,PTS error - units,26v1
+1007660030,unitsres,59,20,2,PTS error – units,26v1
+1015550046,unitsres,56,18,2,PTS error – units,26v1
+4001517502,unitsres,100,10,2,PTS error – units,26v1
+3032657503,unitsres,64,8,2,PTS error – units,26v1
+4004317501,unitsres,55,28,2,PTS error – units,26v1
+1015550046,unitsres,56,18,2,PTS error – units,26v1
+1007660030,unitsres,59,20,2,PTS error – units,26v1


### PR DESCRIPTION
Incorporates 
- QA fixes from @jackrosacker 
- Nulls out Transit Zones for lots that have no intersection with ANY zone. These are entirely lots in the water.

TEMPORARILY:
- pins the versions of a few inputs to match previous builds this round. I'll revert that commit before merging