### PR TITLE
bump facdb version to distribute to open data

### DIFF
--- a/product-metadata/snippets/strings.yml
+++ b/product-metadata/snippets/strings.yml
@@ -61,7 +61,7 @@ bytes_url__ztl: https://www.nyc.gov/content/planning/pages/resources/datasets/zo
 # Versions
 current_version_lion: 26b
 current_version_pluto: 26v1
-current_version_facilities: 25v2
+current_version_facilities: 26v1
 current_version_building_elevation_and_subgrade: 202510
 current_version_cdbg: 202503
 current_version_census_equivalency_tract_table:


### PR DESCRIPTION
related to https://github.com/NYCPlanning/data-engineering/issues/2146

[first distribution attempt ](https://github.com/NYCPlanning/data-engineering/actions/runs/29518537640) still used the old version

[successful distribution here](https://github.com/NYCPlanning/data-engineering/actions/runs/29518934769)