### PR TITLE
bump cscl to 26b

### DIFF
--- a/products/cscl/recipe.yml
+++ b/products/cscl/recipe.yml
@@ -1,6 +1,6 @@
 name: CSCL
 product: cscl
-version: 26a
+version: 26b
 
 inputs:
   dataset_defaults:


### PR DESCRIPTION
so that I could run `python3 poc_validation/prod_data_loader.py load` and load 26b prod files into the database

<img width="442" height="726" alt="Screenshot 2026-06-16 at 8 50 51 AM" src="https://github.com/user-attachments/assets/1dfd8f99-09c6-4e4a-b482-2ca0cf54eaee" />
