### PR TITLE
Add query to visualize side_ap diffs for saf

### DIFF
--- a/products/cscl/scripts/side_ap_geom_query.sql
+++ b/products/cscl/scripts/side_ap_geom_query.sql
@@ -1,0 +1,70 @@
+-- Query to visualize side_ap discrepancies with geometries
+-- Transforms all geometries to EPSG:4326 (WGS84) for mapping
+
+WITH side_ap_diffs AS (
+    SELECT
+        comparison_id,
+        changes -> 'side_ap' ->> 'old' AS old_side_ap,
+        changes -> 'side_ap' ->> 'new' AS new_side_ap
+    FROM ar_cscl_diffs1.qa__diffs_all
+    WHERE diff_group = 'side_ap'
+),
+point_locations AS (
+    SELECT
+        s._saf_key,
+        d.old_side_ap,
+        d.new_side_ap,
+        s.boroughcode,
+        s.saftype,
+        s.segmentid,
+        s.x_coord,
+        s.y_coord,
+        ST_SETSRID(ST_MAKEPOINT(s.x_coord::float, s.y_coord::float), 2263) AS point_geom_2263
+    FROM ar_cscl_diffs1.saf_abcegnpx_roadbed_by_field AS s
+    INNER JOIN side_ap_diffs AS d ON s._saf_key = d.comparison_id
+),
+with_atomic_polygons AS (
+    SELECT
+        p._saf_key,
+        p.old_side_ap,
+        p.new_side_ap,
+        p.boroughcode,
+        p.saftype,
+        p.segmentid,
+        p.x_coord,
+        p.y_coord,
+        p.point_geom_2263,
+        -- Actual atomic polygon containing the point (may not match side_ap due to multiple polygons with same suffix)
+        ap_actual.atomicid AS actual_atomicid,
+        RIGHT(ap_actual.atomicid, 3) AS actual_side_ap,
+        ap_actual.censustract_2020_basic || LPAD(ap_actual.censustract_2020_suffix::text, 2, '0') AS actual_ct2020,
+        ap_actual.censusblock_2020_basic AS actual_cb2020,
+        ap_actual.geom AS actual_ap_geom,
+        -- Check if side_ap matches
+        COALESCE(RIGHT(ap_actual.atomicid, 3) = p.new_side_ap, FALSE) AS side_ap_matches
+    FROM point_locations AS p
+    LEFT JOIN ar_cscl_diffs1.stg__atomicpolygons AS ap_actual
+        ON ST_CONTAINS(ap_actual.geom, p.point_geom_2263)
+)
+SELECT
+    wap._saf_key,
+    wap.old_side_ap,
+    wap.new_side_ap,
+    wap.actual_side_ap,
+    wap.side_ap_matches,
+    wap.boroughcode,
+    wap.saftype,
+    wap.segmentid,
+    wap.actual_atomicid,
+    wap.actual_ct2020,
+    wap.actual_cb2020,
+    -- Point geometry in 4326 (PostGIS geometry type)
+    ST_TRANSFORM(wap.point_geom_2263, 4326) AS point_geom,
+    -- Atomic polygon geometry in 4326 (PostGIS geometry type)
+    ST_TRANSFORM(wap.actual_ap_geom, 4326) AS atomic_polygon_geom,
+    -- Segment geometry in 4326 (PostGIS geometry type)
+    ST_TRANSFORM(seg.geom, 4326) AS segment_geom
+FROM with_atomic_polygons AS wap
+LEFT JOIN ar_cscl_diffs1.int__primary_segments AS seg
+    ON wap.segmentid = seg.segmentid::text
+ORDER BY wap._saf_key;


### PR DESCRIPTION
There are 43 records in the SAF output file `saf_abcegnpx_roadbed` where `side_ap` differs from production.

I believe this is due to x/y coordinate (floating point) truncation differences between ESRI and our tooling. We'd need to do one of the following:
1. confirm with GR that these differences are fine, OR
2. GR can modify the x/y coordinates
3. DE can examine our tooling to try to resolve this (the least preferable option)

### JUST FYI
1. The output SAF records (from the saf_abcegnpx_roadbed_by_field table) contain:
    - A side_ap field indicating which atomic polygon side the address should be on (last 3 digits of the atomic polygon ID)
    - X/Y coordinates (x_coord, y_coord) representing the physical location of that address point
2.  All records with diffs come from SAF GNX records, ABCEP records by definition have NULL `side_ap`
3. The problem: When we spatially join these coordinates to the atomic polygons layer (stg__atomicpolygons), we find that the point geometrically falls inside an atomic polygon whose suffix (last 3 digits of its atomicid) is different from what the SAF's side_ap field claims.


### Sample Images to Visualize the Issue (query is committed in this PR)
<img width="156" height="352" alt="image" src="https://github.com/user-attachments/assets/82616d56-9380-4aa6-ab1c-582879278d12" />

<img width="156" height="352" alt="image" src="https://github.com/user-attachments/assets/e13216ff-1274-4a9e-934d-3061ea68c1ea" />

<img width="156" height="352" alt="image" src="https://github.com/user-attachments/assets/1e7cbaa6-772a-4772-b69b-0e3c8ea355ad" />

### Here are the records:
In this case _saf_key is the combination of `boroughcode || face_code || segment_seqnum`

_saf_key | segmentid | old_side_ap | new_side_ap
-- | -- | -- | --
1000617060 | 0241710 | 131 | 125
1026600105 | 0240879 | 909 | 921
1031917080 | 0240425 | 115 | 116
1033400230 | 0242166 | 002 | 013
1037901090 | 0295128 | 006 | 003
1048702810 | 0242959 | 901 | 156
1051700003 | 0295140 | 002 | 001
1054703275 | 0299454 | 001 | 008
1076603185 | 0143081 | 900 | 920
1076603432 | 0240596 | 118 | 901
1077000050 | 0183604 | 202 | 215
1080900076 | 0284668 | 201 | 205
1088300015 | 0258876 | 001 | 003
1254510810 | 0134572 | 122 | 109
1254512005 | 0332274 | 938 | 205
1315501865 | 9009103 | 003 | 002
1493001088 | 0338051 | 135 | 125
2033400121 | 0297515 | 267 | 106
2038100090 | 0240167 | 255 | 916
2051900145 | 0262102 | 217 | 300
2054300565 | 0258838 | 920 | 903
2125700005 | 0095639 | 225 | 245
2145801005 | 0099721 | 002 | 003
2148700048 | 0179608 | 347 | 327
2327600690 | 0144374 | 941 | 920
2832600045 | 0259123 | 260 | 261
3002000054 | 0235753 | 001 | 006
3026700120 | 0237775 | 005 | 003
3135702040 | 0024767 | 107 | 112
3172002070 | 0143144 | 438 | 401
3862200010 | 0144691 | 220 | 215
4000500001 | 0235756 | 009 | 002
4013305167 | 0180525 | 924 | 105
4247900010 | 0346028 | 138 | 112
4390650010 | 0138883 | 111 | 109
4400602285 | 0156514 | 303 | 321
4464705020 | 0141122 | 104 | 112
4516600530 | 0267428 | 126 | 124
4522400084 | 0281223 | 210 | 208
4538410680 | 0153916 | 103 | 201
5086600180 | 0331662 | 009 | 006
5104700060 | 0122760 | 005 | 001
5551200060 | 0185402 | 290 | 234
