### PR TITLE
add url to source_data_versions

### DIFF
--- a/dcpy/connectors/edm/recipes.py
+++ b/dcpy/connectors/edm/recipes.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from pathlib import Path
 
@@ -45,6 +46,20 @@ def get_archive_date(ds: Dataset | DatasetKey) -> datetime | None:
     if date_created:
         return datetime.fromisoformat(date_created)
     return metadata.last_modified
+
+
+def get_url(ds: Dataset | DatasetKey) -> str | None:
+    """Source URL the dataset version was ingested from, from its archived config.json."""
+    folder = s3_folder_path(ds)
+    files = s3.get_filenames(_bucket(), folder)
+    if not files:
+        return None
+    if "config.json" not in files:
+        return None
+    config_key = f"{folder}/config.json"
+    with s3.get_file_as_stream(_bucket(), config_key) as stream:
+        config = json.loads(stream.read())
+    return config.get("attributes", {}).get("url")
 
 
 def get_all_versions(name: str) -> list[str]:

--- a/dcpy/lifecycle/builds/models.py
+++ b/dcpy/lifecycle/builds/models.py
@@ -41,6 +41,7 @@ class InputDataset(BaseModel, extra="forbid"):
     destination: InputDatasetDestination | None = None
     load_engine: str | None = None
     archive_date: date | None = None
+    url: str | None = None
     custom: dict = Field(default_factory=dict)
 
     @property

--- a/dcpy/lifecycle/builds/plan.py
+++ b/dcpy/lifecycle/builds/plan.py
@@ -227,6 +227,7 @@ def plan_recipe(
             ds.name = connector.get_name(ds.id, ds.version)  # type: ignore
             archive_dt = recipes.get_archive_date(ds.dataset)
             ds.archive_date = archive_dt.date() if archive_dt else None
+            ds.url = recipes.get_url(ds.dataset)
 
     # Resolve any unresolved conf values (e.g. from the environment or provided vars)
     for conf in recipe.get_unresolved_stage_config_values():
@@ -416,7 +417,7 @@ def write_source_data_versions(recipe_file: Path):
         logger.error(exception)
         raise Exception(exception)
 
-    header = ["schema_name", "dataset_name", "v", "file_type", "archive_date"]
+    header = ["schema_name", "dataset_name", "v", "file_type", "archive_date", "url"]
     with open(source_data_versions_path, "w", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=header)
         writer.writeheader()
@@ -427,6 +428,7 @@ def write_source_data_versions(recipe_file: Path):
                 "v": x.version,
                 "file_type": x.file_type,
                 "archive_date": x.archive_date.isoformat() if x.archive_date else "",
+                "url": x.url if x.url else "",
             }
             for x in datasets
         )

--- a/dcpy/test/connectors/edm/resources/ingest/config.json
+++ b/dcpy/test/connectors/edm/resources/ingest/config.json
@@ -3,7 +3,8 @@
     "version": "ingest",
     "acl": "private",
     "attributes": {
-        "name": "Downstream Dataset 1"
+        "name": "Downstream Dataset 1",
+        "url": "https://example.com/data"
     },
     "source": {
         "id": "one_to_many",

--- a/dcpy/test/connectors/edm/test_recipes.py
+++ b/dcpy/test/connectors/edm/test_recipes.py
@@ -137,6 +137,18 @@ def test_get_archive_date_missing_dataset(create_buckets):
     assert result is None
 
 
+def test_get_url(load_ingest: SparseConfig):
+    ds = DatasetKey(id=load_ingest.id, version=load_ingest.version)
+    result = recipes.get_url(ds)
+    assert result == "https://example.com/data"
+
+
+def test_get_url_missing_dataset(create_buckets):
+    ds = DatasetKey(id="nonexistent", version="v1")
+    result = recipes.get_url(ds)
+    assert result is None
+
+
 def test_read_df_cache(load_ingest: SparseConfig, create_temp_filesystem: Path):
     preferred_file_types = [recipes.DatasetType.parquet, recipes.DatasetType.csv]
     dataset = Dataset(id=load_ingest.id, version=load_ingest.version)

--- a/dcpy/test/lifecycle/builds/resources/simple.lock.yml
+++ b/dcpy/test/lifecycle/builds/resources/simple.lock.yml
@@ -5,16 +5,19 @@ inputs:
     name: pg_dump
     version: df
     archive_date: 2024-06-01
+    url: https://example.com/data
   - destination: df
     file_type: csv
     name: df
     version: df
     archive_date: 2024-06-01
+    url: https://example.com/data
   - destination: file
     file_type: csv
     name: file
     version: file
     archive_date: 2024-06-01
+    url: https://example.com/data
 name: Tester
 product: db-test
 version: 23v1

--- a/dcpy/test/lifecycle/builds/test_plan.py
+++ b/dcpy/test/lifecycle/builds/test_plan.py
@@ -241,6 +241,13 @@ class TestRecipesNoDefaults(TestCase):
         planned = plan.plan_recipe(RECIPE_NO_DEFAULTS_PATH)
         assert planned.inputs.datasets[0].archive_date == date(2024, 6, 1)
 
+    @patch("dcpy.connectors.edm.recipes.get_url")
+    def test_plan_recipe_populates_url(self, mock_url, get_file_types):
+        get_file_types.return_value = {DatasetType.pg_dump}
+        mock_url.return_value = "https://example.com/data"
+        planned = plan.plan_recipe(RECIPE_NO_DEFAULTS_PATH)
+        assert planned.inputs.datasets[0].url == "https://example.com/data"
+
 
 @pytest.mark.usefixtures("create_buckets")
 class TestRecipeVars(TestCase):
@@ -561,3 +568,24 @@ class TestWriteSourceDataVersions(TestCase):
                 keep_default_na=False,
             )
         assert list(df["archive_date"]) == [""] * len(df)
