### PR TITLE
add table/record-viewer to CSCL QA page

### DIFF
--- a/apps/qa/src/pages/cscl/cscl.py
+++ b/apps/qa/src/pages/cscl/cscl.py
@@ -101,8 +101,117 @@ def cscl():
                         ]
                     st.caption(f"{len(filtered_df):,} of {len(df):,} rows")
                     st.dataframe(filtered_df, use_container_width=True)
+
+                    _record_cols = {
+                        "comparison_id",
+                        "comparison_column",
+                        "build_table_name",
+                        "production_table_name",
+                    }
+                    if _record_cols.issubset(df.columns):
+                        with st.expander("View source records", expanded=False):
+                            _meta = df.iloc[0]
+                            _id_col = _meta["comparison_column"]
+                            _build_tbl = _meta["build_table_name"]
+                            _prod_tbl = _meta["production_table_name"]
+                            _ids = sorted(
+                                filtered_df["comparison_id"]
+                                .dropna()
+                                .astype(str)
+                                .unique()
+                                .tolist()
+                            )
+                            _selected_id = st.selectbox(
+                                "comparison_id",
+                                options=[""] + _ids,
+                                key=f"record_viewer_{group}_{selected_table}",
+                            )
+                            if _selected_id:
+                                _dev_col, _prod_col = st.columns(2)
+                                with _dev_col:
+                                    st.caption(f"Dev: `{_build_tbl}`")
+                                    try:
+                                        _dev_df = helpers.get_record_by_comparison_id(
+                                            selected_build,
+                                            _build_tbl,
+                                            _id_col,
+                                            _selected_id,
+                                        )
+                                        st.dataframe(
+                                            _dev_df.T, use_container_width=True
+                                        )
+                                    except Exception as e:
+                                        st.warning(f"Could not load: {e}")
+                                with _prod_col:
+                                    st.caption(f"Prod: `{_prod_tbl}`")
+                                    try:
+                                        _prod_df = helpers.get_record_by_comparison_id(
+                                            selected_build,
+                                            _prod_tbl,
+                                            _id_col,
+                                            _selected_id,
+                                        )
+                                        st.dataframe(
+                                            _prod_df.T, use_container_width=True
+                                        )
+                                    except Exception as e:
+                                        st.warning(f"Could not load: {e}")
+                    else:
+                        st.caption(
+                            "ℹ️ Source record lookup not available for this table — missing diff metadata columns."
+                        )
                 except Exception as e:
-                    st.warning(f"Could not load `{selected_table}`: {e}")
+                    st.warning(
+                        f"Could not load `{selected_build}.{selected_table}`: {e}"
+                    )
+
+    st.subheader("Browse Build Tables")
+    st.markdown(
+        body="Explore any table in the build's Postgres schema. Add multiple tables to compare side by side."
+    )
+
+    slot_key = f"browse_table_slots_{selected_build}"
+    if slot_key not in st.session_state:
+        st.session_state[slot_key] = [0]
+
+    available_tables = helpers.get_build_tables(selected_build)
+
+    for slot_idx in st.session_state[slot_key]:
+        col_select, col_remove = st.columns([5, 1])
+        with col_select:
+            chosen = st.selectbox(
+                "Select a table",
+                options=[""] + available_tables,
+                key=f"browse_slot_{selected_build}_{slot_idx}",
+                label_visibility="collapsed",
+                placeholder="Choose a table...",
+            )
+        with col_remove:
+            if st.button(
+                "✕",
+                key=f"browse_remove_{selected_build}_{slot_idx}",
+                help="Remove this table",
+            ):
+                st.session_state[slot_key] = [
+                    s for s in st.session_state[slot_key] if s != slot_idx
+                ]
+                st.rerun()
+
+        if chosen:
+            try:
+                with st.spinner(f"Loading {chosen}..."):
+                    df = helpers.get_build_table(selected_build, chosen)
+                st.caption(f"{len(df):,} rows · {len(df.columns)} columns")
+                st.dataframe(df, use_container_width=True)
+            except Exception as e:
+                st.warning(f"Could not load `{chosen}`: {e}")
+
+    if st.button("＋ Add table", key=f"browse_add_{selected_build}"):
+        next_idx = (
+            max(st.session_state[slot_key]) + 1 if st.session_state[slot_key] else 0
+        )
+        st.session_state[slot_key] = st.session_state[slot_key] + [next_idx]
+        st.rerun()
 
     st.subheader("Diff Row Viewer")
     files_with_diffs = diffs_summary[diffs_summary["Has diffs"]]["File name"].tolist()

--- a/apps/qa/src/pages/cscl/helpers.py
+++ b/apps/qa/src/pages/cscl/helpers.py
@@ -3,7 +3,6 @@ import streamlit as st
 
 from dcpy.connectors.edm import publishing
 from dcpy.connectors.edm.models import BuildKey
-from dcpy.lifecycle.builds.metadata import build_name as sanitize_build_name
 from dcpy.utils import postgres, s3
 
 PRODUCT = "db-cscl"
