### PR TITLE
Add Optional Dependency for Stubs in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,24 @@ product-metadata = [
     "Jinja2",
 ]
 
+# Type stubs for development
+stubs = [
+    "boto3-stubs[s3]",
+    "openpyxl-stubs",
+    "pandas-stubs",
+    "pyarrow-stubs",
+    "sqlalchemy-stubs",
+    "types-beautifulsoup4",
+    "types-paramiko",
+    "types-psycopg2",
+    "types-python-dateutil",
+    "types-pytz",
+    "types-PyYAML>=6.0.1",
+    "types-requests",
+    "types-setuptools",
+    "types-tqdm",
+]
+
 [tool.setuptools.packages.find]
 include = ["dcpy*"]
 exclude = ["dcpy.test*"]


### PR DESCRIPTION
I needed to just install the stubs. Long-term, we should remove them from the requirements files, and only install them in CI when we run `mypy`. Not going to take this on at the moment, but the python project side of things needs a revamp.