+
+    def test_includes_url_column(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "simple.lock.yml"
+            lock_path.write_text(SIMPLE_LOCK_PATH.read_text())
+            plan.write_source_data_versions(lock_path)
+            df = pd.read_csv(Path(tmpdir) / "source_data_versions.csv")
+        assert "url" in df.columns
+        assert list(df["url"]) == ["https://example.com/data"] * len(df)
+
+    def test_url_none_writes_empty_string(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "simple_no_pg.lock.yml"
+            lock_path.write_text(SIMPLE_NO_PG_LOCK_PATH.read_text())
+            plan.write_source_data_versions(lock_path)
+            df = pd.read_csv(
+                Path(tmpdir) / "source_data_versions.csv",
+                dtype=str,
+                keep_default_na=False,
+            )
+        assert list(df["url"]) == [""] * len(df)

--- a/dcpy/test_integration/connectors/edm/test_plan_load.py
+++ b/dcpy/test_integration/connectors/edm/test_plan_load.py
@@ -47,6 +47,7 @@ def test_resolving_and_loading_recipes(tmp_path, pg_client: postgres.PostgresCli
         "v",
         "file_type",
         "archive_date",
+        "url",
     ]
 
     assert recipe_pg_dataset_table_names == load_result_pg_table_names

--- a/products/ceqr/models/_sources.yml
+++ b/products/ceqr/models/_sources.yml
@@ -13,3 +13,4 @@ sources:
           - name: v
           - name: file_type
           - name: archive_date
+          - name: url

--- a/products/template/models/_sources.yml
+++ b/products/template/models/_sources.yml
@@ -13,6 +13,7 @@ sources:
           - name: v
           - name: file_type
           - name: archive_date
+          - name: url
 
   - name: tdb_sources
     schema: "{{ env_var('BUILD_ENGINE_SCHEMA') }}"

--- a/products/template/models/product/_product.yml
+++ b/products/template/models/product/_product.yml
@@ -14,6 +14,8 @@ models:
         description: "File format of the source data (e.g. csv, parquet, pg_dump)"
       - name: archive_date
         description: "Date the source dataset was ingested into edm-recipes (YYYY-MM-DD)"
+      - name: url
+        description: "Source URL the dataset was ingested from"
 
   - name: templatedb
     description: "Template DB place records"

--- a/products/template/models/product/dataset_versions.sql
+++ b/products/template/models/product/dataset_versions.sql
@@ -5,5 +5,6 @@ SELECT
     dataset_name,
     v AS version,
     file_type,
-    archive_date
+    archive_date,
+    url
 FROM {{ source('recipe_sources', 'source_data_versions') }}


### PR DESCRIPTION
requested by AE for their usage of FacDB in their CPP app

new column in the `source_data_versions.csv` generated by the PR tests' Template DB build:

<img width="1186" height="241" alt="Screenshot 2026-06-28 at 10 19 15 PM" src="https://github.com/user-attachments/assets/224a5a84-157e-471e-b882-e63eed5344d5" />
