### PR TITLE
use wpaa footprints dataset, update federal parks url, and fix typos

### DIFF
--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -49,6 +49,8 @@ def resolve_version(recipe: Recipe) -> str:
     match recipe.version_strategy:
         case None:
             raise Exception("No version or version_strategy provided")
+        case versions.SimpleVersionStrategy.today:
+            return versions.generate_today().label
         case versions.SimpleVersionStrategy.first_of_month:
             return versions.generate_first_of_month().label
         case versions.SimpleVersionStrategy.bump_latest_release:

--- a/dcpy/test/lifecycle/builds/test_plan.py
+++ b/dcpy/test/lifecycle/builds/test_plan.py
@@ -76,6 +76,10 @@ class TestVersionStrategies(TestCase):
         with pytest.raises(Exception, match="No version or version_strategy provided"):
             plan.resolve_version(self.recipe)
 
+    def test_today(self):
+        self.recipe.version_strategy = versions.SimpleVersionStrategy.today
+        assert plan.resolve_version(self.recipe) == versions.generate_today().label
+
     def test_first_of_month(self):
         self.recipe.version_strategy = versions.SimpleVersionStrategy.first_of_month
         assert (

--- a/dcpy/utils/versions.py
+++ b/dcpy/utils/versions.py
@@ -226,6 +226,10 @@ class Date(Version):
                 return False
 
 
+def generate_today() -> Date:
+    return Date(date=date.today(), format=DateVersionFormat.date)
+
+
 def generate_first_of_month() -> Date:
     return Date(date=date.today().replace(day=1), format=DateVersionFormat.date)
 
@@ -239,6 +243,7 @@ class PinToSourceDataset(BaseModel):
 
 
 class SimpleVersionStrategy(StrEnum):
+    today = "today"
     first_of_month = "first_of_month"
     bump_latest_release = "bump_latest_release"
 

--- a/ingest_templates/dcp_waterfront_access_map_wpaa.yml
+++ b/ingest_templates/dcp_waterfront_access_map_wpaa.yml
@@ -7,7 +7,7 @@ attributes:
     Waterfront Public Access Areas (WPAAs) are privately owned waterfront zoning lots
     where publicly accessible open space is provided to and along the shoreline for
     public enjoyment.
-  url: https://www.nyc.gov/site/planning/data-maps/open-data/dwn-waterfront.page
+  url: https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-waterfront-access-map
   
 ingestion:
   source:

--- a/ingest_templates/dcp_waterfront_public_access_areas_footprints.yml
+++ b/ingest_templates/dcp_waterfront_public_access_areas_footprints.yml
@@ -1,0 +1,17 @@
+id: dcp_waterfront_public_access_areas_footprints
+acl: public-read
+
+attributes:
+  name: Waterfront Public Access Area Footprints
+  description: |
+    Waterfront Public Access Areas (WPAAs) are privately owned waterfront zoning lots where publicly accessible open space is provided to and along the shoreline for public enjoyment. This dataset contains the physical footprints of the public access areas, as distinct from the full zoning lot boundaries.
+  url: https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-waterfront-access-map
+
+ingestion:
+  source:
+    type: arcgis_feature_server
+    server: dcp
+    dataset: nywpaa_footprints
+    layer_name: Waterfront Public Access Area Footprints
+  file_format:
+    type: geojson

--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -1,6 +1,6 @@
 name: CEQR
 product: db-ceqr
-version_strategy: first_of_month
+version_strategy: today
 
 inputs:
   missing_versions_strategy: find_latest

--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -48,7 +48,7 @@ inputs:
     - name: dcp_pops
       file_type: pg_dump
     - name: dot_pedplazas
-    - name: dcp_waterfront_public_access_areas
+    - name: dcp_waterfront_public_access_areas_footprints
     - name: dcp_publicly_owned_waterfront
     - name: nysparks_parks
     - name: usnps_parks

--- a/products/ceqr/seeds/chapter_datasets.csv
+++ b/products/ceqr/seeds/chapter_datasets.csv
@@ -1,7 +1,7 @@
 chapter_id,use_category,dataset_name,use_details
 analysis_framework,RWCDS,RWCDS Analysis Framework Table,Form required for submission of Reasonable Worst Case Development Scenarios by DCP
 analysis_framework,RWCDS,RWCDS Analysis Spreadsheet,Form required for submission of Reasonable Worst Case Development Scenarios by DCP
-analysis_framework,Existing Condition,MapPLUTO Shoreline Clipped,Establishing built characterstics of parcels within the project area
+analysis_framework,Existing Condition,MapPLUTO Shoreline Clipped,Establishing built characteristics of parcels within the project area
 analysis_framework,Existing and No Action Condition,DCP Housing and Population Projections,"A workbook for use in establishing the existing and no action condition housing and population characteristics within various study areas. Combines our best available population data, housing permit data, and assumptions about household size and vacancy to estimate current conditions and conditions for build years 3-5 years in the future"
 analysis_framework,No Action Condition,ZAP Projects,Establishing non-residential No-Action Condition projects within various study areas
 analysis_framework,Green Fast Track,Green Fast Track Lots,For use in determining if housing projects are eligible for the Green Fast Track Type II determination
@@ -19,7 +19,7 @@ land_use,WRP,Base Flood Elevation 2015,Completing WRP Flood Evaluation worksheet
 land_use,WRP,Limit of Moderate Wave Action,Completing WRP Flood Evaluation worksheet
 land_use,WRP,Future Floodplain 2050s,Completing WRP Flood Evaluation worksheet
 land_use,WRP,Coastal Zone Boundary,"Coastal Zone Boundary Map, Special Area Designations"
-land_use,WRP,Ecologically Sensistive Maritime and Industrial Area,"Coastal Zone Boundary Map, Special Area Designations"
+land_use,WRP,Ecologically Sensitive Maritime and Industrial Area,"Coastal Zone Boundary Map, Special Area Designations"
 land_use,WRP,Priority Marine Activity Zones,"Coastal Zone Boundary Map, Special Area Designations"
 land_use,WRP,Recognized Ecological Complexes,"Coastal Zone Boundary Map, Special Area Designations"
 land_use,WRP,Significant Maritime and Industrial Area,"Coastal Zone Boundary Map, Special Area Designations"
@@ -77,7 +77,7 @@ open_space,Open Spaces,Publicly Owned Waterfront,Open Space Inventory
 open_space,Open Spaces,NYS Parks,Open Space Inventory
 open_space,Open Spaces,Federal Parks,Open Space Inventory
 open_space,Open Spaces,NYC Parks Active and Passive Recreation,Open Space Inventory- for public open spaces managed by NYC Parks
-open_space,No Action Condition,Parks Capital Projects Tracker,Establishing new park spaces in the No-Action Condion
+open_space,No Action Condition,Parks Capital Projects Tracker,Establishing new park spaces in the No-Action Condition
 open_space,Screening Assessment,Walk to a Park Service Area,Open Space screening for detailed analysis
 open_space,Detailed Assessment,Population Fact Finder,Dicennial Census to establish existing population age characteristics for a detailed indirect effects analysis
 shadows,Base Map,2014 3D Model,creating 3D basemap for detailed shadows assessments

--- a/products/ceqr/seeds/datasets.csv
+++ b/products/ceqr/seeds/datasets.csv
@@ -13,7 +13,7 @@ Base Flood Elevation 2015,,webpage,,,https://dcp.maps.arcgis.com/apps/webappview
 Limit of Moderate Wave Action,dcp_limwa,download,shapefile,MULTILINESTRING,https://dcp.maps.arcgis.com/home/item.html?id=e089b65f8a914c80ab72082a1522c7f2
 Future Floodplain 2050s,dcp_floodplain_2050_100,download,shapefile,MULTIPOLYGON,https://dcp.maps.arcgis.com/home/item.html?id=cc996fdd1a134d18a6ae7e3a1ecfe84b
 Coastal Zone Boundary,dcp_wrp_coastal_zone_boundary,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
-Ecologically Sensistive Maritime and Industrial Area,dcp_wrp_sensitive_maritime_and_industrial_area,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
+Ecologically Sensitive Maritime and Industrial Area,dcp_wrp_sensitive_maritime_and_industrial_area,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
 Priority Marine Activity Zones,dcp_wrp_priority_marine_activity_zones,download,shapefile,MULTILINESTRING,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
 Recognized Ecological Complexes,dcp_wrp_recognized_ecological_complexes,download,shapefile,MULTIPOINT,
 Significant Maritime and Industrial Area,dcp_wrp_significant_maritime_and_industrial_area,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/wrp-coastal-zone-boundary
@@ -54,10 +54,10 @@ Projected Public School Ratio,,webpage,,,https://www.nycsca.org/Community/Capita
 Facilities Database,dcp_facilities,download,shapefile,MULTIPOINT,https://www.nyc.gov/content/planning/pages/resources/datasets/facilities
 POPS,dcp_pops,download,shapefile,MULTIPOINT,https://data.cityofnewyork.us/City-Government/Privately-Owned-Public-Spaces-POPS-/rvih-nhyn/about_data
 Plazas,dot_pedplazas,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/Transportation/NYC-DOT-Pedestrian-Plazas/k5k6-6jex/about_data
-Waterfront Public Access Areas,dcp_waterfront_public_access_areas,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-waterfront-access-map
+Waterfront Public Access Areas,dcp_waterfront_public_access_areas_footprints,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-waterfront-access-map
 Publicly Owned Waterfront,dcp_publicly_owned_waterfront,download,shapefile,MULTIPOLYGON,https://www.nyc.gov/content/planning/pages/resources/datasets/nyc-waterfront-access-map
 NYS Parks,nysparks_parks,download,shapefile,MULTIPOLYGON,https://data.gis.ny.gov/datasets/nysparks::ny-state-parks-property/about
-Federal Parks,usnps_parks,download,shapefile,MULTIPOLYGON,https://nps.maps.arcgis.com/apps/webappviewer/index.html?id=43bc9db4736140e88e661c67460936e6
+Federal Parks,usnps_parks,download,shapefile,MULTIPOLYGON,https://experience.arcgis.com/experience/8a40c80626634d42a9062ac15b426179
 NYC Parks Active and Passive Recreation,dpr_active_passive_recreation,download,csv,,https://data.cityofnewyork.us/Recreation/NYC-Parks-Active-and-Passive-Recreation/kcqe-vnci/about_data
 Parks Capital Projects Tracker,dpr_capitalprojects,download,shapefile,MULTIPOINT,https://www.nycgovparks.org/planning-and-building/capital-project-tracker/upcoming
 Walk to a Park Service Area,dpr_walk_to_a_park,download,shapefile,MULTIPOLYGON,https://data.cityofnewyork.us/dataset/Walk-to-a-Park-Service-Area-for-CEQR-Open-Space-As/k66c-pzws/about_data


### PR DESCRIPTION
resolves https://github.com/NYCPlanning/ceqr-data-hub/issues/47
resolves https://github.com/NYCPlanning/ceqr-data-hub/issues/48
resolves https://github.com/NYCPlanning/ceqr-data-hub/issues/49

cc @sallywuhoo and @kufre-u who opened those issues

[all action runs on this branch](https://github.com/NYCPlanning/data-engineering/actions?query=branch%3Adm-fixes)

also added a `today` recipe version strategy. there was already a 2026-05-01 version in `db-ceqr` but this isn't draft 2 of it. this data prodcut definitely isn't updated everyday but it could be updated ad-hoc more than once a month

<img width="385" height="158" alt="Screenshot 2026-05-29 at 7 51 07 AM" src="https://github.com/user-attachments/assets/9891e31e-47cf-44e5-b819-d0d465a14127" />

## todos

- [x] run ingest on new dataset
- [x] run build and promote to draft
- [x] copy markdown in outputs to ceqr-data-hub repo and open PR there
- [x] copy build data to ceqr-data-hub bucket
- [x] merge PRs and redeploy site
