### PR TITLE
fix docker publish dependencies

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -133,6 +133,27 @@ jobs:
       - name: Build and publish dev
         run: ./admin/ops/docker_build_and_publish.sh dev
 
+  qa-streamlit:
+    runs-on: ubuntu-22.04
+    needs: [base]
+    if: inputs.qa-streamlit || github.event_name == 'push'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DOCKER_USERNAME: "op://Data Engineering/Dockerhub/username"
+          DOCKER_PASSWORD: "op://Data Engineering/Dockerhub/password"
+
+      - name: Build and publish qa-streamlit
+        run: ./apps/qa/bash/docker_build_and_publish.sh
+
   docker-geosupport:
     runs-on: ubuntu-22.04
     if: inputs.docker-geosupport || github.event_name == 'push'
@@ -152,23 +173,3 @@ jobs:
 
       - name: Build and publish docker-geosupport
         run: ./admin/ops/docker_build_and_publish.sh docker-geosupport
-
-  qa-streamlit:
-    runs-on: ubuntu-22.04
-    if: inputs.qa-streamlit || github.event_name == 'push'
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
-      - name: Load Secrets
-        uses: 1password/load-secrets-action@v1
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          DOCKER_USERNAME: "op://Data Engineering/Dockerhub/username"
-          DOCKER_PASSWORD: "op://Data Engineering/Dockerhub/password"
-
-      - name: Build and publish qa-streamlit
-        run: ./apps/qa/bash/docker_build_and_publish.sh


### PR DESCRIPTION
the QA app's [Dockerfile](https://github.com/NYCPlanning/data-engineering/blob/main/apps/qa/Dockerfile) is built and published by [apps/qa/bash/docker_build_and_publish.sh](https://github.com/NYCPlanning/data-engineering/blob/main/apps/qa/bash/docker_build_and_publish.sh) and it's published to `nycplanning/qa-streamlit:latest`

that Dockerfile depends on `nycplanning/base:latest`. but the publish action doesn't respect that dependency when it's run after relevant PRs are merged to `main` ([latest run here](https://github.com/NYCPlanning/data-engineering/actions/runs/25822116820)). so `qa-streamlit:latest` doesn't have what it needs

the workaround is to [manually run the action](https://github.com/NYCPlanning/data-engineering/actions/runs/25823547807) for `qa-streamlit` after `base` is published