### PR TITLE
fix ZAP and nightly QA builds

### DIFF
--- a/products/cbbr/geocode/helpers.py
+++ b/products/cbbr/geocode/helpers.py
@@ -26,7 +26,7 @@ GEOCODE_COLUMNS = [
 
 
 def get_hnum(address: str) -> str:
-    if not address:
+    if not isinstance(address, str) or not address:
         return None
     result = [k for (k, v) in usaddress.parse(address) if re.search("Address", v)]
     result = " ".join(result)
@@ -41,7 +41,7 @@ def get_hnum(address: str) -> str:
 
 
 def get_sname(address: str) -> str | None:
-    if not address:
+    if not isinstance(address, str) or not address:
         return None
     result = (
         [k for (k, v) in usaddress.parse(address) if re.search("Street", v)]
@@ -56,7 +56,7 @@ def get_sname(address: str) -> str | None:
 
 
 def get_landmarkname(address: str) -> str | None:
-    if not address:
+    if not isinstance(address, str) or not address:
         return None
     result = (
         [k for (k, v) in usaddress.parse(address) if v == "LandmarkName"]

--- a/products/facilities/facdb/pipelines.py
+++ b/products/facilities/facdb/pipelines.py
@@ -787,5 +787,11 @@ def dispatch(name: str, df: pd.DataFrame):
     pipelines = importlib.import_module(__name__)
     pipeline = getattr(pipelines, name)
 
+    if df.empty:
+        raise ValueError(
+            f"Source dataset '{name}' is empty — refusing to build. "
+            "Check the ingest for this source."
+        )
+
     df["source"] = name  # legacy column. Easier to add here than modify SQL files
     return df.pipe(hash_each_row).pipe(format_field_names).pipe(pipeline)

--- a/products/knownprojects/python/utils.py
+++ b/products/knownprojects/python/utils.py
@@ -108,7 +108,7 @@ def ETL(extractor_func) -> callable:
         # If it's a geopandas dataframe, we will have to
         # Convert geometry column to text first
         if isinstance(df, gpd.geodataframe.GeoDataFrame):
-            df = pd.DataFrame(df, dtype=str)
+            df = pd.DataFrame(df).astype(str)
 
         print(f"export\t{source_dataset_name} to postgres ...")
         df.to_sql(

--- a/products/zap-opendata/src/recode_id.py
+++ b/products/zap-opendata/src/recode_id.py
@@ -114,7 +114,7 @@ class ReuseTracker:
         self.total_records_recoded += 1
         for field in RECODE_ID_FIELDS:
             value = row[field]
-            if value is not None:
+            if not pd.isna(value):
                 if value in self.__getattribute__(field).keys():
                     row[field] = self.__getattribute__(field)[value]
                     self.reused_recodings[field] += 1
@@ -236,7 +236,7 @@ def convert_to_human_readable(
         metadata_keys[metadata_field][1],
     )
     if field_dict is None:
-        if id_val is not None:
+        if not pd.isna(id_val):
             raise Exception(
                 f"data has {local_fieldname} of {id_val} but expanded of {json.dumps(expanded, indent=2)}"
             )

--- a/products/zap-opendata/tests/test_recode_id.py
+++ b/products/zap-opendata/tests/test_recode_id.py
@@ -1,5 +1,11 @@
+import logging
+
+import numpy as np
 import pandas as pd
-from src.recode_id import recode_id
+import pytest
+from src.recode_id import ReuseTracker, convert_to_human_readable, recode_id
+
+_logger = logging.getLogger("test_recode_id")
 
 test_data_input = pd.DataFrame.from_dict(
     {
@@ -55,3 +61,48 @@ recoded_data_expected = pd.DataFrame.from_dict(
 def test_recode_id():
     recoded_data_actual = recode_id(test_data_input)
     pd.testing.assert_frame_equal(recoded_data_actual, recoded_data_expected)
+
+
+def test_convert_to_human_readable_recodes_id():
+    """Happy path: a present id is mapped to its human-readable name."""
+    expanded = {"dcp_leadagencyforenvreview": {"name": "DCP", "accountid": "acct-1"}}
+    row = pd.Series({"crm_project_id": "p1", "ceqr_leadagency": "acct-1"})
+    result = convert_to_human_readable(
+        expanded=expanded,
+        row=row,
+        local_fieldname="ceqr_leadagency",
+        recode_tracker=ReuseTracker(),
+        logger=_logger,
+    )
+    assert result == "DCP"
+
+
+def test_convert_to_human_readable_passes_through_missing_id():
+    """Regression: a missing id (NaN) with no expand metadata must pass through,
+    not raise. pandas 3.0 reads a SQL NULL in a str column as NaN rather than
+    None, so the old `id_val is not None` guard raised here; `pd.isna` fixes it."""
+    expanded = {"dcp_leadagencyforenvreview": None}
+    row = pd.Series({"crm_project_id": "p1", "ceqr_leadagency": np.nan})
+    result = convert_to_human_readable(
+        expanded=expanded,
+        row=row,
+        local_fieldname="ceqr_leadagency",
+        recode_tracker=ReuseTracker(),
+        logger=_logger,
+    )
+    assert pd.isna(result)
+
+
+def test_convert_to_human_readable_raises_on_present_id_without_metadata():
+    """The guard's real purpose is preserved: a present id with no expand
+    metadata is a genuine inconsistency and must still raise."""
+    expanded = {"dcp_leadagencyforenvreview": None}
+    row = pd.Series({"crm_project_id": "p1", "ceqr_leadagency": "acct-1"})
+    with pytest.raises(Exception, match="ceqr_leadagency"):
+        convert_to_human_readable(
+            expanded=expanded,
+            row=row,
+            local_fieldname="ceqr_leadagency",
+            recode_tracker=ReuseTracker(),
+            logger=_logger,
+        )


### PR DESCRIPTION
resolves #2504, related to #2451

## what

fixes build failures related to recent pandas 3.0 version bump

FacDB failed because of some empty source data, fixed by re-ingesting [here](https://github.com/NYCPlanning/data-engineering/actions/runs/29840002851)

(in-progress) successful ZAP run on this branch [here](https://github.com/NYCPlanning/data-engineering/actions/runs/29838159213)
