### PR TITLE
drop usage of repo secret GHP_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "op://Data Engineering/DO_keys/AWS_SECRET_ACCESS_KEY"
           AWS_ACCESS_KEY_ID: "op://Data Engineering/DO_keys/AWS_ACCESS_KEY_ID"
           BUILD_ENGINE_SERVER: "op://Data Engineering/EDM_DATA/server_url"
+          GHP_TOKEN: "op://Data Engineering/GITHUB_TOKENS/de_repo_management"
 
       - name: Finish container setup
         working-directory: ./
@@ -106,7 +107,7 @@ jobs:
         if: ${{ env.PUBLISHING_BUCKET == 'edm-publishing' }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GHP_TOKEN }}
+          github-token: ${{ env.GHP_TOKEN }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -30,7 +30,6 @@ on:
 
 env:
   TOY_SECRET_GITHUB: ${{ secrets.TOY_SECRET }}
-  GHP_TOKEN: ${{ secrets.GHP_TOKEN }}
   BUILD_ENGINE_DB: db-template
   BUILD_NAME: ${{ inputs.build_name }}
   LOGGING_LEVEL: ${{ inputs.logging_level }}


### PR DESCRIPTION
the publish GHA [failed](https://github.com/NYCPlanning/data-engineering/actions/runs/24728527060/job/72336154507) because we no longer use a repo secret for the github token