### PR TITLE
fix failing nightly QA builds

### DIFF
--- a/.github/workflows/cscl_build.yml
+++ b/.github/workflows/cscl_build.yml
@@ -84,4 +84,4 @@ jobs:
         python3 poc_validation/summarize_diffs.py
 
     - name: Upload
-      run: python3 -m dcpy.connectors.edm.publishing upload --product db-cscl --acl public-read
+      run: python3 -m dcpy.connectors.edm.publishing upload --product db-cscl --acl public-read --max_files 1000

--- a/products/ceqr/recipe.yml
+++ b/products/ceqr/recipe.yml
@@ -19,7 +19,6 @@ inputs:
     - name: dcp_green_fast_track_lots
     - name: dcp_projects
     - name: dcp_housing
-      file_type: pg_dump
     - name: dcp_zoningdistricts
     - name: dcp_commercialoverlay
     - name: dcp_specialpurpose

--- a/products/facilities/recipe.yml
+++ b/products/facilities/recipe.yml
@@ -188,7 +188,6 @@ inputs:
       module: facdb.pipelines
       function: dispatch
   - name: dycd_service_sites
-    file_type: csv # not migrated to ingest
     preprocessor:
       module: facdb.pipelines
       function: dispatch

--- a/products/knownprojects/sql/dcp_housing.sql
+++ b/products/knownprojects/sql/dcp_housing.sql
@@ -51,7 +51,7 @@ bbl_join AS (
     SELECT
         a.job_number,
         a.bbl,
-        a.wkb_geometry AS point_geom,
+        a.geom AS point_geom,
         b.wkb_geometry AS bbl_join_geom
     FROM dcp_housing_filtered AS a
     LEFT JOIN dcp_mappluto_wi AS b


### PR DESCRIPTION
resolves #2189

- cscl_build.yml: pass --max_files 1000 to Upload step (output is 947 files, over the 150 default)
- facilities/recipe.yml: drop file_type: csv from dycd_service_sites (now ingest-archived as parquet)
- ceqr/recipe.yml: drop file_type: pg_dump from dcp_housing (25Q4 archived as parquet)
- knownprojects/sql/dcp_housing.sql: a.wkb_geometry -> a.geom (ingest renames geometry column to geom)