### PR TITLE
add archive_date to source_data_versions via recipe planning

### DIFF
--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -30,6 +31,20 @@ def s3_folder_path(ds: Dataset | DatasetKey) -> str:
 
 def s3_file_path(ds: Dataset) -> str:
     return f"{s3_folder_path(ds)}/{ds.file_name}"
+
+
+def get_archive_date(ds: Dataset | DatasetKey) -> datetime | None:
+    """Date the dataset version was ingested, from S3 custom metadata or LastModified."""
+    folder = s3_folder_path(ds)
+    files = s3.get_filenames(_bucket(), folder)
+    if not files:
+        return None
+    key = f"{folder}/{next(iter(files))}"
+    metadata = s3.get_metadata(_bucket(), key)
+    date_created = metadata.custom.get("date-created")
+    if date_created:
+        return datetime.fromisoformat(date_created)
+    return metadata.last_modified
 
 
 def get_all_versions(name: str) -> list[str]:

--- a/dcpy/lifecycle/builds/models.py
+++ b/dcpy/lifecycle/builds/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, ClassVar
@@ -40,6 +40,7 @@ class InputDataset(BaseModel, extra="forbid"):
     preprocessor: DataPreprocessor | None = None
     destination: InputDatasetDestination | None = None
     load_engine: str | None = None
+    archive_date: date | None = None
     custom: dict = Field(default_factory=dict)
 
     @property

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -208,6 +208,8 @@ def plan_recipe(
                 f"Cannot get dataset name from connector type '{connector.conn_type}'"
             )
             ds.name = connector.get_name(ds.id, ds.version)  # type: ignore
+            archive_dt = recipes.get_archive_date(ds.dataset)
+            ds.archive_date = archive_dt.date() if archive_dt else None
 
     # Resolve any unresolved conf values (e.g. from the environment or provided vars)
     for conf in recipe.get_unresolved_stage_config_values():
@@ -347,7 +349,7 @@ def write_source_data_versions(recipe_file: Path):
         logger.error(exception)
         raise Exception(exception)
 
-    header = ["schema_name", "dataset_name", "v", "file_type"]
+    header = ["schema_name", "dataset_name", "v", "file_type", "archive_date"]
     with open(source_data_versions_path, "w", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=header)
         writer.writeheader()
@@ -357,6 +359,7 @@ def write_source_data_versions(recipe_file: Path):
                 "dataset_name": x.name,
                 "v": x.version,
                 "file_type": x.file_type,
+                "archive_date": x.archive_date.isoformat() if x.archive_date else "",
             }
             for x in datasets
         )

--- a/dcpy/test/connectors/edm/test_recipes.py
+++ b/dcpy/test/connectors/edm/test_recipes.py
@@ -7,7 +7,7 @@ import pytest
 import yaml
 
 from dcpy.connectors.edm import recipes
-from dcpy.connectors.edm.models import Dataset, DatasetType
+from dcpy.connectors.edm.models import Dataset, DatasetKey, DatasetType
 from dcpy.library import models as library
 from dcpy.lifecycle.ingest.models import SparseConfig
 from dcpy.test.conftest import RECIPES_BUCKET
@@ -123,6 +123,18 @@ def test_read_df_missing_filetype(load_library: library.Config):
             load_library.sparse_dataset,
             preferred_file_types=[recipes.DatasetType.parquet],
         )
+
+
+def test_get_archive_date(load_ingest: SparseConfig):
+    ds = DatasetKey(id=load_ingest.id, version=load_ingest.version)
+    result = recipes.get_archive_date(ds)
+    assert isinstance(result, datetime)
+
+
+def test_get_archive_date_missing_dataset(create_buckets):
+    ds = DatasetKey(id="nonexistent", version="v1")
+    result = recipes.get_archive_date(ds)
+    assert result is None
 
 
 def test_read_df_cache(load_ingest: SparseConfig, create_temp_filesystem: Path):

--- a/dcpy/test/lifecycle/builds/resources/simple.lock.yml
+++ b/dcpy/test/lifecycle/builds/resources/simple.lock.yml
@@ -4,14 +4,17 @@ inputs:
     file_type: pg_dump
     name: pg_dump
     version: df
+    archive_date: 2024-06-01
   - destination: df
     file_type: csv
     name: df
     version: df
+    archive_date: 2024-06-01
   - destination: file
     file_type: csv
     name: file
     version: file
+    archive_date: 2024-06-01
 name: Tester
 product: db-test
 version: 23v1

--- a/dcpy/test/lifecycle/builds/test_plan.py
+++ b/dcpy/test/lifecycle/builds/test_plan.py
@@ -1,4 +1,7 @@
 import os
+import tempfile
+from datetime import date, datetime
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -221,7 +224,17 @@ class TestRecipesNoDefaults(TestCase):
         lock_file = plan.plan(RECIPE_NO_DEFAULTS_PATH)
         plan.recipe_from_yaml(lock_file)
 
+    @patch("dcpy.connectors.edm.recipes.get_archive_date")
+    def test_plan_recipe_populates_archive_date(
+        self, mock_archive_date, get_file_types
+    ):
+        get_file_types.return_value = {recipes.DatasetType.pg_dump}
+        mock_archive_date.return_value = datetime(2024, 6, 1, 12, 0, 0)
+        planned = plan.plan_recipe(RECIPE_NO_DEFAULTS_PATH)
+        assert planned.inputs.datasets[0].archive_date == date(2024, 6, 1)
 
