### PR TITLE
Refactor apps off of direct connector references -> lifecycle

### DIFF
--- a/admin/ops/setup_dev_bucket.py
+++ b/admin/ops/setup_dev_bucket.py
@@ -12,6 +12,8 @@ os.environ["RECIPES_BUCKET"] = PROD_RECIPES_BUCKET
 os.environ["PUBLISHING_BUCKET"] = PROD_PUBLISHING_BUCKET
 
 from dcpy import configuration
+
+# TODO: publishing connector refactor - replace with: from dcpy.lifecycle.builds import published
 from dcpy.connectors.edm import publishing, recipes
 from dcpy.connectors.edm.models import (
     BuildKey,
@@ -91,6 +93,7 @@ def resolve_latest_publish(target_bucket: str, data_product: str):
     importlib.reload(configuration)
     assert configuration.PUBLISHING_BUCKET != PROD_PUBLISHING_BUCKET
     input = PublishKey(product=data_product, version="latest")
+    # TODO: publishing connector refactor - replace with: published.get_latest_version(data_product)
     latest = publishing.get_latest_version(data_product)
     assert latest
     resolved = PublishKey(product=data_product, version=latest)
@@ -197,6 +200,7 @@ def clone_data_product_by_key(
         target_path=key.path + "/",
     )
     if include_recipe_datasets:
+        # TODO: publishing connector refactor - replace with: published.get_source_data_versions(key.product, key.version)
         for index, row in publishing.get_source_data_versions(key).iterrows():
             dataset_id = str(index)
             clone_recipe(target_bucket, dataset_id, row["version"])

--- a/apps/qa/src/pages/colp/helpers.py
+++ b/apps/qa/src/pages/colp/helpers.py
@@ -1,17 +1,18 @@
 import pandas as pd
 import streamlit as st
+from src.shared.utils.publishing import read_csv_cached
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey
 
 PRODUCT = "db-colp"
 
 
-def get_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
+def get_data(product_key: ProductKey) -> dict[str, pd.DataFrame]:
     rv = {}
 
     def csv_from_DO(file):
         try:
-            return publishing.read_csv(product_key, "qaqc/" + file)
+            return read_csv_cached(product_key, "qaqc/" + file)
         except FileNotFoundError:
             st.warning(f"{file} not found")
 

--- a/apps/qa/src/pages/cpdb/helpers.py
+++ b/apps/qa/src/pages/cpdb/helpers.py
@@ -1,7 +1,8 @@
 import pandas as pd
 from dotenv import load_dotenv
+from src.shared.utils.publishing import read_csv_cached, read_shapefile_cached
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey
 
 load_dotenv()
 
@@ -30,8 +31,8 @@ where would this list comes from? """
 
 
 def get_data(
-    staging_product_key: publishing.ProductKey,
-    reference_product_key: publishing.ProductKey,
+    staging_product_key: ProductKey,
+    reference_product_key: ProductKey,
 ) -> dict:
     rv = {}
     tables = {
@@ -42,16 +43,16 @@ def get_data(
     }
 
     for t in tables["analysis"]:
-        rv[t] = publishing.read_csv(staging_product_key, f"analysis/{t}.csv")
-        rv["pre_" + t] = publishing.read_csv(reference_product_key, f"analysis/{t}.csv")
+        rv[t] = read_csv_cached(staging_product_key, f"analysis/{t}.csv")
+        rv["pre_" + t] = read_csv_cached(reference_product_key, f"analysis/{t}.csv")
 
     for t in tables["others"]:
-        rv[t] = publishing.read_csv(staging_product_key, f"{t}.csv")
-        rv["pre_" + t] = publishing.read_csv(reference_product_key, f"{t}.csv")
+        rv[t] = read_csv_cached(staging_product_key, f"{t}.csv")
+        rv["pre_" + t] = read_csv_cached(reference_product_key, f"{t}.csv")
     for t in tables["no_version_compare"]:
-        rv[t] = publishing.read_csv(staging_product_key, f"{t}.csv")
+        rv[t] = read_csv_cached(staging_product_key, f"{t}.csv")
     for t in tables["geometries"]:
-        rv[t] = publishing.read_shapefile(staging_product_key, f"{t}.shp.zip")
+        rv[t] = read_shapefile_cached(staging_product_key, f"{t}.shp.zip")
     return rv
 
 

--- a/apps/qa/src/pages/cscl/helpers.py
+++ b/apps/qa/src/pages/cscl/helpers.py
@@ -1,8 +1,11 @@
+from io import BytesIO
+
 import pandas as pd
 import streamlit as st
 
-from dcpy.connectors.edm import publishing
+from dcpy.configuration import PUBLISHING_BUCKET
 from dcpy.connectors.edm.models import BuildKey
+from dcpy.lifecycle.builds import builds
 from dcpy.utils import postgres, s3
 
 PRODUCT = "db-cscl"
@@ -38,18 +41,16 @@ DBT_QA_TABLES: dict[str, list[str]] = {
 
 
 def get_builds() -> list[str]:
-    return publishing.get_builds(PRODUCT)
+    return builds.list_builds(PRODUCT)
 
 
 def get_build_version(build: str) -> str:
-    product_key = BuildKey(PRODUCT, build)
-    return publishing.get_build_metadata(product_key).version
+    return builds.get_build_metadata(PRODUCT, build).version
 
 
 @st.cache_data(show_spinner=False, ttl=60)
 def get_diffs_summary(build: str) -> pd.DataFrame:
-    product_key = BuildKey(PRODUCT, build)
-    return publishing.read_csv(product_key, "validation_output/diffs_summary.csv")
+    return builds.read_csv(PRODUCT, build, "validation_output/diffs_summary.csv")
 
 
 @st.cache_data(show_spinner=False, ttl=60)
@@ -59,10 +60,10 @@ def get_diff_rows(build: str, filename: str) -> list[str]:
     Equivalent to comm -23 <(sort dev) <(sort prod).
     Cached so repeated selections don't re-fetch from S3.
     """
-    build_key = BuildKey(PRODUCT, build)
     prod_version = get_build_version(build)
 
-    dev_buffer = publishing.get_file(build_key, filename)
+    dev_file_bytes = builds.get_file(PRODUCT, build, filename)
+    dev_buffer = BytesIO(dev_file_bytes)
     dev_lines = {
         line
         for line in dev_buffer.read().decode("latin-1").splitlines()
@@ -86,7 +87,7 @@ def get_build_output_zip_url(build: str) -> str:
     from dcpy.utils import s3
 
     build_key = BuildKey(PRODUCT, build)
-    bucket = publishing.PUBLISHING_BUCKET
+    bucket = PUBLISHING_BUCKET
     key = f"{build_key.path}/output.zip"
     return s3.get_presigned_get_url(bucket, key)
 

--- a/apps/qa/src/pages/devdb/helpers.py
+++ b/apps/qa/src/pages/devdb/helpers.py
@@ -1,8 +1,9 @@
 import json
 
 import pandas as pd
+from src.shared.utils.publishing import read_csv_cached
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey
 
 PRODUCT = "db-developments"
 
@@ -168,23 +169,21 @@ QAQC_CHECK_DICTIONARY = {
 }
 
 
-def get_latest_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
+def get_latest_data(product_key: ProductKey) -> dict[str, pd.DataFrame]:
     rv = {}
 
-    rv["qaqc_app"] = publishing.read_csv(
+    rv["qaqc_app"] = read_csv_cached(
         product_key, "qaqc_app.csv", dtype={"job_number": "str"}
     )
 
-    rv["qaqc_historic"] = publishing.read_csv(product_key, "qaqc_historic.csv")
+    rv["qaqc_historic"] = read_csv_cached(product_key, "qaqc_historic.csv")
 
-    rv["qaqc_field_distribution"] = publishing.read_csv(
+    rv["qaqc_field_distribution"] = read_csv_cached(
         product_key,
         "qaqc_field_distribution.csv",
         converters={"result": json.loads},
     )
 
-    rv["qaqc_quarter_check"] = publishing.read_csv(
-        product_key, "qaqc_quarter_check.csv"
-    )
+    rv["qaqc_quarter_check"] = read_csv_cached(product_key, "qaqc_quarter_check.csv")
 
     return rv

--- a/apps/qa/src/pages/edde/helpers.py
+++ b/apps/qa/src/pages/edde/helpers.py
@@ -5,6 +5,8 @@ import pandas as pd
 import streamlit as st
 
 from dcpy.configuration import PUBLISHING_BUCKET
+
+# TODO: publishing connector refactor - EDDE uses non-standard folder structure, decide if we should keep legacy wrapper
 from dcpy.connectors.edm import publishing
 from dcpy.utils import s3
 from dcpy.utils.git import github
@@ -58,6 +60,7 @@ def get_demographics_data(branch: str, version: str):
             category_data[geography] = {}
             for match in grouped_matches:
                 year = match.group(2)
+                # TODO: publishing connector refactor - EDDE non-standard path structure
                 category_data[geography][year] = publishing.read_csv_legacy(
                     PRODUCT,
                     f"{branch}/{version}",
@@ -74,6 +77,7 @@ def get_other_data(branch: str, version: str):
     for category in other_categories:
         category_data = {}
         for geography in geographies:
+            # TODO: publishing connector refactor - EDDE non-standard path structure
             category_data[geography] = publishing.read_csv_legacy(
                 PRODUCT,
                 f"{branch}/{version}",

--- a/apps/qa/src/pages/facdb/helpers.py
+++ b/apps/qa/src/pages/facdb/helpers.py
@@ -1,16 +1,17 @@
 import pandas as pd
+from src.shared.utils.publishing import read_csv_cached
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey
 
 PRODUCT = "db-facilities"
 REPO_NAME = "data-engineering"
 
 
 def get_latest_data(
-    product_key: publishing.ProductKey,
+    product_key: ProductKey,
 ) -> tuple[dict[str, dict[str, object]], pd.DataFrame, pd.DataFrame]:
     def read_csv(csv):
-        return publishing.read_csv(product_key, f"{csv}.csv")
+        return read_csv_cached(product_key, f"{csv}.csv")
 
     qc_diff = read_csv("qc_diff")
     qc_captype = read_csv("qc_captype")

--- a/apps/qa/src/pages/pluto/helpers.py
+++ b/apps/qa/src/pages/pluto/helpers.py
@@ -2,18 +2,18 @@ import json
 from datetime import datetime
 
 import pandas as pd
-from src.shared.utils.publishing import unzip_csv
+from src.shared.utils.publishing import get_zip_cached, read_csv_cached, unzip_csv
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey
 
 PRODUCT = "db-pluto"
 
 
-def get_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
+def get_data(product_key: ProductKey) -> dict[str, pd.DataFrame]:
     data = {}
 
     def read_pluto_csv(qaqc_type, **kwargs):
-        return publishing.read_csv(
+        return read_csv_cached(
             product_key,
             f"qaqc/qaqc_{qaqc_type}.csv",
             true_values=["t"],
@@ -37,7 +37,7 @@ def get_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
 
     data = data | get_changes(product_key)
 
-    data["source_data_versions"] = publishing.read_csv(
+    data["source_data_versions"] = read_csv_cached(
         product_key, "source_data_versions.csv"
     )
 
@@ -58,9 +58,9 @@ def get_data(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
     return data
 
 
-def get_changes(product_key: publishing.ProductKey) -> dict[str, pd.DataFrame]:
+def get_changes(product_key: ProductKey) -> dict[str, pd.DataFrame]:
     changes = {}
-    pluto_changes_zip = publishing.get_zip(product_key, "pluto_changes.zip")
+    pluto_changes_zip = get_zip_cached(product_key, "pluto_changes.zip")
     changes["pluto_changes_applied"] = unzip_csv(
         csv_filename="pluto_changes_applied.csv",
         zipfile=pluto_changes_zip,

--- a/apps/qa/src/pages/ztl/components/outputs_report.py
+++ b/apps/qa/src/pages/ztl/components/outputs_report.py
@@ -1,8 +1,10 @@
 import plotly.graph_objects as go
 import streamlit as st
 from src.shared.constants import COLOR_SCHEME
+from src.shared.utils.publishing import read_csv_cached
+from src.shared.utils.source_report import get_source_data_versions_cached
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey, PublishKey
 
 PRODUCT = "db-zoningtaxlots"
 
@@ -37,9 +39,9 @@ ZONING_FIELD_CATEGORIES = {
 }
 
 
-def output_report(product_key: publishing.ProductKey):
+def output_report(product_key: ProductKey):
     def read_ztl_csv(file, **kwargs):
-        return publishing.read_csv(product_key, file, **kwargs)
+        return read_csv_cached(product_key, file, **kwargs)
 
     bbldiff = read_ztl_csv(
         "qc_bbldiffs.csv",
@@ -170,8 +172,8 @@ def output_report(product_key: publishing.ProductKey):
 
     # SOURCE DATA REPORT  ====================================
     st.header("Source Data Versions")
-    source_data_versions = publishing.get_source_data_versions(
-        publishing.PublishKey(PRODUCT, "latest")
+    source_data_versions = get_source_data_versions_cached(
+        PublishKey(PRODUCT, "latest")
     )
     st.table(source_data_versions)
     # SOURCE DATA REPORT  ====================================

--- a/apps/qa/src/pages/ztl/ztl.py
+++ b/apps/qa/src/pages/ztl/ztl.py
@@ -3,7 +3,7 @@ import streamlit as st
 from src.shared.components import build_outputs, sidebar
 from src.shared.components.sources_report import sources_report
 
-from dcpy.connectors.edm import publishing
+from dcpy.lifecycle.builds import published
 
 from .components.outputs_report import PRODUCT, output_report
 
@@ -18,7 +18,7 @@ def ztl():
     col1.markdown(
         f"""[![Build]({DATASET_REPO_URL}/actions/workflows/zoningtaxlots_build.yml/badge.svg)]({DATASET_REPO_URL}/actions/workflows/zoningtaxlots_build.yml)"""
     )
-    col2.markdown(f"latest build version: `{publishing.get_latest_version(PRODUCT)}`")
+    col2.markdown(f"latest build version: `{published.get_latest_version(PRODUCT)}`")
     col3.markdown(f"[github repo]({DATASET_REPO_URL})")
 
     report_type = st.sidebar.radio(

--- a/apps/qa/src/shared/components/build_outputs.py
+++ b/apps/qa/src/shared/components/build_outputs.py
@@ -4,15 +4,19 @@ import geopandas as gpd
 import leafmap.foliumap as lmf
 import pandas as pd
 import streamlit as st
-from src.shared.utils.publishing import read_csv_cached, read_file_metadata
+from src.shared.utils.publishing import (
+    get_data_directory_url,
+    read_csv_cached,
+    read_file_metadata,
+)
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey
 from dcpy.utils.formats import Geometry
 from dcpy.utils.geospatial import geometry, mapping, transform
 
 
-def data_directory_link(product_key: publishing.ProductKey):
-    data_url = publishing.get_data_directory_url(product_key)
+def data_directory_link(product_key: ProductKey):
+    data_url = get_data_directory_url(product_key)
     st.markdown(
         f"""
         [Link]({data_url}) to the dataset in Digital Ocean.        

--- a/apps/qa/src/shared/components/sidebar.py
+++ b/apps/qa/src/shared/components/sidebar.py
@@ -1,11 +1,10 @@
 import streamlit as st
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import BuildKey, DraftKey, ProductKey, PublishKey
+from dcpy.lifecycle.builds import builds, drafts, published
 
 
-def data_selection(
-    product: str, section_label: str | None = None
-) -> publishing.ProductKey | None:
+def data_selection(product: str, section_label: str | None = None) -> ProductKey | None:
     if section_label is not None:
         st.sidebar.title(section_label)
     product_type = st.sidebar.selectbox(
@@ -17,18 +16,18 @@ def data_selection(
     match product_type:
         case "Build":
             label = "Select a build"
-            options = publishing.get_builds(product)
+            options = builds.list_builds(product)
             select = st.sidebar.selectbox(label, options, key=f"{section_label}_output")
             if select:
-                return publishing.BuildKey(product, select)
+                return BuildKey(product, select)
         case "Draft":
             label = "Select a version"
-            options = publishing.get_draft_versions(product)
+            options = drafts.get_dataset_versions(product)
             version_select = st.sidebar.selectbox(
                 label, options, key=f"{section_label}_version"
             )
             if version_select:
-                draft_revision_options = publishing.get_draft_version_revisions(
+                draft_revision_options = drafts.get_dataset_version_revisions(
                     product, version_select
                 )
                 draft_revision_label = "Select a draft"
@@ -38,16 +37,12 @@ def data_selection(
                     key=f"{section_label}_output",
                 )
                 if subversion_select:
-                    return publishing.DraftKey(
-                        product, version_select, subversion_select
-                    )
+                    return DraftKey(product, version_select, subversion_select)
         case "Published":
             label = "Select a version"
-            options = publishing.get_published_versions(
-                product=product, exclude_latest=False
-            )
+            options = published.get_versions(product=product, exclude_latest=False)
             select = st.sidebar.selectbox(label, options, key=f"{section_label}_output")
             if select:
-                return publishing.PublishKey(product, select)
+                return PublishKey(product, select)
 
     return None

--- a/apps/qa/src/shared/components/sources_report.py
+++ b/apps/qa/src/shared/components/sources_report.py
@@ -9,13 +9,13 @@ from src.shared.utils.source_report import (
     load_source_data_to_compare,
 )
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import ProductKey
 from dcpy.utils import postgres
 
 
 def sources_report(
-    reference_product_key: publishing.ProductKey,
-    staging_product_key: publishing.ProductKey,
+    reference_product_key: ProductKey,
+    staging_product_key: ProductKey,
 ):
     print("STARTING Source Data Review")
     st.header("Source Data Review")

--- a/apps/qa/src/shared/utils/publishing.py
+++ b/apps/qa/src/shared/utils/publishing.py
@@ -1,7 +1,8 @@
+from urllib.parse import urlencode, urljoin
 from zipfile import ZipFile
 
+import geopandas as gpd
 import pandas as pd
-import streamlit as st
 
 from dcpy.configuration import PUBLISHING_BUCKET
 from dcpy.connectors.edm.models import BuildKey, DraftKey, ProductKey, PublishKey
@@ -19,9 +20,12 @@ def read_file_metadata(product_key: ProductKey, filepath: str) -> s3.Metadata:
     return s3.get_metadata(PUBLISHING_BUCKET, f"{product_key.path}/{filepath}")
 
 
-@st.cache_data(ttl=600)
 def read_csv_cached(product_key: ProductKey, filepath: str, **kwargs) -> pd.DataFrame:
-    """Read CSV from any lifecycle stage (builds, drafts, or published)."""
+    """Read CSV from any lifecycle stage (builds, drafts, or published).
+
+    Note: Caching removed from this wrapper to support unhashable kwargs like 'converters'.
+    Caching should be done at the component level if needed.
+    """
     if isinstance(product_key, BuildKey):
         return builds.read_csv(
             product_key.product, product_key.build, filepath, **kwargs
@@ -40,3 +44,53 @@ def read_csv_cached(product_key: ProductKey, filepath: str, **kwargs) -> pd.Data
         )
     else:
         raise TypeError(f"Unsupported product key type: {type(product_key)}")
+
+
+def read_shapefile_cached(product_key: ProductKey, filepath: str) -> gpd.GeoDataFrame:
+    """Read shapefile from any lifecycle stage (builds, drafts, or published).
+
+    Note: Caching removed - GeoDataFrames should be cached at component level if needed.
+    """
+    if isinstance(product_key, BuildKey):
+        return builds.read_shapefile(product_key.product, product_key.build, filepath)
+    elif isinstance(product_key, DraftKey):
+        return drafts.read_shapefile(
+            product_key.product, product_key.version, product_key.revision, filepath
+        )
+    elif isinstance(product_key, PublishKey):
+        return published.read_shapefile(
+            product_key.product, product_key.version, filepath
+        )
+    else:
+        raise TypeError(f"Unsupported product key type: {type(product_key)}")
+
+
+def get_zip_cached(product_key: ProductKey, filepath: str) -> ZipFile:
+    """Get ZipFile from any lifecycle stage (builds, drafts, or published).
+
+    Note: Caching removed - ZipFile objects are not serializable by st.cache_data.
+    If caching is needed, extract the data first and cache that at component level.
+    """
+    if isinstance(product_key, BuildKey):
+        return builds.get_zip(product_key.product, product_key.build, filepath)
+    elif isinstance(product_key, DraftKey):
+        return drafts.get_zip(
+            product_key.product, product_key.version, product_key.revision, filepath
+        )
+    elif isinstance(product_key, PublishKey):
+        return published.get_zip(product_key.product, product_key.version, filepath)
+    else:
+        raise TypeError(f"Unsupported product key type: {type(product_key)}")
+
+
+def get_data_directory_url(product_key: ProductKey) -> str:
+    """Get Digital Ocean data directory URL for any lifecycle stage."""
+    assert PUBLISHING_BUCKET, "PUBLISHING_BUCKET must be defined"
+    path = product_key.path
+    if not path.endswith("/"):
+        path += "/"
+    endpoint = urlencode({"path": path})
+    url = urljoin(
+        f"https://cloud.digitalocean.com/spaces/{PUBLISHING_BUCKET}", "?" + endpoint
+    )
+    return url

--- a/apps/qa/src/shared/utils/publishing.py
+++ b/apps/qa/src/shared/utils/publishing.py
@@ -4,7 +4,8 @@ import pandas as pd
 import streamlit as st
 
 from dcpy.configuration import PUBLISHING_BUCKET
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import BuildKey, DraftKey, ProductKey, PublishKey
+from dcpy.lifecycle.builds import builds, drafts, published
 from dcpy.utils import s3
 
 
@@ -13,15 +14,29 @@ def unzip_csv(csv_filename: str, zipfile: ZipFile) -> pd.DataFrame:
         return pd.read_csv(csv, true_values=["t"], false_values=["f"])
 
 
-def read_file_metadata(
-    product_key: publishing.ProductKey, filepath: str
-) -> s3.Metadata:
+def read_file_metadata(product_key: ProductKey, filepath: str) -> s3.Metadata:
     assert PUBLISHING_BUCKET, "PUBLISHING_BUCKET must be defined"
     return s3.get_metadata(PUBLISHING_BUCKET, f"{product_key.path}/{filepath}")
 
 
 @st.cache_data(ttl=600)
-def read_csv_cached(
-    product_key: publishing.ProductKey, filepath: str, **kwargs
-) -> pd.DataFrame:
-    return publishing.read_csv(product_key, filepath, **kwargs)
+def read_csv_cached(product_key: ProductKey, filepath: str, **kwargs) -> pd.DataFrame:
+    """Read CSV from any lifecycle stage (builds, drafts, or published)."""
+    if isinstance(product_key, BuildKey):
+        return builds.read_csv(
+            product_key.product, product_key.build, filepath, **kwargs
+        )
+    elif isinstance(product_key, DraftKey):
+        return drafts.read_csv(
+            product_key.product,
+            product_key.version,
+            product_key.revision,
+            filepath,
+            **kwargs,
+        )
+    elif isinstance(product_key, PublishKey):
+        return published.read_csv(
+            product_key.product, product_key.version, filepath, **kwargs
+        )
+    else:
+        raise TypeError(f"Unsupported product key type: {type(product_key)}")

--- a/apps/qa/src/shared/utils/source_report.py
+++ b/apps/qa/src/shared/utils/source_report.py
@@ -5,8 +5,14 @@ import pandas as pd
 from src import QAQC_DB_SCHEMA_SOURCE_DATA
 from src.shared.constants import construct_dataset_by_version
 
-from dcpy.connectors.edm import publishing, recipes
+from dcpy.connectors.edm.models import (
+    BuildKey,
+    DatasetType,
+    ProductKey,
+    PublishKey,
+)
 from dcpy.lifecycle import data_loader
+from dcpy.lifecycle.builds import builds, published
 from dcpy.lifecycle.builds.models import InputDataset
 
 
@@ -15,25 +21,35 @@ def dataframe_style_source_report_results(value) -> str:
     return f"background-color: {color}"
 
 
-def get_source_dataset_ids(product_key: publishing.ProductKey) -> list[str]:
+def _get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
+    """Helper to get source data versions from any lifecycle stage."""
+    if isinstance(product_key, BuildKey):
+        return builds.get_source_data_versions(product_key.product, product_key.build)
+    elif isinstance(product_key, PublishKey):
+        return published.get_source_data_versions(
+            product_key.product, product_key.version
+        )
+    else:
+        raise TypeError(
+            f"Unsupported product key type for source data versions: {type(product_key)}"
+        )
+
+
+def get_source_dataset_ids(product_key: ProductKey) -> list[str]:
     """Gets names of source products used in build
     TODO this should not come from publishing, but should be defined in code for each data product
     """
-    source_data_versions = publishing.get_source_data_versions(product_key)
+    source_data_versions = _get_source_data_versions(product_key)
     return sorted(source_data_versions.index.values.tolist())
 
 
 def get_source_data_versions_to_compare(
-    reference_product_key: publishing.ProductKey,
-    staging_product_key: publishing.ProductKey,
+    reference_product_key: ProductKey,
+    staging_product_key: ProductKey,
 ):
     # TODO (nice-to-have) add column with links to data-library yaml templates
-    reference_source_data_versions = publishing.get_source_data_versions(
-        reference_product_key
-    )
-    latest_source_data_versions = publishing.get_source_data_versions(
-        staging_product_key
-    )
+    reference_source_data_versions = _get_source_data_versions(reference_product_key)
+    latest_source_data_versions = _get_source_data_versions(staging_product_key)
     source_data_versions = reference_source_data_versions.merge(
         latest_source_data_versions,
         left_index=True,
@@ -104,7 +120,7 @@ def load_source_data(dataset_id: str, version: str, pg_client) -> str:
             f"Database already has `{QAQC_DB_SCHEMA_SOURCE_DATA}.{dataset_by_version}`"
         )
 
-    ds_type = recipes.DatasetType.pg_dump
+    ds_type = DatasetType.pg_dump
     data_loader.import_dataset(
         InputDataset(
             id=dataset_id,

--- a/apps/qa/src/shared/utils/source_report.py
+++ b/apps/qa/src/shared/utils/source_report.py
@@ -2,6 +2,7 @@
 from typing import cast
 
 import pandas as pd
+import streamlit as st
 from src import QAQC_DB_SCHEMA_SOURCE_DATA
 from src.shared.constants import construct_dataset_by_version
 
@@ -21,8 +22,8 @@ def dataframe_style_source_report_results(value) -> str:
     return f"background-color: {color}"
 
 
-def _get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
-    """Helper to get source data versions from any lifecycle stage."""
+def get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
+    """Get source data versions from any lifecycle stage (builds or published)."""
     if isinstance(product_key, BuildKey):
         return builds.get_source_data_versions(product_key.product, product_key.build)
     elif isinstance(product_key, PublishKey):
@@ -35,11 +36,17 @@ def _get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
         )
 
 
+@st.cache_data(ttl=600)
+def get_source_data_versions_cached(product_key: ProductKey) -> pd.DataFrame:
+    """Cached version for use in Streamlit apps."""
+    return get_source_data_versions(product_key)
+
+
 def get_source_dataset_ids(product_key: ProductKey) -> list[str]:
     """Gets names of source products used in build
     TODO this should not come from publishing, but should be defined in code for each data product
     """
-    source_data_versions = _get_source_data_versions(product_key)
+    source_data_versions = get_source_data_versions(product_key)
     return sorted(source_data_versions.index.values.tolist())
 
 
@@ -48,8 +55,8 @@ def get_source_data_versions_to_compare(
     staging_product_key: ProductKey,
 ):
     # TODO (nice-to-have) add column with links to data-library yaml templates
-    reference_source_data_versions = _get_source_data_versions(reference_product_key)
-    latest_source_data_versions = _get_source_data_versions(staging_product_key)
+    reference_source_data_versions = get_source_data_versions(reference_product_key)
+    latest_source_data_versions = get_source_data_versions(staging_product_key)
     source_data_versions = reference_source_data_versions.merge(
         latest_source_data_versions,
         left_index=True,

--- a/apps/qa/tests/test_pluto.py
+++ b/apps/qa/tests/test_pluto.py
@@ -4,7 +4,7 @@ from src.pages.pluto.components.expected_value_differences_report import (
 )
 from src.pages.pluto.helpers import PRODUCT, get_data
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import PublishKey
 
 TEST_VERSION_1 = "23v1"
 TEST_VERSION_2 = "22v3"
@@ -12,7 +12,7 @@ TEST_VERSION_2 = "22v3"
 
 @pytest.fixture
 def example_ExpectedValueDifferencesReport():
-    data = get_data(publishing.PublishKey(PRODUCT, TEST_VERSION_1))
+    data = get_data(PublishKey(PRODUCT, TEST_VERSION_1))
     return ExpectedValueDifferencesReport(
         data=data["df_expected"],
         v=TEST_VERSION_1,

--- a/apps/qa/tests/test_source_report.py
+++ b/apps/qa/tests/test_source_report.py
@@ -6,10 +6,11 @@ from src.shared.constants import DATASET_NAMES
 from src.shared.utils.source_report import (
     compare_source_data_columns,
     compare_source_data_row_count,
+    get_source_data_versions,
     get_source_dataset_ids,
 )
 
-from dcpy.connectors.edm import publishing
+from dcpy.connectors.edm.models import PublishKey
 from dcpy.utils.postgres import PostgresClient
 
 REFERENCE_VESION = "2023-04-01"
@@ -38,8 +39,8 @@ TEST_SOURCE_REPORT_RESULTS = {
 
 
 def test_get_source_data_versions_from_build():
-    source_data_versions = publishing.get_source_data_versions(
-        publishing.PublishKey(TEST_DATASET_NAME, TEST_DATASET_REFERENCE_VERSION)
+    source_data_versions = get_source_data_versions(
+        PublishKey(TEST_DATASET_NAME, TEST_DATASET_REFERENCE_VERSION)
     )
     assert isinstance(source_data_versions, pd.DataFrame)
     assert (
@@ -50,7 +51,7 @@ def test_get_source_data_versions_from_build():
 
 def test_get_source_dataset_names():
     source_dataset_names = get_source_dataset_ids(
-        publishing.PublishKey(TEST_DATASET_NAME, REFERENCE_VESION)
+        PublishKey(TEST_DATASET_NAME, REFERENCE_VESION)
     )
     assert source_dataset_names == TEST_DATA_SOURCE_NAMES
 

--- a/dcpy/connectors/edm/publishing.py
+++ b/dcpy/connectors/edm/publishing.py
@@ -1,3 +1,22 @@
+"""
+⚠️  DEPRECATION WARNING ⚠️
+
+This module is DEPRECATED. Use lifecycle stage APIs instead:
+  - dcpy.lifecycle.builds.artifacts.builds
+  - dcpy.lifecycle.builds.artifacts.published
+  - dcpy.lifecycle.builds.artifacts.drafts
+
+For QA apps, use: apps/qa/src/shared/utils/publishing.py
+
+═══════════════════════════════════════════════════════════════════════════════
+TODO: Migrate remaining usages to stage APIs
+
+Search codebase for "TODO: publishing connector refactor" to find all methods
+that still need migration. Each method below is marked with specific references.
+
+═══════════════════════════════════════════════════════════════════════════════
+"""
+
 import json
 import re
 from dataclasses import asdict
@@ -42,6 +61,10 @@ def exists(key: ProductKey) -> bool:
     return s3.folder_exists(_bucket(), key.path)
 
 
+# TODO: publishing connector refactor
+# Used in: products/cscl/poc_validation/run_validation.py
+# Replace with: builds.get_build_metadata(product, build)
+# Search for: "publishing.get_build_metadata"
 def get_build_metadata(product_key: ProductKey) -> BuildMetadata:
     """Retrieve a product build metadata from s3."""
     key = f"{product_key.path}/build_metadata.json"
@@ -61,6 +84,10 @@ def get_version(product_key: ProductKey) -> str:
     return get_build_metadata(product_key).version
 
 
+# TODO: publishing connector refactor
+# Used in: admin/ops/setup_dev_bucket.py
+# Replace with: published.get_latest_version(product)
+# Search for: "publishing.get_latest_version"
 def get_latest_version(product: str) -> str | None:
     """Given product name, gets latest version
     Assumes existence of build_metadata.json in output folder
@@ -96,6 +123,10 @@ def get_plan_version_revisions(product: str, version: str) -> list[str]:
     )
 
 
+# TODO: publishing connector refactor
+# Used in: dcpy/lifecycle/builds/plan.py
+# Replace with: Move this function to drafts.get_revision_label() and import from there
+# Search for: "get_draft_revision_label"
 def get_draft_revision_label(product: str, version: str, revision_num: int) -> str:
     """Given a draft revision number, return draft revision label in s3."""
     draft_revision_label = None
@@ -130,6 +161,10 @@ def get_plan_revision_label(product: str, version: str, revision_num: int) -> st
     return plan_revision_label
 
 
+# TODO: publishing connector refactor
+# Used in: products/template/tests/test_build.py
+# Replace with: builds.list_builds(product)
+# Search for: "publishing.get_builds"
 def get_builds(product: str) -> list[str]:
     return sorted(s3.get_subfolders(_bucket(), f"{product}/build/"), reverse=True)
 
@@ -167,10 +202,18 @@ def get_previous_version(
             )
 
 
+# TODO: publishing connector refactor
+# Used in: products/cscl/poc_validation/run_validation.py, products/template/tests/test_build.py
+# Replace with: builds.get_filenames(product, build) [currently NotImplemented]
+# Search for: "publishing.get_filenames"
 def get_filenames(product_key: ProductKey) -> set[str]:
     return s3.get_filenames(_bucket(), product_key.path)
 
 
+# TODO: publishing connector refactor
+# Used in: admin/ops/setup_dev_bucket.py
+# Replace with: published.get_source_data_versions(product, version)
+# Search for: "publishing.get_source_data_versions"
 def get_source_data_versions(product_key: ProductKey) -> pd.DataFrame:
     """Given product name, gets source data versions of published version"""
     source_data_versions = read_csv(product_key, "source_data_versions.csv", dtype=str)
@@ -270,6 +313,10 @@ def legacy_upload(
             s3.copy_file(bucket, str(key), str(prefix / "latest" / output.name), acl)
 
 
+# TODO: publishing connector refactor
+# Used in: products/checkbook/build_scripts/export.py
+# Replace with: builds.upload(output_path, product, build, acl)
+# Search for: "publishing.upload_build"
 def upload_build(
     output_path: Path,
     product: str,
@@ -500,6 +547,10 @@ def file_exists(product_key: ProductKey, filepath: str) -> bool:
     return s3.object_exists(bucket=_bucket(), key=f"{product_key.path}/{filepath}")
 
 
+# TODO: publishing connector refactor
+# Used in: products/cscl/poc_validation/run_validation.py
+# Replace with: builds.get_file(product, build, filepath) returns bytes (not BytesIO)
+# Search for: "publishing.get_file"
 def get_file(product_key: ProductKey, filepath: str) -> BytesIO:
     """Returns file as BytesIO given product key and path within output folder"""
     return s3.get_file_as_stream(_bucket(), f"{product_key.path}/{filepath}")
@@ -528,6 +579,10 @@ def read_csv(product_key: ProductKey, filepath: str, **kwargs) -> pd.DataFrame:
     return _read_data_helper(f"{product_key.path}/{filepath}", pd.read_csv, **kwargs)
 
 
+# TODO: publishing connector refactor
+# Used in: apps/qa/src/pages/edde/helpers.py (non-standard folder structure)
+# Replace with: Move to EDDE-specific helper or keep minimal wrapper
+# Search for: "publishing.read_csv_legacy"
 def read_csv_legacy(
     product: str, version: str, filepath: str, **kwargs
 ) -> pd.DataFrame:

--- a/dcpy/lifecycle/builds/__init__.py
+++ b/dcpy/lifecycle/builds/__init__.py
@@ -1,3 +1,4 @@
+from dcpy.lifecycle.builds.artifacts import builds, drafts, published
 from dcpy.lifecycle.builds.config import (
     BUILD_ARTIFACT_DIRS,
     get_build_metadata_path,
@@ -14,6 +15,10 @@ from dcpy.lifecycle.builds.plan import (
 )
 
 __all__ = [
+    # Lifecycle stage modules
+    "builds",
+    "published",
+    "drafts",
     # Constants
     "BUILD_ARTIFACT_DIRS",
     "ARTIFACTS",

--- a/dcpy/lifecycle/builds/artifacts/builds.py
+++ b/dcpy/lifecycle/builds/artifacts/builds.py
@@ -3,7 +3,9 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from zipfile import ZipFile
 
+import geopandas as gpd
 import pandas as pd
 import pytz
 import yaml
@@ -354,3 +356,48 @@ def get_source_data_versions(product: str, build: str) -> pd.DataFrame:
     df.set_index("datalibrary_name", inplace=True)
 
     return df
+
+
+def read_shapefile(product: str, build: str, filepath: str) -> gpd.GeoDataFrame:
+    """Read shapefile from a build.
+
+    Args:
+        product: Product name
+        build: Build name
+        filepath: Path to shapefile (typically .shp.zip) within the build
+
+    Returns:
+        GeoDataFrame containing the shapefile data
+    """
+    connector = get_builds_default_connector()
+    with tempfile.NamedTemporaryFile(suffix=".shp.zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=build,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return gpd.read_file(result["path"])
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def get_zip(product: str, build: str, filepath: str) -> ZipFile:
+    """Get ZipFile object from a build.
+
+    Args:
+        product: Product name
+        build: Build name
+        filepath: Path to zip file within the build
+
+    Returns:
+        ZipFile object
+    """
+    file_bytes = get_file(product, build, filepath)
+    from io import BytesIO
+
+    return ZipFile(BytesIO(file_bytes))

--- a/dcpy/lifecycle/builds/artifacts/builds.py
+++ b/dcpy/lifecycle/builds/artifacts/builds.py
@@ -1,8 +1,10 @@
 import json
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pandas as pd
 import pytz
 import yaml
 
@@ -213,3 +215,142 @@ def promote_to_draft(
     #     )
 
     return draft_key
+
+
+# File Query Functions (for QA apps)
+
+
+def list_builds(product: str) -> list[str]:
+    """List all builds for a product."""
+    return get_builds_default_connector().list_versions(product, sort_desc=True)
+
+
+def read_csv(product: str, build: str, filepath: str, **kwargs) -> pd.DataFrame:
+    """Read CSV file from a build.
+
+    Args:
+        product: Product name
+        build: Build name
+        filepath: Path to CSV file within the build
+        **kwargs: Additional arguments passed to pd.read_csv()
+
+    Returns:
+        DataFrame containing the CSV data
+    """
+    connector = get_builds_default_connector()
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=build,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return pd.read_csv(result["path"], **kwargs)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def read_parquet(product: str, build: str, filepath: str, **kwargs) -> pd.DataFrame:
+    """Read Parquet file from a build.
+
+    Args:
+        product: Product name
+        build: Build name
+        filepath: Path to Parquet file within the build
+        **kwargs: Additional arguments passed to pd.read_parquet()
+
+    Returns:
+        DataFrame containing the Parquet data
+    """
+    connector = get_builds_default_connector()
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=build,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return pd.read_parquet(result["path"], **kwargs)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def get_file(product: str, build: str, filepath: str) -> bytes:
+    """Get raw file contents from a build.
+
+    Args:
+        product: Product name
+        build: Build name
+        filepath: Path to file within the build
+
+    Returns:
+        Raw bytes of the file
+    """
+    connector = get_builds_default_connector()
+    with TemporaryDirectory() as temp_dir:
+        result = connector.pull_versioned(
+            key=product,
+            version=build,
+            filepath=filepath,
+            destination_path=Path(temp_dir),
+        )
+        with open(result["path"], "rb") as f:
+            return f.read()
+
+
+def get_filenames(product: str, build: str) -> list[str]:
+    """Get list of all filenames in a build.
+
+    Args:
+        product: Product name
+        build: Build name
+
+    Returns:
+        List of filenames in the build
+    """
+    # This requires listing objects in the connector's storage
+    # We'll need to pull the entire build directory to list files
+    # For now, raise NotImplementedError as this needs connector support
+    raise NotImplementedError(
+        "get_filenames() requires connector-level support for listing objects. "
+        "Use the connector directly if you need this functionality."
+    )
+
+
+def get_source_data_versions(product: str, build: str) -> pd.DataFrame:
+    """Get source data versions from a build.
+
+    Args:
+        product: Product name
+        build: Build name
+
+    Returns:
+        DataFrame with source data versions
+    """
+    df = read_csv(product, build, "source_data_versions.csv", dtype=str)
+
+    # Transform columns (handles both old and new formats)
+    rename_map = {}
+    if "schema_name" in df.columns:
+        rename_map["schema_name"] = "datalibrary_name"
+    elif "dataset" in df.columns:
+        rename_map["dataset"] = "datalibrary_name"
+
+    if "v" in df.columns:
+        rename_map["v"] = "version"
+
+    if rename_map:
+        df.rename(columns=rename_map, inplace=True)
+
+    df.sort_values(by=["datalibrary_name"], ascending=True, inplace=True)
+    df.set_index("datalibrary_name", inplace=True)
+
+    return df

--- a/dcpy/lifecycle/builds/artifacts/drafts.py
+++ b/dcpy/lifecycle/builds/artifacts/drafts.py
@@ -1,3 +1,4 @@
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -158,3 +159,130 @@ def get_metadata(product: str, full_version: str) -> BuildMetadata:
             .get("path")
         )
         return BuildMetadata(**yaml.safe_load(open(md_path).read()))
+
+
+# File Query Functions (for QA apps)
+
+
+def list_all_drafts(product: str) -> list[str]:
+    """List all drafts for a product (returns full version.revision strings).
+
+    Args:
+        product: Product name
+
+    Returns:
+        List of draft version.revision strings (e.g., "24v1.1-my-draft")
+    """
+    return get_drafts_default_connector().list_versions(product, sort_desc=True)
+
+
+def read_csv(
+    product: str, version: str, revision: str, filepath: str, **kwargs
+) -> pd.DataFrame:
+    """Read CSV file from a draft.
+
+    Args:
+        product: Product name
+        version: Version string (e.g., "24v1")
+        revision: Revision string (e.g., "1-my-draft")
+        filepath: Path to CSV file within the draft
+        **kwargs: Additional arguments passed to pd.read_csv()
+
+    Returns:
+        DataFrame containing the CSV data
+    """
+    connector = get_drafts_default_connector()
+    full_version = f"{version}.{revision}"
+
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=full_version,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return pd.read_csv(result["path"], **kwargs)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def read_parquet(
+    product: str, version: str, revision: str, filepath: str, **kwargs
+) -> pd.DataFrame:
+    """Read Parquet file from a draft.
+
+    Args:
+        product: Product name
+        version: Version string (e.g., "24v1")
+        revision: Revision string (e.g., "1-my-draft")
+        filepath: Path to Parquet file within the draft
+        **kwargs: Additional arguments passed to pd.read_parquet()
+
+    Returns:
+        DataFrame containing the Parquet data
+    """
+    connector = get_drafts_default_connector()
+    full_version = f"{version}.{revision}"
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=full_version,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return pd.read_parquet(result["path"], **kwargs)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def get_file(product: str, version: str, revision: str, filepath: str) -> bytes:
+    """Get raw file contents from a draft.
+
+    Args:
+        product: Product name
+        version: Version string (e.g., "24v1")
+        revision: Revision string (e.g., "1-my-draft")
+        filepath: Path to file within the draft
+
+    Returns:
+        Raw bytes of the file
+    """
+    connector = get_drafts_default_connector()
+    full_version = f"{version}.{revision}"
+
+    with TemporaryDirectory() as temp_dir:
+        result = connector.pull_versioned(
+            key=product,
+            version=full_version,
+            filepath=filepath,
+            destination_path=Path(temp_dir),
+        )
+        with open(result["path"], "rb") as f:
+            return f.read()
+
+
+def get_filenames(product: str, version: str, revision: str) -> list[str]:
+    """Get list of all filenames in a draft.
+
+    Args:
+        product: Product name
+        version: Version string (e.g., "24v1")
+        revision: Revision string (e.g., "1-my-draft")
+
+    Returns:
+        List of filenames in the draft
+    """
+    # This requires listing objects in the connector's storage
+    raise NotImplementedError(
+        "get_filenames() requires connector-level support for listing objects. "
+        "Use the connector directly if you need this functionality."
+    )

--- a/dcpy/lifecycle/builds/artifacts/drafts.py
+++ b/dcpy/lifecycle/builds/artifacts/drafts.py
@@ -2,7 +2,9 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from zipfile import ZipFile
 
+import geopandas as gpd
 import pandas as pd
 import yaml
 
@@ -286,3 +288,54 @@ def get_filenames(product: str, version: str, revision: str) -> list[str]:
         "get_filenames() requires connector-level support for listing objects. "
         "Use the connector directly if you need this functionality."
     )
+
+
+def read_shapefile(
+    product: str, version: str, revision: str, filepath: str
+) -> gpd.GeoDataFrame:
+    """Read shapefile from a draft.
+
+    Args:
+        product: Product name
+        version: Version string (e.g., "24v1")
+        revision: Revision string (e.g., "1-my-draft")
+        filepath: Path to shapefile (typically .shp.zip) within the draft
+
+    Returns:
+        GeoDataFrame containing the shapefile data
+    """
+    connector = get_drafts_default_connector()
+    full_version = f"{version}.{revision}"
+
+    with tempfile.NamedTemporaryFile(suffix=".shp.zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=full_version,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return gpd.read_file(result["path"])
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def get_zip(product: str, version: str, revision: str, filepath: str) -> ZipFile:
+    """Get ZipFile object from a draft.
+
+    Args:
+        product: Product name
+        version: Version string (e.g., "24v1")
+        revision: Revision string (e.g., "1-my-draft")
+        filepath: Path to zip file within the draft
+
+    Returns:
+        ZipFile object
+    """
+    file_bytes = get_file(product, version, revision, filepath)
+    from io import BytesIO
+
+    return ZipFile(BytesIO(file_bytes))

--- a/dcpy/lifecycle/builds/artifacts/published.py
+++ b/dcpy/lifecycle/builds/artifacts/published.py
@@ -2,7 +2,9 @@ import json
 import tempfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from zipfile import ZipFile
 
+import geopandas as gpd
 import pandas as pd
 import yaml
 
@@ -425,6 +427,51 @@ def get_file(product: str, version: str, filepath: str) -> bytes:
         )
         with open(result["path"], "rb") as f:
             return f.read()
+
+
+def read_shapefile(product: str, version: str, filepath: str) -> gpd.GeoDataFrame:
+    """Read shapefile from a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+        filepath: Path to shapefile (typically .shp.zip) within the version
+
+    Returns:
+        GeoDataFrame containing the shapefile data
+    """
+    connector = get_published_default_connector()
+    with tempfile.NamedTemporaryFile(suffix=".shp.zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=version,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return gpd.read_file(result["path"])
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def get_zip(product: str, version: str, filepath: str) -> ZipFile:
+    """Get ZipFile object from a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+        filepath: Path to zip file within the version
+
+    Returns:
+        ZipFile object
+    """
+    file_bytes = get_file(product, version, filepath)
+    from io import BytesIO
+
+    return ZipFile(BytesIO(file_bytes))
 
 
 def get_filenames(product: str, version: str) -> list[str]:

--- a/dcpy/lifecycle/builds/artifacts/published.py
+++ b/dcpy/lifecycle/builds/artifacts/published.py
@@ -1,15 +1,19 @@
 import json
+import tempfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pandas as pd
 import yaml
 
 from dcpy.connectors.edm.models import PublishKey
 from dcpy.lifecycle.builds import connector as build_conns
 from dcpy.lifecycle.builds.artifacts.drafts import (
     get_dataset_version_revisions,
-    get_metadata,
     resolve_full_version,
+)
+from dcpy.lifecycle.builds.artifacts.drafts import (
+    get_metadata as get_draft_metadata,
 )
 from dcpy.lifecycle.builds.connector import (
     get_published_default_connector,
@@ -142,7 +146,7 @@ def patch_metadata(
     logger.info(
         f"Patching metadata version {draft_version_revision} with new version {publish_version}"
     )
-    md = get_metadata(product, draft_version_revision)
+    md = get_draft_metadata(product, draft_version_revision)
     md.version = patch_version
     patched_md_path = tmp_dir / "build_metadata_patched.json"
     patched_md_path.write_text(json.dumps(md.model_dump(mode="json"), indent=4))
@@ -312,3 +316,160 @@ def publish(
 
     logger.info(f"Successfully published {product} version {publish_version}")
     return PublishKey(product, publish_version)
+
+
+# File Query Functions (for QA apps)
+
+
+def get_metadata(product: str, version: str) -> BuildMetadata:
+    """Get metadata from a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+
+    Returns:
+        BuildMetadata object
+    """
+    connector = get_published_default_connector()
+    with TemporaryDirectory() as temp_dir:
+        result = connector.pull_versioned(
+            key=product,
+            version=version,
+            filepath=BUILD_METADATA_FILE,
+            destination_path=Path(temp_dir),
+        )
+        metadata_path = result.get("path")
+        if not metadata_path or not Path(metadata_path).exists():
+            raise FileNotFoundError(f"Build metadata not found for {product}/{version}")
+
+        return BuildMetadata(**yaml.safe_load(open(metadata_path).read()))
+
+
+def read_csv(product: str, version: str, filepath: str, **kwargs) -> pd.DataFrame:
+    """Read CSV file from a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+        filepath: Path to CSV file within the version
+        **kwargs: Additional arguments passed to pd.read_csv()
+
+    Returns:
+        DataFrame containing the CSV data
+    """
+    connector = get_published_default_connector()
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=version,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return pd.read_csv(result["path"], **kwargs)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def read_parquet(product: str, version: str, filepath: str, **kwargs) -> pd.DataFrame:
+    """Read Parquet file from a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+        filepath: Path to Parquet file within the version
+        **kwargs: Additional arguments passed to pd.read_parquet()
+
+    Returns:
+        DataFrame containing the Parquet data
+    """
+    connector = get_published_default_connector()
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = connector.pull_versioned(
+            key=product,
+            version=version,
+            filepath=filepath,
+            destination_path=tmp_path,
+        )
+        return pd.read_parquet(result["path"], **kwargs)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def get_file(product: str, version: str, filepath: str) -> bytes:
+    """Get raw file contents from a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+        filepath: Path to file within the version
+
+    Returns:
+        Raw bytes of the file
+    """
+    connector = get_published_default_connector()
+    with TemporaryDirectory() as temp_dir:
+        result = connector.pull_versioned(
+            key=product,
+            version=version,
+            filepath=filepath,
+            destination_path=Path(temp_dir),
+        )
+        with open(result["path"], "rb") as f:
+            return f.read()
+
+
+def get_filenames(product: str, version: str) -> list[str]:
+    """Get list of all filenames in a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+
+    Returns:
+        List of filenames in the version
+    """
+    # This requires listing objects in the connector's storage
+    raise NotImplementedError(
+        "get_filenames() requires connector-level support for listing objects. "
+        "Use the connector directly if you need this functionality."
+    )
+
+
+def get_source_data_versions(product: str, version: str) -> pd.DataFrame:
+    """Get source data versions from a published version.
+
+    Args:
+        product: Product name
+        version: Version string
+
+    Returns:
+        DataFrame with source data versions
+    """
+    df = read_csv(product, version, "source_data_versions.csv", dtype=str)
+
+    # Transform columns (handles both old and new formats)
+    rename_map = {}
+    if "schema_name" in df.columns:
+        rename_map["schema_name"] = "datalibrary_name"
+    elif "dataset" in df.columns:
+        rename_map["dataset"] = "datalibrary_name"
+
+    if "v" in df.columns:
+        rename_map["v"] = "version"
+
+    if rename_map:
+        df.rename(columns=rename_map, inplace=True)
+
+    df.sort_values(by=["datalibrary_name"], ascending=True, inplace=True)
+    df.set_index("datalibrary_name", inplace=True)
+
+    return df

--- a/dcpy/lifecycle/builds/load.py
+++ b/dcpy/lifecycle/builds/load.py
@@ -6,9 +6,8 @@ import pandas as pd
 import typer
 import yaml
 
-from dcpy.connectors.edm import recipes
 from dcpy.lifecycle import data_loader
-from dcpy.lifecycle.builds import metadata, plan
+from dcpy.lifecycle.builds import metadata, plan, utils
 from dcpy.lifecycle.builds.models import (
     BuildMetadata,
     ImportedDataset,
@@ -62,8 +61,7 @@ def import_dataset(
             logger.info(f"Finished inserting {ds.dataset} into postgres")
             return ImportedDataset.from_input(ds, table)
         case InputDatasetDestination.df:
-            # TODO: remove reference to recipes
-            df = recipes.read_df(ds.dataset)
+            df = utils.read_recipe_df(ds.dataset)
             return ImportedDataset.from_input(ds, df)
         case InputDatasetDestination.file:
             return ImportedDataset.from_input(ds, file_path)

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -566,6 +566,7 @@ def _cli_wrapper_repeat_recipe(
         help="Manually specified version. Only needed if attempting to rebuild and older draft where version cannot be easily determined.",
     ),
 ):
+    # TODO: publishing connector refactor - move get_draft_revision_label to drafts.py
     from dcpy.connectors.edm.publishing import get_draft_revision_label
 
     product_key: BuildKey | DraftKey | PublishKey

--- a/dcpy/lifecycle/builds/utils.py
+++ b/dcpy/lifecycle/builds/utils.py
@@ -9,8 +9,18 @@ from pathlib import Path
 
 import pandas as pd
 
-from dcpy.connectors.edm.models import BuildKey, DraftKey, ProductKey, PublishKey
-from dcpy.lifecycle.builds.connector import get_published_default_connector
+from dcpy.connectors.edm.models import (
+    BuildKey,
+    Dataset,
+    DatasetType,
+    DraftKey,
+    ProductKey,
+    PublishKey,
+)
+from dcpy.lifecycle.builds.connector import (
+    get_published_default_connector,
+    get_recipes_default_connector,
+)
 from dcpy.utils import versions
 from dcpy.utils.logging import logger
 
@@ -173,3 +183,83 @@ def get_file_contents(
     finally:
         if tmp_path.exists():
             tmp_path.unlink()
+
+
+def read_recipe_df(
+    dataset: Dataset,
+    preferred_file_types: list[DatasetType] | None = None,
+) -> pd.DataFrame:
+    """Read a recipe dataset as a pandas DataFrame.
+
+    Uses the configured recipes connector to pull and read the dataset.
+    Supports parquet and CSV file types.
+
+    Args:
+        dataset: Dataset object with id, version, and optional file_type
+        preferred_file_types: List of file types to try, in order of preference.
+                             Defaults to [parquet, csv]
+
+    Returns:
+        DataFrame containing the dataset contents
+
+    Raises:
+        ValueError: If dataset has unsupported file_type
+        FileNotFoundError: If dataset file doesn't exist
+    """
+    connector = get_recipes_default_connector()
+
+    # Determine file type preference
+    preferred_file_types = preferred_file_types or [
+        DatasetType.parquet,
+        DatasetType.csv,
+    ]
+
+    # Use dataset's file_type if set, otherwise try preferred types
+    file_types_to_try = (
+        [dataset.file_type] if dataset.file_type else preferred_file_types
+    )
+
+    last_error = None
+    for file_type in file_types_to_try:
+        # Create temp file with appropriate extension
+        suffix = f".{file_type.to_extension()}"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+
+        try:
+            # Pull the file
+            result = connector.pull_versioned(
+                key=dataset.id,
+                version=dataset.version,
+                destination_path=tmp_path,
+                file_type=file_type,
+            )
+
+            # Read based on file type
+            if file_type == DatasetType.parquet:
+                return pd.read_parquet(result["path"])
+            elif file_type == DatasetType.csv:
+                return pd.read_csv(result["path"])
+            else:
+                raise ValueError(
+                    f"Unsupported file type for DataFrame reading: {file_type}"
+                )
+
+        except Exception as e:
+            last_error = e
+            logger.debug(
+                f"Failed to read {dataset.id} v{dataset.version} as {file_type}: {e}"
+            )
+            continue
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+    # If we get here, all attempts failed
+    if last_error:
+        raise last_error
+    else:
+        raise FileNotFoundError(
+            f"Could not read dataset {dataset.id} v{dataset.version} "
+            f"with any of the preferred file types: {file_types_to_try}"
+        )

--- a/dcpy/test/lifecycle/builds/test_load.py
+++ b/dcpy/test/lifecycle/builds/test_load.py
@@ -48,19 +48,6 @@ def _mock_fetch_parquet(ds, _=None):
 @pytest.mark.usefixtures("file_setup_teardown")
 @pytest.mark.usefixtures("create_buckets")
 class TestImportDatasets(TestCase):
-    @patch("dcpy.connectors.edm.recipes.read_df", return_value=_test_df)
-    def test_import_parquet_df(self, read_df):
-        ds = InputDataset(
-            id="test",
-            version="1",
-            import_as="new_table_name",
-            file_type=recipes.DatasetType.parquet,
-            destination=InputDatasetDestination.df,
-        )
-        res = load.import_dataset(ds, Path("./"), None)
-        assert isinstance(res.destination, pd.DataFrame)
-        assert _test_df.equals(res.destination)
-
     def test_import_parquet_file(self):
         # recipes.fetch_dataset = MagicMock(side_effect=_mock_fetch_parquet)
 

--- a/products/checkbook/build_scripts/export.py
+++ b/products/checkbook/build_scripts/export.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+# TODO: publishing connector refactor - replace with: from dcpy.lifecycle.builds import builds
 from dcpy.connectors.edm import publishing
 from dcpy.utils import git
 
@@ -13,6 +14,7 @@ if __name__ == "__main__":
     with open("version.txt", "w") as f:
         f.write(str(date.today()))
     build_environment = git.branch()
+    # TODO: publishing connector refactor - replace with: builds.upload(OUTPUT_DIR, PRODUCT, build_environment, acl="public-read")
     publishing.upload_build(
         OUTPUT_DIR, PRODUCT, acl="public-read", build=build_environment
     )

--- a/products/cscl/poc_validation/run_validation.py
+++ b/products/cscl/poc_validation/run_validation.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import typer
 
+# TODO: publishing connector refactor - replace with: from dcpy.lifecycle.builds import builds
 from dcpy.connectors.edm import publishing
 from dcpy.connectors.edm.models import BuildKey
 from dcpy.utils import s3
@@ -44,6 +45,7 @@ def _compute_file_diff(
     diff_rows contains lines present in the dev build but not in prod,
     equivalent to comm -23 <(sort dev) <(sort prod).
     """
+    # TODO: publishing connector refactor - replace with: builds.get_file(build_key.product, build_key.build, filename)
     dev_buffer = publishing.get_file(build_key, filename)
     dev_lines = {
         line
@@ -78,9 +80,11 @@ def run(
 
     if prod_version is None:
         print(f"Reading prod version from build metadata for '{build}'...")
+        # TODO: publishing connector refactor - replace with: builds.get_build_metadata(build_key.product, build_key.build).version
         prod_version = publishing.get_build_metadata(build_key).version
     print(f"Prod version: {prod_version}")
 
+    # TODO: publishing connector refactor - replace with: builds.get_filenames(build_key.product, build_key.build)
     all_filenames = publishing.get_filenames(build_key)
     cscl_output_filenames = sorted(
         f for f in all_filenames if "/" not in f and f not in BUILD_METADATA_FILES

--- a/products/template/tests/test_build.py
+++ b/products/template/tests/test_build.py
@@ -3,6 +3,8 @@ import pytest
 from build_scripts import PG_CLIENT
 
 from dcpy.configuration import BUILD_NAME
+
+# TODO: publishing connector refactor - replace with: from dcpy.lifecycle.builds import builds
 from dcpy.connectors.edm import publishing
 from dcpy.connectors.edm.models import BuildKey
 
@@ -29,6 +31,7 @@ def test_transform_staging():
 # * test Export stage
 @pytest.mark.end_to_end()
 def test_export_build():
+    # TODO: publishing connector refactor - replace with: builds.list_builds(product=BUILD_KEY.product)
     assert BUILD_KEY.build in publishing.get_builds(product=BUILD_KEY.product)
 
 
@@ -48,6 +51,7 @@ def test_export_files():
         "templatedb.zip",
         "output.zip",
     }
+    # TODO: publishing connector refactor - replace with: builds.get_filenames(BUILD_KEY.product, BUILD_KEY.build)
     actual_files = publishing.get_filenames(BUILD_KEY)
     target_files = {f for f in actual_files if f.startswith("target/")}
     assert target_files, "Expected dbt target/ directory to be present in export"


### PR DESCRIPTION
Removes MOST direct references to edm connectors. We should be going through dcpy.lifecycle (the dwim layer), which should dynamically dispatch the configured connector to push/pull/list files. 

There are still a few stragglers before we can delete the old publishing connector. They're clearly marked. I just don't have the willpower / brainpower to think about them at the moment.