### PR TITLE
Move doi evictions geocoding upstream to ingest

### DIFF
--- a/dcpy/test/lifecycle/ingest/resources/transform_to_parquet.yml
+++ b/dcpy/test/lifecycle/ingest/resources/transform_to_parquet.yml
@@ -94,3 +94,8 @@
     type: json
     json_read_fn: normalize
     json_read_kwargs: { "max_level": 1 }
+
+# parquet non-spatial case
+- file_name: test.parquet
+  file_format:
+    type: parquet

--- a/dcpy/test/utils/test_data.py
+++ b/dcpy/test/utils/test_data.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from dcpy.utils import data
+from dcpy.utils import data, formats
 
 
 @pytest.fixture
@@ -183,3 +183,23 @@ def test_upsert_df_columns():
             }
         )
     )
+
+
+def test_read_parquet():
+    """
+    Test reading parquet files with read_data_to_df.
+
+    Checks:
+        - Function successfully reads parquet file
+        - Returned DataFrame has expected shape and columns
+        - Data matches expected values
+    """
+    parquet_format = formats.Parquet(type="parquet")
+    parquet_path = Path(__file__).parent / "resources" / "simple.parquet"
+
+    df = data.read_data_to_df(data_format=parquet_format, local_data_path=parquet_path)
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape == (5, 1)
+    assert "row_id" in df.columns
+    assert df["row_id"].tolist() == ["a", "b", "c", "d", "e"]

--- a/dcpy/utils/data.py
+++ b/dcpy/utils/data.py
@@ -162,6 +162,11 @@ def read_data_to_df(
             gdf = (
                 df if not data_format.geometry else df_to_gdf(df, data_format.geometry)
             )
+        case file.Parquet():
+            df = pd.read_parquet(local_data_path)
+            gdf = (
+                df if not data_format.geometry else df_to_gdf(df, data_format.geometry)
+            )
 
     if data_format.unzipped_filename and clean_extracted_zip:
         assert extracted_files_dir

--- a/dcpy/utils/formats.py
+++ b/dcpy/utils/formats.py
@@ -85,4 +85,12 @@ class Html(SortedSerializedBase, extra="forbid"):
     geometry: Geometry | None = None
 
 
-Format: TypeAlias = Csv | Excel | Shapefile | Geodatabase | Json | GeoJson | Html
+class Parquet(BaseModel, extra="allow"):
+    type: Literal["parquet"]
+    unzipped_filename: str | None = None
+    geometry: Geometry | None = None
+
+
+Format: TypeAlias = (
+    Csv | Excel | Shapefile | Geodatabase | Json | GeoJson | Html | Parquet
+)

--- a/ingest_templates/doi_evictions_geocoded.yml
+++ b/ingest_templates/doi_evictions_geocoded.yml
@@ -1,0 +1,76 @@
+id: doi_evictions_geocoded
+acl: public-read
+
+attributes:
+  name: Department of Investigation - Evictions (Geocoded)
+  description: >-
+    IN PROGRESS: ideally this would be automated, but punting on that. For the moment,
+    there's a script under products/edde/scripts/evictions_ingest/ to geocode. For now:
+    1) run manually,
+    2) upload to inbox,
+    3) then run this ingest template
+
+    This dataset contains DOI evictions data with enhanced geocoding using Geosupport.
+
+    Records from doi_evictions have been geocoded where lat/lon were missing, using the
+    eviction address and Geosupport. The dataset excludes the current year (incomplete data).
+
+    Base data source: https://data.cityofnewyork.us/City-Government/Evictions/6z8x-wfk4
+  url: https://data.cityofnewyork.us/City-Government/Evictions/6z8x-wfk4
+
+ingestion:
+  source:
+    type: s3
+    bucket: edm-recipes
+    key: inbox/doi/evictions_geocoded/{{ version }}/doi_evictions_geocoded.parquet
+  file_format:
+    type: parquet
+
+columns:
+- id: court_index_number
+  data_type: text
+- id: docket_number
+  data_type: text
+- id: eviction_address
+  data_type: text
+- id: eviction_apartment_number
+  data_type: text
+- id: executed_date
+  data_type: text
+- id: marshal_first_name
+  data_type: text
+- id: marshal_last_name
+  data_type: text
+- id: residential/commercial
+  data_type: text
+- id: borough
+  data_type: text
+- id: eviction_postcode
+  data_type: text
+- id: ejectment
+  data_type: text
+- id: eviction/legal_possession
+  data_type: text
+- id: latitude
+  data_type: decimal
+- id: longitude
+  data_type: decimal
+- id: community_board
+  data_type: text
+- id: council_district
+  data_type: text
+- id: census_tract
+  data_type: text
+- id: bin
+  data_type: text
+- id: bbl
+  data_type: text
+- id: nta
+  data_type: text
+- id: year
+  data_type: text
+- id: borough_name
+  data_type: text
+- id: puma
+  data_type: text
+  description: PUMA code from Geosupport geocoding

