### PR TITLE
Fix dcpy.lifecycle build imports

### DIFF
--- a/admin/ops/clean_build_artifacts.py
+++ b/admin/ops/clean_build_artifacts.py
@@ -3,10 +3,29 @@ import subprocess
 import requests
 import typer
 
-from dcpy.lifecycle.builds import BUILD_DBS, BUILD_REPO, metadata
+from dcpy.lifecycle.builds import metadata
 from dcpy.utils import postgres
 from dcpy.utils.git import github
 from dcpy.utils.logging import logger
+
+BUILD_REPO = "data-engineering"
+
+BUILD_DBS = [
+    "db-cbbr",
+    "db-cdbg",
+    "db-ceqr",
+    "db-checkbook",
+    "db-colp",
+    "db-cpdb",
+    "db-devdb",
+    "db-facilities",
+    "db-green-fast-track",
+    # "db-cscl", we need to preserve schemas while this data product is in development
+    "db-pluto",
+    "db-template",
+    "db-ztl",
+    "kpdb",
+]
 
 PROTECTED_BUILD_NAMES = ["nightly_qa"]
 

--- a/dcpy/lifecycle/builds/__init__.py
+++ b/dcpy/lifecycle/builds/__init__.py
@@ -1,7 +1,5 @@
 from dcpy.lifecycle.builds.config import (
     BUILD_ARTIFACT_DIRS,
-    BUILD_DBS,
-    BUILD_REPO,
     get_build_metadata_path,
     get_recipe_lock_path,
     get_recipe_path,
@@ -17,9 +15,7 @@ from dcpy.lifecycle.builds.plan import (
 
 __all__ = [
     # Constants
-    "BUILD_REPO",
     "BUILD_ARTIFACT_DIRS",
-    "BUILD_DBS",
     "ARTIFACTS",
     # Path helpers
     "get_recipe_path",

--- a/dcpy/lifecycle/builds/__init__.py
+++ b/dcpy/lifecycle/builds/__init__.py
@@ -1,136 +1,36 @@
-from pathlib import Path
-
+from dcpy.lifecycle.builds.config import (
+    BUILD_ARTIFACT_DIRS,
+    BUILD_DBS,
+    BUILD_REPO,
+    get_build_metadata_path,
+    get_recipe_lock_path,
+    get_recipe_path,
+)
 from dcpy.lifecycle.builds.connector import get_recipes_default_connector
 from dcpy.lifecycle.builds.models import Recipe
-from dcpy.lifecycle.builds.plan import recipe_from_yaml
-
-# TODO: Move these out of here
-BUILD_REPO = "data-engineering"
-BUILD_ARTIFACT_DIRS = ["target"]
-BUILD_DBS = [
-    "db-cbbr",
-    "db-cdbg",
-    "db-ceqr",
-    "db-checkbook",
-    "db-colp",
-    "db-cpdb",
-    "db-devdb",
-    "db-facilities",
-    "db-green-fast-track",
-    # "db-cscl", we need to preserve schemas while this data product is in development
-    "db-pluto",
-    "db-template",
-    "db-ztl",
-    "kpdb",
-]
-
-BUILD_PLAN_ARTIFACTS = [
-    "recipe.lock.yml",
-    "build_metadata.json",
-    "source_data_versions.csv",
-]
-
-
-def get_recipe_path(product_path: Path, recipe_name: str | None = None) -> Path:
-    """Get the path to a recipe file for a product.
-
-    Args:
-        product_path: Path to the product directory
-        recipe_name: Name of the recipe file (e.g., "my-recipe.yml").
-                    If None, defaults to "recipe.yml"
-
-    Returns:
-        Path to the recipe file
-    """
-    if recipe_name is None:
-        recipe_name = "recipe"
-    return product_path / f"{recipe_name}.yml"
-
-
-def get_recipe_lock_path(product_path: Path, recipe_name: str | None = None) -> Path:
-    """Get the path to a recipe lockfile for a product.
-
-    Args:
-        product_path: Path to the product directory
-        recipe_name: Name of the recipe file (e.g., "my-recipe.yml").
-                    If None, defaults to "recipe.yml"
-
-    Returns:
-        Path to the recipe lockfile (e.g., "recipe.lock.yml" or "my-recipe.lock.yml")
-    """
-    recipe_path = get_recipe_path(product_path, recipe_name)
-    # Insert .lock before .yml extension
-    return recipe_path.parent / f"{recipe_path.stem}.lock.yml"
-
-
-def get_build_metadata_path(product_path: Path) -> Path:
-    """Get the path to the build metadata file for a product.
-
-    Args:
-        product_path: Path to the product directory
-
-    Returns:
-        Path to the build_metadata.json file
-    """
-    return product_path / "build_metadata.json"
-
-
-def get_recipe(
-    product_path: Path,
-    recipe_name: str | None = None,
-    render_templates: bool = True,
-    vars: dict[str, str] | None = None,
-) -> Recipe:
-    """Load a recipe file as a pydantic Recipe model.
-
-    Args:
-        product_path: Path to the product directory
-        recipe_name: Name of the recipe file (e.g., "my-recipe").
-                    If None, defaults to "recipe"
-        render_templates: If True, render Jinja2 templates from vars or BUILD_ENV_* vars.
-                         If False, preserve templates as strings (for DAG generation).
-        vars: Optional dict of template variables. If provided, these are used instead
-              of BUILD_ENV_* environment variables.
-
-    Returns:
-        Recipe pydantic model
-    """
-    recipe_path = get_recipe_path(product_path, recipe_name)
-    return recipe_from_yaml(recipe_path, render_templates=render_templates, vars=vars)
-
-
-def get_recipe_lock(
-    product_path: Path,
-    recipe_name: str | None = None,
-    render_templates: bool = True,
-    vars: dict[str, str] | None = None,
-) -> Recipe:
-    """Load a recipe lockfile as a pydantic Recipe model.
-
-    Args:
-        product_path: Path to the product directory
-        recipe_name: Name of the recipe file (e.g., "my-recipe").
-                    If None, defaults to "recipe"
-        render_templates: If True, render Jinja2 templates from vars or BUILD_ENV_* vars.
-                         If False, preserve templates as strings (for DAG generation).
-        vars: Optional dict of template variables. If provided, these are used instead
-              of BUILD_ENV_* environment variables.
-
-    Returns:
-        Recipe pydantic model from the lockfile
-    """
-    recipe_lock_path = get_recipe_lock_path(product_path, recipe_name)
-    return recipe_from_yaml(
-        recipe_lock_path, render_templates=render_templates, vars=vars
-    )
-
+from dcpy.lifecycle.builds.plan import (
+    ARTIFACTS,
+    get_recipe,
+    get_recipe_lock,
+    recipe_from_yaml,
+)
 
 __all__ = [
-    "get_recipes_default_connector",
+    # Constants
+    "BUILD_REPO",
+    "BUILD_ARTIFACT_DIRS",
+    "BUILD_DBS",
+    "ARTIFACTS",
+    # Path helpers
     "get_recipe_path",
     "get_recipe_lock_path",
     "get_build_metadata_path",
+    # Recipe loading
     "get_recipe",
     "get_recipe_lock",
+    "recipe_from_yaml",
+    # Connectors
     "get_recipes_default_connector",
+    # Models
+    "Recipe",
 ]

--- a/dcpy/lifecycle/builds/config.py
+++ b/dcpy/lifecycle/builds/config.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+# Build configuration constants
+BUILD_REPO = "data-engineering"
+
+BUILD_ARTIFACT_DIRS = ["target"]
+
+BUILD_DBS = [
+    "db-cbbr",
+    "db-cdbg",
+    "db-ceqr",
+    "db-checkbook",
+    "db-colp",
+    "db-cpdb",
+    "db-devdb",
+    "db-facilities",
+    "db-green-fast-track",
+    # "db-cscl", we need to preserve schemas while this data product is in development
+    "db-pluto",
+    "db-template",
+    "db-ztl",
+    "kpdb",
+]
+
+
+def get_recipe_path(product_path: Path, recipe_name: str | None = None) -> Path:
+    """Get the path to a recipe file for a product.
+
+    Args:
+        product_path: Path to the product directory
+        recipe_name: Name of the recipe file (e.g., "my-recipe.yml").
+                    If None, defaults to "recipe.yml"
+
+    Returns:
+        Path to the recipe file
+    """
+    if recipe_name is None:
+        recipe_name = "recipe"
+    return product_path / f"{recipe_name}.yml"
+
+
+def get_recipe_lock_path(product_path: Path, recipe_name: str | None = None) -> Path:
+    """Get the path to a recipe lockfile for a product.
+
+    Args:
+        product_path: Path to the product directory
+        recipe_name: Name of the recipe file (e.g., "my-recipe.yml").
+                    If None, defaults to "recipe.yml"
+
+    Returns:
+        Path to the recipe lockfile (e.g., "recipe.lock.yml" or "my-recipe.lock.yml")
+    """
+    recipe_path = get_recipe_path(product_path, recipe_name)
+    # Insert .lock before .yml extension
+    return recipe_path.parent / f"{recipe_path.stem}.lock.yml"
+
+
+def get_build_metadata_path(product_path: Path) -> Path:
+    """Get the path to the build metadata file for a product.
+
+    Args:
+        product_path: Path to the product directory
+
+    Returns:
+        Path to the build_metadata.json file
+    """
+    return product_path / "build_metadata.json"

--- a/dcpy/lifecycle/builds/config.py
+++ b/dcpy/lifecycle/builds/config.py
@@ -1,26 +1,7 @@
 from pathlib import Path
 
 # Build configuration constants
-BUILD_REPO = "data-engineering"
-
 BUILD_ARTIFACT_DIRS = ["target"]
-
-BUILD_DBS = [
-    "db-cbbr",
-    "db-cdbg",
-    "db-ceqr",
-    "db-checkbook",
-    "db-colp",
-    "db-cpdb",
-    "db-devdb",
-    "db-facilities",
-    "db-green-fast-track",
-    # "db-cscl", we need to preserve schemas while this data product is in development
-    "db-pluto",
-    "db-template",
-    "db-ztl",
-    "kpdb",
-]
 
 
 def get_recipe_path(product_path: Path, recipe_name: str | None = None) -> Path:

--- a/dcpy/lifecycle/builds/export.py
+++ b/dcpy/lifecycle/builds/export.py
@@ -9,12 +9,8 @@ import typer
 from shapely import MultiPoint, MultiPolygon
 
 from dcpy.lifecycle import config
-from dcpy.lifecycle.builds import (
-    BUILD_ARTIFACT_DIRS,
-    BUILD_PLAN_ARTIFACTS,
-    metadata,
-    plan,
-)
+from dcpy.lifecycle.builds import config as build_config
+from dcpy.lifecycle.builds import metadata, plan
 from dcpy.lifecycle.builds.models import ExportDataset, ExportFormat
 from dcpy.utils import postgres
 from dcpy.utils.logging import logger
@@ -224,14 +220,14 @@ def export(
         shutil.rmtree(output_folder)
     output_folder.mkdir(parents=True)
 
-    for filename in BUILD_PLAN_ARTIFACTS:
+    for filename in plan.ARTIFACTS:
         source_path = Path(recipe_lock_path).parent / filename
         if not source_path.exists():
             logger.warning(f"Expected build artifact {source_path} does not exist")
             continue
         shutil.copy(source_path, output_folder / filename)
 
-    for dirname in BUILD_ARTIFACT_DIRS:
+    for dirname in build_config.BUILD_ARTIFACT_DIRS:
         source_dir = Path(recipe_lock_path).parent / dirname
         if source_dir.is_dir():
             shutil.copytree(source_dir, output_folder / dirname)

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -14,6 +14,7 @@ from jinja2 import (
 )
 
 from dcpy.connectors.edm import publishing, recipes
+from dcpy.lifecycle.builds import config
 from dcpy.lifecycle.builds.connector import get_recipes_default_connector
 from dcpy.lifecycle.builds.models import (
     InputDatasetDefaults,
@@ -29,6 +30,12 @@ RECIPE_FILE_TYPE_PREFERENCE = [
     recipes.DatasetType.pg_dump,
     recipes.DatasetType.parquet,
     recipes.DatasetType.csv,
+]
+
+ARTIFACTS = [
+    "recipe.lock.yml",
+    "build_metadata.json",
+    "source_data_versions.csv",
 ]
 
 
@@ -319,6 +326,56 @@ def recipe_from_yaml(
     recipe = Recipe(**s)
     _apply_recipe_defaults(recipe)
     return recipe
+
+
+def get_recipe(
+    product_path: Path,
+    recipe_name: str | None = None,
+    render_templates: bool = True,
+    vars: dict[str, str] | None = None,
+) -> Recipe:
+    """Load a recipe file as a pydantic Recipe model.
+
+    Args:
+        product_path: Path to the product directory
+        recipe_name: Name of the recipe file (e.g., "my-recipe").
+                    If None, defaults to "recipe"
+        render_templates: If True, render Jinja2 templates from vars or BUILD_ENV_* vars.
+                         If False, preserve templates as strings (for DAG generation).
+        vars: Optional dict of template variables. If provided, these are used instead
+              of BUILD_ENV_* environment variables.
+
+    Returns:
+        Recipe pydantic model
+    """
+    recipe_path = config.get_recipe_path(product_path, recipe_name)
+    return recipe_from_yaml(recipe_path, render_templates=render_templates, vars=vars)
+
+
+def get_recipe_lock(
+    product_path: Path,
+    recipe_name: str | None = None,
+    render_templates: bool = True,
+    vars: dict[str, str] | None = None,
+) -> Recipe:
+    """Load a recipe lockfile as a pydantic Recipe model.
+
+    Args:
+        product_path: Path to the product directory
+        recipe_name: Name of the recipe file (e.g., "my-recipe").
+                    If None, defaults to "recipe"
+        render_templates: If True, render Jinja2 templates from vars or BUILD_ENV_* vars.
+                         If False, preserve templates as strings (for DAG generation).
+        vars: Optional dict of template variables. If provided, these are used instead
+              of BUILD_ENV_* environment variables.
+
+    Returns:
+        Recipe pydantic model from the lockfile
+    """
+    recipe_lock_path = config.get_recipe_lock_path(product_path, recipe_name)
+    return recipe_from_yaml(
+        recipe_lock_path, render_templates=render_templates, vars=vars
+    )
 
 
 def generate_lock_file(recipe_file: Path, recipe: Recipe) -> Path:


### PR DESCRIPTION
tweaks `dcpy.lifecycle.builds`
- remove child imports from ancestor "__init__" files. 
- moves BUILD_DBS and BUILD_REPO to the ops folder, where its referenced