@@ -96,16 +95,40 @@ def get_build_output_zip_url(build: str) -> str:
 
 
 def get_pg_client(build: str) -> postgres.PostgresClient:
-    """Return a PostgresClient scoped to the dbt schema for the given build.
+    """Return a PostgresClient scoped to the dbt schema for the given build."""
+    return postgres.PostgresClient(
+        database=PRODUCT, schema=build.lower().replace("-", "_")
+    )
 
-    In CI, BUILD_ENGINE_SCHEMA is set to the build name, so the dbt tables
-    for build 'nightly_qa' live in schema 'nightly_qa'.
-    """
-    return postgres.PostgresClient(database=PRODUCT, schema=sanitize_build_name(build))
+
+@st.cache_data(show_spinner=False)
+def get_build_tables(build: str) -> list[str]:
+    """List all tables in the build's Postgres schema."""
+    client = get_pg_client(build)
+    return client.get_schema_tables()
 
 
 @st.cache_data(show_spinner=False)
 def get_dbt_qa_table(build: str, table_name: str) -> pd.DataFrame:
     """Read a dbt QA model table from Postgres into a DataFrame."""
     client = get_pg_client(build)
-    return client.read_table_df(table_name)
+    return client.read_table_df(table_name, schema=client.schema)
+
+
+@st.cache_data(show_spinner=False)
+def get_record_by_comparison_id(
+    build: str, table_name: str, id_column: str, id_value: str
+) -> pd.DataFrame:
+    """Fetch a single record from a build table by its primary key value."""
+    client = get_pg_client(build)
+    return client.execute_select_query(
+        f'SELECT * FROM "{table_name}" WHERE "{id_column}" = :id_value',
+        id_value=id_value,
+    )
+
+
+@st.cache_data(show_spinner=False)
+def get_build_table(build: str, table_name: str) -> pd.DataFrame:
+    """Read any table from the build's Postgres schema into a DataFrame."""
+    client = get_pg_client(build)
+    return client.read_table_df(table_name, schema=client.schema)

--- a/products/cscl/models/etl_dev_qa/diffs/_diffs.yml
+++ b/products/cscl/models/etl_dev_qa/diffs/_diffs.yml
@@ -48,11 +48,22 @@ models:
       Reserved for finer-grained categorization within a diff_group. Currently
       always an empty string across all upstream models.
   - name: comparison_column
-    description: Column used as the primary key in the generate_diff_summary macro call for this record's product.
+    description: >
+      Name of the primary key column in the source tables (e.g. _saf_key,
+      atomicid). Emitted as a string literal by the generate_diff_summary macro
+      and consistent across all rows for a given output_file_id. Use together
+      with comparison_id, build_table_name, and production_table_name to look
+      up the full source record for any diff row.
   - name: build_table_name
-    description: Name of the dev build table that was compared.
+    description: >
+      Name of the dev build table that was compared, as passed to the
+      generate_diff_summary macro. Use with comparison_column and comparison_id
+      to fetch the dev-side record for a given diff.
   - name: production_table_name
-    description: Name of the production table that was compared.
+    description: >
+      Name of the production table that was compared, as passed to the
+      generate_diff_summary macro. Use with comparison_column and comparison_id
+      to fetch the prod-side record for a given diff.
   - name: accounted_for
     description: >
       Boolean flag set by each upstream model indicating whether this diff is
@@ -60,4 +71,6 @@ models:
       deliberate behavior change). Records with accounted_for = true can be
       excluded from burndown counts.
   - name: diff_run_date
-    description: Date on which this table was last materialized, stamped via CURRENT_DATE.
+    description: >
+      Date this table was last materialized, stamped once via CURRENT_DATE at
+      build time. All rows in a given materialization share the same value.


### PR DESCRIPTION
helps with reviewing diffs
- adds "View source records" to parse diff table to get relevant prod and dev tables, filter by a comparison_id value, and show the results side-by-side
- adds "Browse Build Tables" to see any build table (was the first approach to viewing prod and dev tables, the above change is better, but this seems worth keeping)

## screenshots

<img width="1430" height="684" alt="Screenshot 2026-05-19 at 10 34 20 AM" src="https://github.com/user-attachments/assets/8517d0a4-67eb-403f-904a-75770b3f682c" />
<img width="1114" height="754" alt="Screenshot 2026-05-19 at 11 29 32 AM" src="https://github.com/user-attachments/assets/2a2c7a8d-f300-46b6-a64b-48b31d71d73a" />
<img width="1110" height="592" alt="Screenshot 2026-05-19 at 11 29 51 AM" src="https://github.com/user-attachments/assets/b6bf8aba-8524-46ed-a272-2408256ba200" />
<img width="621" height="361" alt="Screenshot 2026-05-19 at 11 30 06 AM" src="https://github.com/user-attachments/assets/d3308cdd-de78-491f-94a1-a26228c4a359" />
<img width="1009" height="583" alt="Screenshot 2026-05-19 at 11 30 23 AM" src="https://github.com/user-attachments/assets/ed52f160-a89c-4a50-b5b4-8cb7e3c05967" />