--- a/products/edde/aggregate/housing_security/evictions_by_city_marshals.py
+++ b/products/edde/aggregate/housing_security/evictions_by_city_marshals.py
@@ -1,90 +1,85 @@
 import geopandas as gpd
 import pandas as pd
-import usaddress
 from ingest import ingestion_helpers
 from internal_review.set_internal_review_file import set_internal_review_files
-from utils.geo_helpers import borough_name_mapper, puma_from_point
-from utils.geocode import get_geosupport_puma
-
-report_years = {"2019", "2020", "2021", "2022", "2023", "2024"}
+from utils.geo_helpers import puma_from_point
 
 
-def _load_residential_evictions() -> pd.DataFrame:
-    evictions = ingestion_helpers.load_data("doi_evictions")
-    evictions = gpd.GeoDataFrame(
-        evictions,
-        geometry=gpd.points_from_xy(evictions.longitude, evictions.latitude),
-        crs="EPSG:4326",
-    ).to_crs("EPSG:2263")
+def _load_residential_evictions() -> gpd.GeoDataFrame:
+    """
+    Load geocoded residential evictions data.
 
+    Uses the pre-geocoded doi_evictions_geocoded dataset which has:
+    - Geocoded coordinates for missing lat/lon
+    - PUMA codes where available
+    - Current year already filtered out
+    - Borough names already cleaned
+    """
+    evictions = ingestion_helpers.load_data(
+        "doi_evictions_geocoded", is_geospatial=True
+    )
+
+    # Filter to residential only
     residential_evictions = evictions[
         evictions["residential/commercial"] == "Residential"
     ].copy()
 
