### PR TITLE
add draft download URL to QA issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/product_qa.md
+++ b/.github/ISSUE_TEMPLATE/product_qa.md
@@ -2,7 +2,8 @@
 name: "Product QA: {{ env.PRODUCT }}"
 about: "Product QA: {{ env.PRODUCT }}"
 title: "{{ env.PRODUCT }} {{ env.VERSION }} QA Draft {{ env.DRAFT }}"
-# labels: 'GIS'
 ---
 
 This issue was created as a part of [this]({{ env.PROMOTE_TO_DRAFT_URL }}) action.
+
+[draft build zip file in Digital Ocean]({{ env.DRAFT_DOWNLOAD_URL }})

--- a/.github/workflows/promote_to_draft.yml
+++ b/.github/workflows/promote_to_draft.yml
@@ -46,7 +46,7 @@ on:
       create_qa_github_issue:
         description: "Create Github Issue for product QA?"
         type: boolean
-        default: false
+        default: true
         required: true
   workflow_call:
     inputs:
@@ -115,8 +115,11 @@ jobs:
   
       - name: Set version and draft number 
         run: |
-          echo "version=$(cat build_metadata.json | jq -r .version)" >> $GITHUB_ENV
-          echo "draft_number=$(cat build_metadata.json | jq -r .draft_revision_name)" >> $GITHUB_ENV
+          version=$(cat build_metadata.json | jq -r .version)
+          draft_number=$(cat build_metadata.json | jq -r .draft_revision_name)
+          echo "version=${version}" >> $GITHUB_ENV
+          echo "draft_number=${draft_number}" >> $GITHUB_ENV
+          echo "draft_download_url=https://nyc3.digitaloceanspaces.com/${PUBLISHING_BUCKET}/${{ inputs.product }}/draft/${version}/${draft_number}/output.zip" >> $GITHUB_ENV
 
       - name: Create Github Issue for QA
         if: ${{ inputs.create_qa_github_issue }}      
@@ -124,6 +127,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROMOTE_TO_DRAFT_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DRAFT_DOWNLOAD_URL: ${{ env.draft_download_url }}
           PRODUCT: ${{ inputs.product }}
           VERSION: ${{ env.version }}
           DRAFT: ${{ env.draft_number }}


### PR DESCRIPTION
it can be a pain sharing links to draft builds. we already have this nice automation of issue creation and it has all the info needed to construct a convenient URL

[example Template DB QA issue](https://github.com/NYCPlanning/data-engineering/issues/2342) with new link

this assumes there's an `output.zip`, which seems to be our standard approach for many data products already and not such a bad one