### PR TITLE
export parquet files and dbt artifacts

### DIFF
--- a/dcpy/lifecycle/builds/__init__.py
+++ b/dcpy/lifecycle/builds/__init__.py
@@ -25,4 +25,8 @@ BUILD_PLAN_ARTIFACTS = [
     "source_data_versions.csv",
 ]
 
+BUILD_ARTIFACT_DIRS = [
+    "target",
+]
+
 __all__ = ["get_recipes_default_connector"]

--- a/dcpy/lifecycle/builds/export.py
+++ b/dcpy/lifecycle/builds/export.py
@@ -9,7 +9,12 @@ import typer
 from shapely import MultiPoint, MultiPolygon
 
 from dcpy.lifecycle import config
-from dcpy.lifecycle.builds import BUILD_PLAN_ARTIFACTS, metadata, plan
+from dcpy.lifecycle.builds import (
+    BUILD_ARTIFACT_DIRS,
+    BUILD_PLAN_ARTIFACTS,
+    metadata,
+    plan,
+)
 from dcpy.lifecycle.builds.models import ExportDataset, ExportFormat
 from dcpy.utils import postgres
 from dcpy.utils.logging import logger
@@ -222,6 +227,13 @@ def export(
             logger.warning(f"Expected build artifact {source_path} does not exist")
             continue
         shutil.copy(source_path, output_folder / filename)
+
+    for dirname in BUILD_ARTIFACT_DIRS:
+        source_dir = Path(recipe_lock_path).parent / dirname
+        if source_dir.is_dir():
+            shutil.copytree(source_dir, output_folder / dirname)
+        else:
+            logger.warning(f"Expected build artifact directory {source_dir} does not exist")
 
     # GDB entries are grouped by output filename so multiple tables can share one file.
     # All other formats are written one entry at a time.

--- a/dcpy/lifecycle/builds/export.py
+++ b/dcpy/lifecycle/builds/export.py
@@ -57,6 +57,9 @@ def export_dataset_from_postgres(
             )
 
             line_endings = "crlf"
+        case ExportFormat.parquet:
+            df = pg_client.read_table_df(table_name)
+            df.to_parquet(file_path, index=False)
         case ExportFormat.shapefile | ExportFormat.gdb:
             export_geodataset_from_postgres(
                 table_name=table_name,
@@ -233,7 +236,9 @@ def export(
         if source_dir.is_dir():
             shutil.copytree(source_dir, output_folder / dirname)
         else:
-            logger.warning(f"Expected build artifact directory {source_dir} does not exist")
+            logger.warning(
+                f"Expected build artifact directory {source_dir} does not exist"
+            )
 
     # GDB entries are grouped by output filename so multiple tables can share one file.
     # All other formats are written one entry at a time.

--- a/dcpy/test/lifecycle/builds/test_build.py
+++ b/dcpy/test/lifecycle/builds/test_build.py
@@ -244,3 +244,49 @@ exports:
     file_path: Path = mock_write.call_args[0][1]
     assert file_path.suffix == ".zip", f"Expected .zip suffix, got {file_path.suffix}"
     assert "mytable" in file_path.name
+
+
+_MINIMAL_RECIPE = """\
+name: Test Product
+product: test
+version: 24Q1
+inputs:
+  datasets: []
+exports:
+  output_folder: {output_folder}
+  datasets: []
+"""
+
+
+def test_export_copies_target_dir_when_present(tmp_path):
+    """export() copies the dbt target/ sibling directory recursively into the output folder."""
+    output_folder = tmp_path / "output"
+    recipe_path = tmp_path / "recipe.lock.yml"
+    recipe_path.write_text(_MINIMAL_RECIPE.format(output_folder=str(output_folder)))
+
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    (target_dir / "run_results.json").write_text('{"results": []}')
+    compiled_dir = target_dir / "compiled"
+    compiled_dir.mkdir()
+    (compiled_dir / "x.sql").write_text("select 1")
+
+    export(recipe_path, pg_client=MagicMock())
+
+    assert (output_folder / "target").is_dir()
+    assert (output_folder / "target" / "run_results.json").exists()
+    assert (output_folder / "target" / "compiled" / "x.sql").exists()
+
+
+def test_export_warns_when_target_dir_missing(tmp_path):
+    """export() logs a warning and continues when target/ does not exist."""
+    output_folder = tmp_path / "output"
+    recipe_path = tmp_path / "recipe.lock.yml"
+    recipe_path.write_text(_MINIMAL_RECIPE.format(output_folder=str(output_folder)))
+
+    with patch("dcpy.lifecycle.builds.export.logger") as mock_logger:
+        export(recipe_path, pg_client=MagicMock())
+
+    assert not (output_folder / "target").exists()
+    warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+    assert any("target" in msg for msg in warning_calls)

--- a/dcpy/test_integration/lifecycle/test_builds.py
+++ b/dcpy/test_integration/lifecycle/test_builds.py
@@ -76,17 +76,23 @@ def test_export_to_dat(client_with_sample_data, tmp_path):
     assert len(lines) == 5, "Should have exactly 5 rows without header"
 
 
-def test_export_unsupported_format(client_with_sample_data, tmp_path):
-    """Test that unsupported formats raise NotImplementedError."""
+def test_export_to_parquet(client_with_sample_data, tmp_path):
+    """Test parquet export."""
     output_file = tmp_path / "test_export.parquet"
 
-    with pytest.raises(NotImplementedError, match="Export of dataset format"):
-        build.export_dataset_from_postgres(
-            table_name=SAMPLE_TABLE,
-            file_path=output_file,
-            format=ExportFormat.parquet,
-            pg_client=client_with_sample_data,
-        )
+    build.export_dataset_from_postgres(
+        table_name=SAMPLE_TABLE,
+        file_path=output_file,
+        format=ExportFormat.parquet,
+        pg_client=client_with_sample_data,
+    )
+
+    assert output_file.exists()
+
+    exported_df = pd.read_parquet(output_file)
+    assert len(exported_df) == 5
+    assert list(exported_df.columns) == ["id", "name", "value", "category"]
+    assert exported_df["name"].tolist() == ["Alice", "Bob", "Charlie", "Diana", "Eve"]
 
 
 def test_export(client_with_sample_data, tmp_path):

--- a/products/template/recipe.yml
+++ b/products/template/recipe.yml
@@ -28,6 +28,8 @@ exports:
   - name: templatedb
     format: csv
   - name: templatedb
+    format: parquet
+  - name: templatedb
     format: shp
     filename: templatedb_points.zip
     custom:

--- a/products/template/tests/test_build.py
+++ b/products/template/tests/test_build.py
@@ -48,4 +48,6 @@ def test_export_files():
         "output.zip",
     }
     actual_files = publishing.get_filenames(BUILD_KEY)
-    assert actual_files == expected_export_file_names
+    target_files = {f for f in actual_files if f.startswith("target/")}
+    assert actual_files - target_files == expected_export_file_names
+    assert target_files, "Expected dbt target/ directory to be present in export"

--- a/products/template/tests/test_build.py
+++ b/products/template/tests/test_build.py
@@ -42,6 +42,7 @@ def test_export_files():
         "data_dictionary.pdf",
         "data_dictionary.xlsx",
         "templatedb.csv",
+        "templatedb.parquet",
         "templatedb_points.zip",
         "templatedb_polygons.zip",
         "templatedb.zip",
@@ -49,5 +50,5 @@ def test_export_files():
     }
     actual_files = publishing.get_filenames(BUILD_KEY)
     target_files = {f for f in actual_files if f.startswith("target/")}
-    assert actual_files - target_files == expected_export_file_names
     assert target_files, "Expected dbt target/ directory to be present in export"
+    assert actual_files - target_files == expected_export_file_names


### PR DESCRIPTION
## why
- we love parquet files and we might as well start generating them at the end of builds as (eventual) primary outputs along with the usual csv, shapefiles, and gdbs
- some of the artifcats generated by dbt builds are useful metadata (compiled SQL, run results, [manifest](https://docs.getdbt.com/reference/artifacts/manifest-json))