### PR TITLE
handle historic landmarks without geometries

### DIFF
--- a/products/template/models/_sources.yml
+++ b/products/template/models/_sources.yml
@@ -83,4 +83,6 @@ sources:
               - not_null
           - name: wkb_geometry
             tests:
-              - not_null
+              - not_null::
+                  config:
+                    severity: warn

--- a/products/template/models/intermediate/_intermediate.yml
+++ b/products/template/models/intermediate/_intermediate.yml
@@ -38,11 +38,14 @@ models:
         tests:
           - not_null
       - name: borough
-      - name: bbls
+      - name: bbl
       - name: wkb_geometry
+        tests:
+          - not_null
     tests:
       - dbt_utils.unique_combination_of_columns:
           name: historic_landmarks_unique_compound_key
           combination_of_columns:
             - landmark_name
+            - bbl
             - wkb_geometry

--- a/products/template/models/intermediate/historic_landmarks.sql
+++ b/products/template/models/intermediate/historic_landmarks.sql
@@ -13,6 +13,7 @@ landmarks_reprojected AS (
         ST_TRANSFORM(ST_SETSRID(wkb_geometry, 2263), 4326) AS wkb_geometry
     FROM
         landmarks
+    WHERE wkb_geometry IS NOT NULL
 ),
 
 landmarks_borough_names AS (


### PR DESCRIPTION
Template DB build is failing on all branches because some LPC Landmarks records now have null geometries