-    # Filter down to just our report years
-    residential_evictions["year"] = residential_evictions.executed_date.apply(
-        lambda x: x[-4:]
+    # Create GeoDataFrame with geometry
+    # Filter out records without valid coordinates
+    has_coords = (
+        residential_evictions["latitude"].notna()
+        & residential_evictions["longitude"].notna()
     )
-    residential_evictions = residential_evictions[
-        residential_evictions["year"].isin(report_years)
-    ].copy()
+    residential_evictions = residential_evictions[has_coords].copy()
 
-    residential_evictions["borough_name"] = (
-        residential_evictions["borough"].str[0]
-        + residential_evictions["borough"].str[1:].str.lower()
-    )
-
-    # Hot fix, can be made neater
-    residential_evictions["borough_name"] = residential_evictions[
-        "borough_name"
-    ].replace({"Staten island": "Staten Island"})
-    residential_evictions["borough"] = residential_evictions["borough_name"].map(
-        borough_name_mapper
-    )
-
-    num_cols = ["latitude", "longitude"]
-    for c in num_cols:
-        residential_evictions[c] = pd.to_numeric(residential_evictions[c])
+    residential_evictions = gpd.GeoDataFrame(
+        residential_evictions,
+        geometry=gpd.points_from_xy(
+            residential_evictions.longitude, residential_evictions.latitude
+        ),
+        crs="EPSG:4326",
+    ).to_crs("EPSG:2263")
 
     return residential_evictions
 
 
-def _from_geocoded_eviction_address(record) -> str:
-    """Return latitude, longitude in degrees"""
-    """Using these docs as guide https://usaddress.readthedocs.io/en/latest/"""
-    parsed = usaddress.parse(record.eviction_address)
-    parsed = {k: v for v, k in parsed}
-    rv = {}
-    rv["address_num"] = parsed.get("AddressNumber", "")
-    street_name_components = [
-        parsed.get("StreetNamePreModifier"),
-        parsed.get("StreetNamePreDirectional"),
-        parsed.get("StreetNamePreType"),
-        parsed.get("StreetName"),
-        parsed.get("StreetNamePostModifier"),
-        parsed.get("StreetNamePostDirectional"),
-        parsed.get("StreetNamePostType"),
-    ]
-    rv["street_name"] = " ".join([s for s in street_name_components if s])
-    rv["borough"] = record.borough
-    rv["zip"] = record.eviction_postcode
-
-    return get_geosupport_puma(rv)
-
-
 def _get_puma(df_record) -> str | None:
-    if pd.notnull(df_record.latitude) and pd.notnull(df_record.longitude):
+    """
+    Get PUMA for a record.
+
+    Uses pre-computed PUMA if available (from Geosupport geocoding),
+    otherwise computes from geometry point.
+    """
+    if pd.notnull(df_record.get("puma")):
+        return df_record["puma"]
+    elif pd.notnull(df_record.latitude) and pd.notnull(df_record.longitude):
         return puma_from_point(df_record.geometry)
     else:
-        return _from_geocoded_eviction_address(df_record)
+        return None
 
 
 def _aggregate_by_geography(evictions, geography_level):
+    """
+    Aggregate evictions by geography level.
+
+    Args:
+        evictions: GeoDataFrame of evictions
+        geography_level: One of "citywide", "borough", or "puma"
+    """
     assert geography_level in ["citywide", "borough", "puma"]
+
+    evictions = evictions.copy()
+
     if geography_level == "puma":
-        evictions["puma"] = evictions.apply(_get_puma, axis=1)
+        # Compute PUMA for records that don't have it
+        needs_puma = evictions["puma"].isna()
+        if needs_puma.any():
+            evictions.loc[needs_puma, "puma"] = evictions[needs_puma].apply(
+                _get_puma, axis=1
+            )
     elif geography_level == "citywide":
         evictions["citywide"] = "citywide"
+
     final = evictions.groupby(geography_level).size()
     final.name = "evictions_count"
 
@@ -92,6 +87,19 @@ def _aggregate_by_geography(evictions, geography_level):
 
 
 def count_residential_evictions(geography_level, write_to_internal_review=False):
+    """
+    Count residential evictions by geography level.
+
+    Uses the doi_evictions_geocoded dataset which already excludes the current year
+    (incomplete data) so all historical years are included.
+
+    Args:
+        geography_level: One of "citywide", "borough", or "puma"
+        write_to_internal_review: Whether to write output to internal review
+
+    Returns:
+        DataFrame with eviction counts by geography
+    """
     residential_evictions = _load_residential_evictions()
 
     aggregated_by_geography = _aggregate_by_geography(

--- a/products/edde/ingest/ingestion_helpers.py
+++ b/products/edde/ingest/ingestion_helpers.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from dcpy.lifecycle.builds import load
 from dcpy.utils.geospatial import parquet
+from dcpy.utils.logging import logger
 
 
 def load_data(
@@ -12,6 +13,7 @@ def load_data(
     # TODO: is_geospatial flag is hacky. This should be inferred elsewhere
 
     build_metadata = load.get_build_metadata(config.PRODUCT_PATH)
+    logger.info(f"loading dataset={name}, version={version}")
     assert build_metadata.load_result, "You must load data before reading data."
 
     if is_geospatial:

--- a/products/edde/recipe.yml
+++ b/products/edde/recipe.yml
@@ -14,8 +14,8 @@ inputs:
   datasets:
 # From the spreadsheet
   # Ingested
-  - name: doi_evictions # 3.09
-    version: 20250423
+  - name: doi_evictions_geocoded # 3.09 (geocoded version)
+    version: 20260514
   - name: hpd_hny_units_by_building # 3.11, 4.02
     version: 20250303
   - name: dcp_housing # 4.01

--- a/products/edde/scripts/evictions_ingest/process_eviction_address_for_ingest.py
+++ b/products/edde/scripts/evictions_ingest/process_eviction_address_for_ingest.py
@@ -1,0 +1,187 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import usaddress
+from geosupport import Geosupport, GeosupportError
+
+# Add parent directories to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from utils.geo_helpers import borough_name_mapper
+
+
+# Geosupport wrapper - kept local to this script to avoid geosupport dependency in main pipeline
+class _GW:
+    """Geosupport wrapper"""
+
+    def __init__(self) -> None:
+        self.g = None
+
+    @property
+    def geosupport(self):
+        if not self.g:
+            self.g = Geosupport()
+        return self.g
+
+
+_gw = _GW()
+
+
+def geocode_address(address: dict) -> dict | None:
+    """
+    Geocode an address using Geosupport and return coordinates.
+
+    Requires docker with geosupport.
+
+    Returns:
+        dict: Dictionary with 'latitude', 'longitude', 'puma' if successful
+        None: If geocoding fails
+    """
+    try:
+        geocoded = _gw.geosupport["1E"](
+            street_name=address["street_name"],
+            house_number=address["address_num"],
+            borough=address["borough"],
+            mode="extended",
+        )
+        return {
+            "latitude": geocoded.get("Latitude"),
+            "longitude": geocoded.get("Longitude"),
+            "puma": geocoded.get("PUMA Code"),
+        }
+    except GeosupportError:
+        return None
+
+
+def load_and_prepare_evictions(input_file: str) -> pd.DataFrame:
+    """
+    Load evictions data and prepare it for geocoding.
+
+    Filters out current year records (incomplete data) and cleans borough names.
+    """
+    print(f"Loading evictions data from {input_file}")
+    evictions = pd.read_parquet(input_file)
+
+    # Extract year from executed_date
+    evictions["year"] = evictions.executed_date.apply(lambda x: x[-4:])
+
+    # Get current year and exclude those records (incomplete data)
+    current_year = str(datetime.now().year)
+    evictions = evictions[evictions["year"] != current_year].copy()
+
+    # Clean borough names
+    evictions["borough_name"] = (
+        evictions["borough"].str[0] + evictions["borough"].str[1:].str.lower()
+    )
+    evictions["borough_name"] = evictions["borough_name"].replace(
+        {"Staten island": "Staten Island"}
+    )
+    evictions["borough"] = evictions["borough_name"].map(borough_name_mapper)
+
+    # Ensure numeric columns are properly typed
+    num_cols = ["latitude", "longitude"]
+    for c in num_cols:
+        evictions[c] = pd.to_numeric(evictions[c], errors="coerce")
+
+    return evictions
+
+
+def geocode_from_address(record) -> dict | None:
+    """
+    Geocode an eviction record using the address when lat/lon are missing.
+
+    Using usaddress parser: https://usaddress.readthedocs.io/en/latest/
+
+    Returns:
+        dict: Dictionary containing geocoded information (latitude, longitude, puma)
+        None: If geocoding fails
+    """
+    try:
+        parsed = usaddress.parse(record.eviction_address)
+        parsed = {k: v for v, k in parsed}
+
+        address_parts = {
+            "address_num": parsed.get("AddressNumber", ""),
+            "street_name": " ".join(
+                filter(
+                    None,
+                    [
+                        parsed.get("StreetNamePreModifier"),
+                        parsed.get("StreetNamePreDirectional"),
+                        parsed.get("StreetNamePreType"),
+                        parsed.get("StreetName"),
+                        parsed.get("StreetNamePostModifier"),
+                        parsed.get("StreetNamePostDirectional"),
+                        parsed.get("StreetNamePostType"),
+                    ],
+                )
+            ),
+            "borough": record.borough,
+            "zip": record.eviction_postcode,
+        }
+
+        return geocode_address(address_parts)
+    except Exception:
+        # If geocoding fails, return None
+        return None
+
+
+def geocode_evictions(evictions: pd.DataFrame) -> pd.DataFrame:
+    """
+    Geocode evictions records where lat/lon are missing.
+
+    For records with valid lat/lon, keep them as-is.
+    For records without valid lat/lon, attempt to geocode from the address.
+    """
+    geocoded = evictions.copy()
+
+    # Identify records that need geocoding (missing or invalid lat/lon)
+    needs_geocoding = geocoded["latitude"].isna() | geocoded["longitude"].isna()
+
+    print(f"Total records: {len(geocoded)}")
+    print(f"Records needing geocoding: {needs_geocoding.sum()}")
+
+    # Apply geocoding to records that need it
+    if needs_geocoding.sum() > 0:
+        geocoded_results = geocoded[needs_geocoding].apply(geocode_from_address, axis=1)
+
+        # Extract geocoded coordinates and update the dataframe
+        for idx, result in geocoded_results.items():
+            if result is not None:
+                # Convert to float to ensure proper numeric types
+                lat = result.get("latitude")
+                lon = result.get("longitude")
+                geocoded.loc[idx, "latitude"] = float(lat) if lat is not None else None
+                geocoded.loc[idx, "longitude"] = float(lon) if lon is not None else None
+                geocoded.loc[idx, "puma"] = result.get("puma")
+
+        successfully_geocoded = geocoded_results.notna().sum()
+        print(
+            f"Geocoding complete. Records successfully geocoded: {successfully_geocoded}"
+        )
+
+    # Ensure latitude and longitude are numeric types
+    geocoded["latitude"] = pd.to_numeric(geocoded["latitude"], errors="coerce")
+    geocoded["longitude"] = pd.to_numeric(geocoded["longitude"], errors="coerce")
+
+    return geocoded
+
+
+def process_evictions_for_ingest(input_file: str, output_file: str):
+    """
+    Main function to process evictions data for ingest.
+
+    Args:
+        input_file: Path to input parquet file
+        output_file: Path to output parquet file
+    """
+    evictions = load_and_prepare_evictions(input_file)
+    geocoded_evictions = geocode_evictions(evictions)
+
+    print(f"\nSaving geocoded data to {output_file}")
+    geocoded_evictions.to_parquet(output_file, index=False)
+    print(f"✓ Saved {len(geocoded_evictions)} records")
+
+    return geocoded_evictions

--- a/products/edde/scripts/evictions_ingest/run_geocode.sh
+++ b/products/edde/scripts/evictions_ingest/run_geocode.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Run DOI Evictions geocoding using Geosupport
+
+set -e
+
+IMAGE="nycplanning/build-geosupport:latest"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EDDE_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PROJECT_ROOT="$(cd "${EDDE_ROOT}/../.." && pwd)"
+
+# Use first argument as input file, or default to doi_evictions.parquet
+INPUT_FILE="${1:-${SCRIPT_DIR}/doi_evictions.parquet}"
+OUTPUT_FILE="${2:-${SCRIPT_DIR}/doi_evictions_geocoded.parquet}"
+
+# Get relative paths for docker (relative to /app/products/edde working directory)
+# Convert absolute paths to relative from EDDE_ROOT
+INPUT_REL="${INPUT_FILE#${EDDE_ROOT}/}"
+OUTPUT_REL="${OUTPUT_FILE#${EDDE_ROOT}/}"
+
+echo "================================"
+echo "DOI Evictions Geocoding"
+echo "================================"
+echo "Input:  ${INPUT_FILE}"
+echo "Output: ${OUTPUT_FILE}"
+echo ""
+echo "Mounting ${PROJECT_ROOT} into docker container..."
+echo "Working directory: /app/products/edde"
+echo ""
+
+docker run --rm \
+  -v "${PROJECT_ROOT}:/app" \
+  -w /app/products/edde \
+  -e PYTHONPATH=/app \
+  ${IMAGE} \
+  python3 scripts/evictions_ingest/process_eviction_address_for_ingest.py \
+    "${INPUT_REL}" \
+    "${OUTPUT_REL}"
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✓ Geocoding complete! Output: ${OUTPUT_FILE}"
+else
+    echo ""
+    echo "✗ Geocoding failed."
+    exit 1
+fi

--- a/products/edde/utils/geocode.py
+++ b/products/edde/utils/geocode.py
@@ -1,31 +1,6 @@
-from geosupport import Geosupport, GeosupportError
-
-
-class _GW:
-    """Geosupport wrapper"""
-
-    def __init__(self) -> None:
-        self.g = None
-
-    @property
-    def geosupport(self):
-        if not self.g:
-            self.g = Geosupport()
-        return self.g
-
-
-_gw = _GW()
-
-
-def get_geosupport_puma(address: dict) -> str:
-    """Requires docker"""
-    try:
-        geocoded = _gw.geosupport["1E"](
-            street_name=address["street_name"],
-            house_number=address["address_num"],
-            borough=address["borough"],
-            mode="extended",
-        )
-        return geocoded["PUMA Code"]
-    except GeosupportError:
-        return None
+# This module previously contained Geosupport geocoding functions.
+# Those have been moved to products/edde/scripts/evictions_ingest/process_eviction_address_for_ingest.py
+# to keep Geosupport dependencies out of the main build pipeline.
+#
+# If you need geocoding functionality, use the geocoded dataset (doi_evictions_geocoded)
+# which is preprocessed with Geosupport before ingestion.


### PR DESCRIPTION
I want to run EDDE without a docker container, which means removing geosupport from the build process. The only dataset that uses it is `doi-evictions`, so this adds another ingest dataset to take `doi_evictions` and turn it into `doi_evictions_geocoded`. Down the line, we can "dag" these together in dagster.

Other small notes
- We don't actually ingest parquet files currently (🤷‍♂️) so I've added that as an ingest input type.  
- I've got another PR in progress to actually DAG'ify this in dagster. For now, the new doi_evictions_geocoded must be run manually. 