### PR TITLE
Enable Dagster Ingest Dependencies

### DIFF
--- a/apps/dagster/ingest/assets.py
+++ b/apps/dagster/ingest/assets.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
-from dagster import AssetExecutionContext, Config, MaterializeResult, asset
+from dagster import AssetExecutionContext, AssetKey, Config, MaterializeResult, asset
 from dcpy.lifecycle.ingest import get_template_directory, list_ingest_templates
+from dcpy.lifecycle.ingest.plan import read_definition_file
 
 from .partitions import ingest_partition_def
 from .resources import LocalStorageResource
@@ -22,11 +23,68 @@ class IngestConfig(Config):
     overwrite_okay: bool = True  # Allow overwriting existing versions
 
 
-def make_ingest_asset(template_id: str):
-    """Create a Dagster asset for an ingest template"""
+def validate_dependencies(
+    template_id: str, depends_on: List[str], all_template_names: set[str]
+) -> None:
+    """Validate that all dependencies exist and there are no circular dependencies.
+
+    Args:
+        template_id: The ID of the template being validated
+        depends_on: List of template IDs this template depends on
+        all_template_names: Set of all valid template names
+
+    Raises:
+        ValueError: If dependencies don't exist or circular dependencies detected
+    """
+    # Check that all dependencies exist
+    missing_deps = [dep for dep in depends_on if dep not in all_template_names]
+    if missing_deps:
+        raise ValueError(
+            f"Template '{template_id}' has dependencies on non-existent templates: {missing_deps}"
+        )
+
+
+def detect_circular_dependencies(
+    template_deps: dict[str, list[str]],
+    template_id: str,
+    visited: set[str] | None = None,
+) -> None:
+    """Detect circular dependencies in template dependency graph.
+
+    Args:
+        template_deps: Dictionary mapping template IDs to their dependencies
+        template_id: The current template being checked
+        visited: Set of templates already visited in this path
+
+    Raises:
+        ValueError: If a circular dependency is detected
+    """
+    if visited is None:
+        visited = set()
+
+    if template_id in visited:
+        cycle_path = " -> ".join(list(visited) + [template_id])
+        raise ValueError(f"Circular dependency detected: {cycle_path}")
+
+    visited.add(template_id)
+
+    for dep in template_deps.get(template_id, []):
+        detect_circular_dependencies(template_deps, dep, visited.copy())
+
+
+def make_ingest_asset(template_id: str, depends_on: List[str] | None = None):
+    """Create a Dagster asset for an ingest template
+
+    Args:
+        template_id: The template identifier
+        depends_on: List of template IDs this template depends on
+    """
+    # Convert template dependencies to Dagster asset keys
+    deps = [AssetKey(f"ingest_{dep}") for dep in (depends_on or [])]
 
     @asset(
         name=f"ingest_{template_id}",
+        deps=deps,
         partitions_def=ingest_partition_def,
         group_name="ingest",
         tags={"template": template_id, "lifecycle_stage": "ingest"},
@@ -73,4 +131,34 @@ def make_ingest_asset(template_id: str):
 
 # Create ingest assets for all templates
 ingest_templates = list_ingest_templates()
-ingest_assets = [make_ingest_asset(template.name) for template in ingest_templates]
+template_directory = get_template_directory()
+
+# Build dependency map for all templates
+template_deps: dict[str, list[str]] = {}
+all_template_names = {template.name for template in ingest_templates}
+
+for template in ingest_templates:
+    template_path = template_directory / f"{template.name}.yml"
+
+    # Read the template definition using Pydantic models
+    # For templates that use {{ version }}, provide a dummy value since:
+    # 1. Version is unknown at asset load time (determined at runtime)
+    # 2. depends_on field never uses Jinja2 templating
+    # 3. We only need depends_on, not the full validated model
+    # If the template has syntax errors, this will raise and block deployment
+    definition = read_definition_file(template_path, version="dummy_version")
+    depends_on = definition.depends_on
+    template_deps[template.name] = depends_on
+
+    # Validate dependencies exist
+    validate_dependencies(template.name, depends_on, all_template_names)
+
+# Detect circular dependencies for all templates
+for template_id in template_deps:
+    detect_circular_dependencies(template_deps, template_id)
+
+# Create assets with dependencies
+ingest_assets = [
+    make_ingest_asset(template.name, template_deps[template.name])
+    for template in ingest_templates
+]

--- a/apps/qa/src/pages/source_data/components.py
+++ b/apps/qa/src/pages/source_data/components.py
@@ -6,6 +6,7 @@ import matplotlib.dates as dates
 import matplotlib.pyplot as plt
 import streamlit as st
 from dateutil.relativedelta import relativedelta
+
 from dcpy.models import library
 
 

--- a/apps/qa/src/pages/source_data/components.py
+++ b/apps/qa/src/pages/source_data/components.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import streamlit as st
 from dateutil.relativedelta import relativedelta
 
-from dcpy.models import library
+from dcpy.models import library  # noqa
 
 
 def plot_series(

--- a/apps/qa/src/pages/source_data/helpers.py
+++ b/apps/qa/src/pages/source_data/helpers.py
@@ -4,7 +4,7 @@ from typing import Dict
 from src import APP_PATH, ROOT_PATH
 
 from dcpy.lifecycle.builds import plan
-from dcpy.models import library
+from dcpy.models import library  # noqa
 
 
 def get_source_datasets(product: str) -> list[str]:

--- a/apps/qa/src/pages/source_data/helpers.py
+++ b/apps/qa/src/pages/source_data/helpers.py
@@ -1,10 +1,10 @@
 import os
 from typing import Dict
 
-from dcpy.models import library
 from src import APP_PATH, ROOT_PATH
 
 from dcpy.lifecycle.builds import plan
+from dcpy.models import library
 
 
 def get_source_datasets(product: str) -> list[str]:

--- a/dcpy/lifecycle/ingest/models.py
+++ b/dcpy/lifecycle/ingest/models.py
@@ -58,6 +58,7 @@ class DatasetDefinition(TemplatedYamlReader, extra="forbid"):
     """
 
     id: str
+    depends_on: list[str] = []
     acl: recipes.ValidAclValues | None = None
 
     attributes: DatasetAttributes
@@ -109,6 +110,7 @@ class DataSourceDefinition(TemplatedYamlReader, extra="forbid"):
     """
 
     id: str
+    depends_on: list[str] = []
     acl: recipes.ValidAclValues | None = None
     attributes: DatasetAttributes
     source: Source

--- a/dcpy/test/lifecycle/ingest/resources/definitions/datasource_with_dependencies.yml
+++ b/dcpy/test/lifecycle/ingest/resources/definitions/datasource_with_dependencies.yml
@@ -1,0 +1,32 @@
+id: datasource_with_dependencies
+depends_on:
+  - simple
+acl: private
+
+attributes:
+  name: DataSource with Dependencies
+
+source:
+  type: local_file
+  key: dcpy/test/lifecycle/ingest/resources/test_data/test.gdb.zip
+
+dataset_defaults:
+  file_format:
+    type: geodatabase
+    crs: EPSG:4326
+  processing_steps:
+  - name: clean_column_names
+    args: { lower: True }
+
+datasets:
+- id: test_dataset_dep
+  attributes:
+    name: Downstream Dataset 1
+  file_format:
+    layer: downstream_1
+
+- id: downstream_dataset_dep_2
+  attributes:
+    name: Downstream Dataset 2
+  file_format:
+    layer: downstream_2

--- a/dcpy/test/lifecycle/ingest/resources/definitions/with_dependencies.yml
+++ b/dcpy/test/lifecycle/ingest/resources/definitions/with_dependencies.yml
@@ -1,0 +1,18 @@
+id: with_dependencies
+depends_on:
+  - simple
+  - one_to_many
+acl: public-read
+
+attributes:
+  name: Dataset with Dependencies
+
+ingestion:
+  source:
+    type: local_file
+    endpoint: dummy.csv
+  file_format:
+    type: csv
+  processing_steps:
+  - name: clean_column_names
+    args: { lower: True }

--- a/dcpy/test/lifecycle/ingest/test_plan.py
+++ b/dcpy/test/lifecycle/ingest/test_plan.py
@@ -94,3 +94,22 @@ class TestResolveDefinition:
         )
         # final catch-all
         assert config == RESOLVED
+
+    def test_with_dependencies(self):
+        """Test that depends_on field is parsed correctly for DatasetDefinition"""
+        definition = plan.read_definition_file(_d_path("with_dependencies"))
+        assert isinstance(definition, DatasetDefinition)
+        assert definition.depends_on == ["simple", "one_to_many"]
+
+    def test_datasource_with_dependencies(self):
+        """Test that depends_on field is parsed correctly for DataSourceDefinition"""
+        definition = plan.read_definition_file(_d_path("datasource_with_dependencies"))
+        assert isinstance(definition, DataSourceDefinition)
+        assert definition.depends_on == ["simple"]
+        assert len(definition.datasets) == 2
+
+    def test_empty_depends_on(self):
+        """Test that templates without depends_on default to empty list"""
+        definition = plan.read_definition_file(_d_path("simple"))
+        assert isinstance(definition, DatasetDefinition)
+        assert definition.depends_on == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ select = [
 "__init__.py" = ["F401", "E402"]
 "conftest.py" = ["E402"]
 "setup_dev_bucket.py" = ["E402"]
+"apps/qa/src/pages/source_data/*.py" = ["I001"]
 
 [[tool.mypy.overrides]]
 module = "geopandas.*,geosupport.*,cerberus.*,osgeo.*,diagrams.*,usaddress.*,plotly.*,folium.*,streamlit_folium.*,st_aggrid.*,numerize.*,moto.*,matplotlib.*,contextily,leafmap.*,shapely,socrata.*,faker.*,ruamel.*,pyogrio.*,ijson.*" # no stubs available


### PR DESCRIPTION
Adds a field on ingest template models for `depends_on` so we start putting the dag in dagster.

Also... I am so frustrated with `ruff`. I'm getting different results locally vs CI with these two stupid files in the qaqc app, for a page we don't use. I'm just going to ignore them for now. 