+
+@pytest.mark.usefixtures("create_buckets")
 class TestRecipeVars(TestCase):
     def test_version_type_var_is_absent(self):
         """Ensures VERSION_TYPE is absent in recipe 'vars' attribute when version_type is None."""
@@ -433,3 +446,30 @@ class TestPlanStageConfs(TestCase):
         assert StageConfigValue.UNRESOLVABLE_ERROR in str(e.exception), (
             "The error should mention that the stage var is unresolvable."
         )
+
+
+SIMPLE_LOCK_PATH = RESOURCES_DIR / "simple.lock.yml"
+SIMPLE_NO_PG_LOCK_PATH = RESOURCES_DIR / "simple_no_pg.lock.yml"
+
+
+class TestWriteSourceDataVersions(TestCase):
+    def test_includes_archive_date_column(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "simple.lock.yml"
+            lock_path.write_text(SIMPLE_LOCK_PATH.read_text())
+            plan.write_source_data_versions(lock_path)
+            df = pd.read_csv(Path(tmpdir) / "source_data_versions.csv")
+        assert "archive_date" in df.columns
+        assert list(df["archive_date"]) == ["2024-06-01"] * len(df)
+
+    def test_archive_date_none_writes_empty_string(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "simple_no_pg.lock.yml"
+            lock_path.write_text(SIMPLE_NO_PG_LOCK_PATH.read_text())
+            plan.write_source_data_versions(lock_path)
+            df = pd.read_csv(
+                Path(tmpdir) / "source_data_versions.csv",
+                dtype=str,
+                keep_default_na=False,
+            )
+        assert list(df["archive_date"]) == [""] * len(df)

--- a/dcpy/test_integration/connectors/edm/test_plan_load.py
+++ b/dcpy/test_integration/connectors/edm/test_plan_load.py
@@ -45,6 +45,7 @@ def test_resolving_and_loading_recipes(tmp_path, pg_client: postgres.PostgresCli
         "dataset_name",
         "v",
         "file_type",
+        "archive_date",
     ]
 
     assert recipe_pg_dataset_table_names == load_result_pg_table_names

--- a/products/ceqr/models/_sources.yml
+++ b/products/ceqr/models/_sources.yml
@@ -12,3 +12,4 @@ sources:
           - name: dataset_name
           - name: v
           - name: file_type
+          - name: archive_date

--- a/products/template/models/_sources.yml
+++ b/products/template/models/_sources.yml
@@ -1,6 +1,19 @@
 version: 2
 
 sources:
+  - name: recipe_sources
+    schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
+    tables:
+      - name: source_data_versions
+        description: |
+          Versions of all source data listed in the recipe.yml file and loaded via the dcpy.lifecycle.builds.load CLI
+        columns:
+          - name: schema_name
+          - name: dataset_name
+          - name: v
+          - name: file_type
+          - name: archive_date
+
   - name: tdb_sources
     schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"
     tables:

--- a/products/template/models/product/_product.yml
+++ b/products/template/models/product/_product.yml
@@ -1,6 +1,20 @@
 version: 2
 
 models:
+  - name: dataset_versions
+    description: "Versions and ingest dates of all source datasets used in this build"
+    columns:
+      - name: dataset_id
+        description: "Dataset identifier used to load source data (e.g. dcp_pluto)"
+      - name: dataset_name
+        description: "Human-readable dataset name"
+      - name: version
+        description: "Version string of the source data as loaded"
+      - name: file_type
+        description: "File format of the source data (e.g. csv, parquet, pg_dump)"
+      - name: archive_date
+        description: "Date the source dataset was ingested into edm-recipes (YYYY-MM-DD)"
+
   - name: templatedb
     description: "Template DB place records"
     columns:

--- a/products/template/models/product/dataset_versions.sql
+++ b/products/template/models/product/dataset_versions.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='table') }}
+
+SELECT
+    schema_name AS dataset_id,
+    dataset_name,
+    v AS version,
+    file_type,
+    archive_date
+FROM {{ source('recipe_sources', 'source_data_versions') }}


### PR DESCRIPTION
adds `archive_date` column to planned recipes and `source_data_versions` tables during load step of a build

having the "archived" dates for loaded source data be easily available during a build would help us quickly determine how stale source data is and decide if we need to get fresher data (e.g. is a passing build ready for QA?)

the date is the `date-created` or `last_modified` from the S3 metadata of the file in the `edm-recipes` bucket. didn't try to make it more clever with something like "use the Open Data metadata" but I think that's in the ingest metadata and technically usable.  seems nice for this to be generalized and not too dependent on data source type

[FacDB build run](https://github.com/NYCPlanning/data-engineering/actions/runs/26138099777)

some of the `source_data_versions` table records from a FacDB build
- <img width="925" height="463" alt="Screenshot 2026-05-19 at 10 55 02 PM" src="https://github.com/user-attachments/assets/f8f200e2-e028-45f4-8598-493d62184d0d" />
