### PR TITLE
add step to build and publish QA app docker image

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -33,6 +33,11 @@ on:
         type: boolean
         required: true
         default: false
+      qa-streamlit:
+        description: "Build 'qa-streamlit' image"
+        type: boolean
+        required: true
+        default: false
 
 jobs:
   base:
@@ -147,3 +152,23 @@ jobs:
 
       - name: Build and publish docker-geosupport
         run: ./admin/ops/docker_build_and_publish.sh docker-geosupport
+
+  qa-streamlit:
+    runs-on: ubuntu-22.04
+    if: inputs.qa-streamlit || github.event_name == 'push'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DOCKER_USERNAME: "op://Data Engineering/Dockerhub/username"
+          DOCKER_PASSWORD: "op://Data Engineering/Dockerhub/password"
+
+      - name: Build and publish qa-streamlit
+        run: ./apps/qa/bash/docker_build_and_publish.sh


### PR DESCRIPTION
we don't have any actions updating the published `nycplanning/qa-streamlit:latest` which is pulled and used in the DE Tools deployment

- [docker image publish action run](https://github.com/NYCPlanning/data-engineering/actions/runs/25182441079)
- subsequent [DE tools deploy action run](https://github.com/NYCPlanning/data-engineering/actions/runs/25182441079)

deployed QA app now shows what was missing before: the new CSCL page:
<img width="613" height="448" alt="Screenshot 2026-04-30 at 2 35 04 PM" src="https://github.com/user-attachments/assets/734646f3-fb18-4004-a01e-fdee0cb6d2ef" />
