### PR TITLE
build CPDB 26exec

### DIFF
--- a/dcpy/library/ingest.py
+++ b/dcpy/library/ingest.py
@@ -21,6 +21,7 @@ from rich.progress import (
 )
 
 from dcpy.library import models as library
+from dcpy.utils.logging import logger
 from dcpy.utils.metadata import get_run_details
 
 from . import base_path
@@ -89,8 +90,9 @@ def translator(func):
 
         output_files = []
         path = args[0]
-        c = Config(path, kwargs.get("version"), kwargs.get("source_path_override"))
-        dataset = c.compute
+        dataset = self._resolve_source(
+            path, kwargs.get("version"), kwargs.get("source_path_override")
+        )
         assert dataset.source.gdalpath
         assert dataset.version
         # initiate source and destination datasets
@@ -265,6 +267,32 @@ def translator(func):
 class Ingestor:
     def __init__(self):
         self.base_path = base_path
+        # Cache of resolved source datasets (Config.compute output), keyed by
+        # (path, version, source_path_override). One Ingestor is reused across
+        # all output formats of a single archive run, so this scopes the cache to
+        # that run and makes the source fetch happen once instead of per format.
+        self._source_cache: dict = {}
+
+    def _resolve_source(
+        self, path: str, version: str | None, source_path_override: str | None
+    ) -> library.DatasetDefinition:
+        """Resolve a dataset's source once per archive run and reuse it across
+        output formats. A single Ingestor is shared across all of a dataset's
+        formats (see Archive), so caching here avoids re-running an expensive
+        source fetch for each of pgdump/parquet/csv. This matters most for
+        `script:` sources, whose runner() can be a multi-hour API crawl."""
+        cache_key = (path, version, source_path_override)
+        if cache_key not in self._source_cache:
+            self._source_cache[cache_key] = Config(
+                path, version, source_path_override
+            ).compute
+        else:
+            cached = self._source_cache[cache_key]
+            logger.info(
+                f"Reusing already-resolved source for {cached.name} "
+                f"({cached.version}); skipping re-fetch."
+            )
+        return self._source_cache[cache_key]
 
     def compress(self, path: str, *files, inplace: bool = True):
         with zipfile.ZipFile(

--- a/dcpy/library/script/nycoc_checkbook.py
+++ b/dcpy/library/script/nycoc_checkbook.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any, Literal, TypedDict
 
 import pandas as pd
-import pytz
 import requests
 
 from dcpy.utils.logging import logger
@@ -63,7 +62,7 @@ VISID_COOKIE_TOKEN_ENV_VAR = "NYCOC_CHECKBOOK_VISID_COOKIE_TOKEN"
 MAYBE_VISID_TOKEN: str | None = os.environ.get(VISID_COOKIE_TOKEN_ENV_VAR)
 
 if not MAYBE_VISID_TOKEN:
-    logger.warn(
+    logger.warning(
         "Running nycoc ingestion without an incapsula token. This could cause problems if your IP is not whitelisted"
     )
 NYCOC_USER_AGENT_ENV_VAR = "NYCOC_CHECKBOOK_USER_AGENT"
@@ -120,6 +119,9 @@ class Scriptor(ScriptorInterface):
                 "end": end,
             }
             search_criteria_modified = search_criteria + [month_criteria]
+            logger.info(
+                f"Fetching {type_of_data} records for period {start} to {end}..."
+            )
             df = get_data(
                 type_of_data=type_of_data,
                 records_from=records_from,
@@ -128,7 +130,7 @@ class Scriptor(ScriptorInterface):
                 search_criteria=search_criteria_modified,
                 num_retries=num_retries,
             )
-            print(f"There are {len(df)} records for period {start}-{end}.")
+            logger.info(f"There are {len(df)} records for period {start}-{end}.")
 
             filename = f"{start}-{end}_checkbook.parquet"
             filepath = str(data_dir / filename)
@@ -234,20 +236,29 @@ def get_response(
 
     for n in range(num_retries):
         try:
+            logger.info(
+                f"Requesting {type_of_data} records from #{records_from} "
+                f"(attempt {n + 1}/{num_retries})..."
+            )
             response = requests.post(url=api_endpoint, data=xml_string, headers=headers)
             response.raise_for_status()
             return response
         except requests.exceptions.RequestException as e:
             # user_agent = random.choice(USER_AGENTS)   # TODO: uncomment or remove completely
-            timestamp = (
-                dt.datetime.utcnow()
-                .astimezone(pytz.timezone("US/Eastern"))
-                .strftime("%Y-%m-%d %H:%M")
+            # Surface what a rate limit / WAF block looks like: the HTTP status and
+            # any Retry-After header. Connection errors/timeouts carry no response.
+            failed_response = getattr(e, "response", None)
+            status = (
+                failed_response.status_code if failed_response is not None else "none"
             )
-            print(
-                f"Failed to get a response from api (try # {n + 1}/{num_retries}) at {timestamp}."
-                f"\nRequest body: \n{xml_string}"
-                f"\nException: {e}"
+            retry_after = (
+                failed_response.headers.get("Retry-After")
+                if failed_response is not None
+                else None
+            )
+            logger.warning(
+                f"Failed to get a response from api (try # {n + 1}/{num_retries}); "
+                f"status: {status}, Retry-After: {retry_after}. Exception: {e}"
             )
             # pausing before next request: we don't want to overload API
             time.sleep(random.randint(15, 20))

--- a/dcpy/lifecycle/ingest/transform.py
+++ b/dcpy/lifecycle/ingest/transform.py
@@ -505,7 +505,7 @@ class ProcessingFunctions:
             regex: True
 
         Which has the effect of
-        `df["jobnum"] = df["jobnum"].str.replace("-[a-zA-Z\d]1$", "", regex=True)`
+        `df["jobnum"] = df["jobnum"].str.replace("-[a-zA-Z\\d]1$", "", regex=True)`
 
         "function_name" must be a valid function of a pd.Series. This is validated
         kwargs are validated by name only, as annotations for these functions are quite messy

--- a/dcpy/test/library/test_ingest.py
+++ b/dcpy/test/library/test_ingest.py
@@ -96,3 +96,30 @@ class TestIngestor:
     def test_script(self, request_get):
         self.ingestor.csv(f"{template_path}/bpl_libraries.yml", version="test")
         assert os.path.isfile(".library/datasets/bpl_libraries/test/bpl_libraries.csv")
+
+
+class TestResolveSourceCaching:
+    """A dataset's source must be resolved once per archive run and reused across
+    output formats. One Ingestor is shared across all of a dataset's formats, so
+    re-resolving would re-run the source fetch — e.g. a script source's multi-hour
+    API crawl — once for each output file format."""
+
+    @patch("dcpy.library.ingest.Config")
+    def test_resolves_once_per_key_and_reuses(self, MockConfig):
+        ingestor = Ingestor()
+
+        first = ingestor._resolve_source("template.yml", "v1", None)
+        second = ingestor._resolve_source("template.yml", "v1", None)
+
+        # Constructed (and thus source-fetched) exactly once...
+        assert MockConfig.call_count == 1
+        # ...and the same resolved dataset is handed back both times.
+        assert first is second is MockConfig.return_value.compute
+
+    @patch("dcpy.library.ingest.Config")
+    def test_distinct_sources_resolve_separately(self, MockConfig):
+        ingestor = Ingestor()
+        ingestor._resolve_source("a.yml", "v1", None)
+        ingestor._resolve_source("b.yml", "v1", None)  # different path
+        ingestor._resolve_source("a.yml", "v2", None)  # different version
+        assert MockConfig.call_count == 3

--- a/products/cpdb/recipe.yml
+++ b/products/cpdb/recipe.yml
@@ -1,6 +1,6 @@
 name: CPDB
 product: db-cpdb
-version: 26prelim
+version: 26exec
 inputs:
   missing_versions_strategy: find_latest
   datasets:

--- a/products/cpdb/seeds/dcp_projecttypes_agencies.csv
+++ b/products/cpdb/seeds/dcp_projecttypes_agencies.csv
@@ -1,41 +1,41 @@
 projecttype,tycs,agencyname,agencyabbrev,agencycode,agencyacronym,agency,projecttypeabbrev
-Correction,CORRECTION                                                  ,New York City Department of Correction,NYCDOC,72,DOC,Department of Correction,C
-Courts,COURTS                                                      ,New York City Office of Court Administration,NYCOCA,0,OCA,Office of Court Administration,CO
-Childrens Services,ADMIN FOR CHILDREN'S SERVICES                               ,New York City Administration for Childrens Services,NYCACS,68,ACS,Administration for Childrens Services,CS
-Dept. of Information Technology & Telecomm,DOITT DP EQUIPMENT                                          ,New York City Department of Information Technology and Telecommunications,NYCDOITT,858,DOITT,Department of Information Technology and Telecommunications,DP
-Education,EDUCATION                                                   ,New York City Department of Education,NYCDOE,40,DOE,Department of Education,E
-Economic Development,ECONOMIC DEVELOPMENT                                        ,New York City Department of Small Business Services,NYCSBS,801,SBS,Department of Small Business Services,ED
-Environmental Protection-Equipment,DEP EQUIPMENT                                               ,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,EP
-Fire Department,FIRE                                                        ,New York City Fire Department,NYCFDNY,57,FDNY,Fire Department,F
-Ferries and Aviation,FERRIES & AVIATION                                          ,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,FA
-Housing Authority,HOUSING AUTHORITY                                           ,New York City Housing Authority,NYCHA,996,NYCHA,Housing Authority,HA
-Highway Bridges,HIGHWAY BRIDGES                                             ,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,HB
-Housing Preservation and Development,HOUSING & DEVELOPMENT                                       ,New York City Department of Housing Preservation and Development,NYCHPD,806,HPD,Department of Housing Preservation and Development,HD
-Homeless Services,HOMELESS SERVICES                                           ,New York City Department of Homeless Services,NYCDHS,71,DHS,Department of Homeless Services,HH
-Health and Mental Hygiene,HEALTH                                                      ,New York City Department of Health and Mental Hygiene,NYCDOHMH,816,DOHMH,Department of Health and Mental Hygiene,HL
-City University of New York,HIGHER EDUCATION                                            ,City University of New York,CUNY,42,CUNY,City University of New York,HN
-Health and Hospitals Corporation,HEALTH & HOSPITALS CORP.                                    ,New York City Health and Hospitals Corporation,NYCHHC,819,HHC,Health and Hospitals Corporation,HO
-Human Resources,HUMAN RESOURCES                                             ,New York City Human Resources Administration/Department of Social Services,NYCHRA/DSS,69,HRA/DSS,Human Resources Administration/Department of Social Services,HR
-Highways,HIGHWAYS                                                    ,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,HW
-New York Research Library,NEW YORK RESEARCH LIBRARY                                   ,0,0,35,NYRL,New York Research Libraries,L
-Brooklyn Public Library,BROOKLYN PUBLIC LIBRARY                                     ,Brooklyn Public Library,BPL,38,BPL,Brooklyn Public Library,LB
-New York Public Library,NEW YORK PUBLIC LIBRARY                                     ,New York Public Library,NYPL,37,NYPL,New York Public Library,LN
-Queens Borough Public Library,QUEENS BOROUGH PUB. LIB.                                    ,Queens Public Library,QPL,39,QBPL,Queens Public Library,LQ
+Correction,CORRECTION,New York City Department of Correction,NYCDOC,72,DOC,Department of Correction,C
+Courts,COURTS,New York City Office of Court Administration,NYCOCA,0,OCA,Office of Court Administration,CO
+Childrens Services,ADMIN FOR CHILDREN'S SERVICES,New York City Administration for Childrens Services,NYCACS,68,ACS,Administration for Childrens Services,CS
+Dept. of Information Technology & Telecomm,DOITT DP EQUIPMENT,New York City Department of Information Technology and Telecommunications,NYCDOITT,858,DOITT,Department of Information Technology and Telecommunications,DP
+Education,EDUCATION,New York City Department of Education,NYCDOE,40,DOE,Department of Education,E
+Economic Development,ECONOMIC DEVELOPMENT,New York City Department of Small Business Services,NYCSBS,801,SBS,Department of Small Business Services,ED
+Environmental Protection-Equipment,DEP EQUIPMENT,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,EP
+Fire Department,FIRE,New York City Fire Department,NYCFDNY,57,FDNY,Fire Department,F
+Ferries and Aviation,FERRIES & AVIATION,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,FA
+Housing Authority,HOUSING AUTHORITY,New York City Housing Authority,NYCHA,996,NYCHA,Housing Authority,HA
+Highway Bridges,HIGHWAY BRIDGES,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,HB
+Housing Preservation and Development,HOUSING & DEVELOPMENT,New York City Department of Housing Preservation and Development,NYCHPD,806,HPD,Department of Housing Preservation and Development,HD
+Homeless Services,HOMELESS SERVICES,New York City Department of Homeless Services,NYCDHS,71,DHS,Department of Homeless Services,HH
+Health and Mental Hygiene,HEALTH,New York City Department of Health and Mental Hygiene,NYCDOHMH,816,DOHMH,Department of Health and Mental Hygiene,HL
+City University of New York,HIGHER EDUCATION,City University of New York,CUNY,42,CUNY,City University of New York,HN
+Health and Hospitals Corporation,HEALTH & HOSPITALS CORP.,New York City Health and Hospitals Corporation,NYCHHC,819,HHC,Health and Hospitals Corporation,HO
+Human Resources,HUMAN RESOURCES,New York City Human Resources Administration/Department of Social Services,NYCHRA/DSS,69,HRA/DSS,Human Resources Administration/Department of Social Services,HR
+Highways,HIGHWAYS,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,HW
+New York Research Library,NEW YORK RESEARCH LIBRARY,0,0,35,NYRL,New York Research Libraries,L
+Brooklyn Public Library,BROOKLYN PUBLIC LIBRARY,Brooklyn Public Library,BPL,38,BPL,Brooklyn Public Library,LB
+New York Public Library,NEW YORK PUBLIC LIBRARY,New York Public Library,NYPL,37,NYPL,New York Public Library,LN
+Queens Borough Public Library,QUEENS BOROUGH PUB. LIB.,Queens Public Library,QPL,39,QBPL,Queens Public Library,LQ
 MTA Bus Company,,Metropolitan Transportation Authority,MTA,0,MTA,Metropolitan Transportation Authority,MT
-Parks and Recreation,PARKS                                                       ,New York City Department of Parks and Recreation,NYCDPR,846,DPR,Department of Parks and Recreation,P
-Police,POLICE                                                      ,New York City Police Department,NYPD,56,NYPD,Police Department,PO
-Cultural Affairs,CULTURAL INSTITUTIONS                                       ,New York City Department of Cultural Affairs,NYCDCLA,126,DCLA,Department of Cultural Affairs,PV
-Public Buildings,PUBLIC BUILDINGS                                            ,New York City Department of Citywide Administrative Services,NYCDCAS,856,DCAS,Department of Citywide Administrative Services,PW
-Real Property,REAL PROPERTY                                               ,New York City Department of Citywide Administrative Services,NYCDCAS,856,DCAS,Department of Citywide Administrative Services,RE
-Sanitation,SANITATION                                                  ,New York City Department of Sanitation,NYCDSNY,827,DSNY,Department of Sanitation,S
-Sewers,SEWERS                                                      ,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,SE
-Staten Island Rapid Transit,SIRTOA                                                      ,Metropolitan Transportation Authority,MTA,0,MTA,Metropolitan Transportation Authority,ST
-Transit Authority,TRANSIT AUTHORITY                                           ,Metropolitan Transportation Authority,MTA,0,MTA,Metropolitan Transportation Authority,T
-Transportation - Equipment,TRANSPORTATION EQUIPMENT                                    ,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,TD
-Traffic,TRAFFIC                                                     ,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,TF
-Water Supply,WATER SUPPLY                                                ,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,W
+Parks and Recreation,PARKS,New York City Department of Parks and Recreation,NYCDPR,846,DPR,Department of Parks and Recreation,P
+Police,POLICE,New York City Police Department,NYPD,56,NYPD,Police Department,PO
+Cultural Affairs,CULTURAL INSTITUTIONS,New York City Department of Cultural Affairs,NYCDCLA,126,DCLA,Department of Cultural Affairs,PV
+Public Buildings,PUBLIC BUILDINGS,New York City Department of Citywide Administrative Services,NYCDCAS,856,DCAS,Department of Citywide Administrative Services,PW
+Real Property,REAL PROPERTY,New York City Department of Citywide Administrative Services,NYCDCAS,856,DCAS,Department of Citywide Administrative Services,RE
+Sanitation,SANITATION,New York City Department of Sanitation,NYCDSNY,827,DSNY,Department of Sanitation,S
+Sewers,SEWERS,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,SE
+Staten Island Rapid Transit,SIRTOA,Metropolitan Transportation Authority,MTA,0,MTA,Metropolitan Transportation Authority,ST
+Transit Authority,TRANSIT AUTHORITY,Metropolitan Transportation Authority,MTA,0,MTA,Metropolitan Transportation Authority,T
+Transportation - Equipment,TRANSPORTATION EQUIPMENT,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,TD
+Traffic,TRAFFIC,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,TF
+Water Supply,WATER SUPPLY,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,W
 "Water Mains, Sources and Treatment","WATER MAINS, SOURCES AND TREATMENT                          ",New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,WM
-Water Pollution Control,WATER POLLUTION CONTROL                                     ,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,WP
-Aging,DEPARTMENT FOR THE AGING                                    ,New York City Department for the Aging,NYCDFTA,125,DFTA,Department for the Aging,AG
-Waterway Bridges,WATERWAY BRIDGES                                            ,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,BR
-EDP Equipment and Finance Costs,EDP EQUIP & FINANC COSTS                                    ,New York City Department of Citywide Administrative Services,NYCDCAS,856,DCAS,Department of Citywide Administrative Services,PU
+Water Pollution Control,WATER POLLUTION CONTROL,New York City Department of Environmental Protection,NYCDEP,826,DEP,Department of Environmental Protection,WP
+Aging,DEPARTMENT FOR THE AGING,New York City Department for the Aging,NYCDFTA,125,DFTA,Department for the Aging,AG
+Waterway Bridges,WATERWAY BRIDGES,New York City Department of Transportation,NYCDOT,841,DOT,Department of Transportation,BR
+EDP Equipment and Finance Costs,EDP EQUIP & FINANC COSTS,New York City Department of Citywide Administrative Services,NYCDCAS,856,DCAS,Department of Citywide Administrative Services,PU

--- a/products/cpdb/sql/ccp_commitments.sql
+++ b/products/cpdb/sql/ccp_commitments.sql
@@ -16,6 +16,7 @@ SELECT
     REPLACE(p.budget_proj_type, ' ', '') || '-' || p.budget_line_id AS budgetline,
     b.projecttype,
     b.agencyacronym AS sagencyacro,
+    b.agencyabbrev AS sagencyabbrev,
     b.agency AS sagencyname,
     RIGHT(p.planned_commit_date, 2) || '/' || SUBSTRING(p.planned_commit_date FROM 3 FOR 2) AS plancommdate,
     p.short_descr AS projectdescription,


### PR DESCRIPTION
related to #2151

[build runs on this branch](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-cpdb-26exec)

improvements to nycoc_checkbook and library code reduced action run time from [3 hours](https://github.com/NYCPlanning/data-engineering/actions/runs/28187467988) to [1 hour](https://github.com/NYCPlanning/data-engineering/actions/runs/28214129684). will move it to ingest sometime soon, just didn't wanna deal with the script-in-ingest complexity yet (all other ingest templates using a script only use it for processing, not fetching the data)