### PR TITLE
add CSCL District Boundaries gdb

### DIFF
--- a/.github/workflows/cscl_build.yml
+++ b/.github/workflows/cscl_build.yml
@@ -83,6 +83,7 @@ jobs:
         ./poc_validation/validate_outputs.sh
         python3 poc_validation/summarize_diffs.py
         python3 poc_validation/compare_gdb.py
+        python3 poc_validation/compare_districts.py
 
     - name: Upload
       run: python3 -m dcpy.connectors.edm.publishing upload --product db-cscl --acl public-read --max_files 1000

--- a/dcpy/lifecycle/builds/export.py
+++ b/dcpy/lifecycle/builds/export.py
@@ -174,14 +174,23 @@ def _write_shapefile_zip(gdf, table_name: str, file_path: Path, tmp_dir: Path) -
 
 
 def _write_gdb_zip(
-    layers: list[tuple[str, Any]], file_path: Path, tmp_dir: Path
+    layers: list[tuple[str, Any]],
+    file_path: Path,
+    tmp_dir: Path,
+    allow_empty: set[str] | None = None,
 ) -> None:
     """Write one or more named layers to a zipped FGDB.
 
     Each entry in `layers` is (layer_name, gdf). OpenFileGDB requires a single
     geometry type per layer; use geometry_type='points' or 'polygons' in the
     recipe custom fields to filter before reaching here.
+
+    An empty layer is an error by default, since it usually means a geometry_type
+    filter matched nothing. Layers named in `allow_empty` (recipe `custom.allow_empty`)
+    are written as schema-only instead, for feature classes that are legitimately
+    empty upstream and still have to appear in the output.
     """
+    allow_empty = allow_empty or set()
     gdb_name = file_path.stem
     gdb_path = tmp_dir / f"{gdb_name}.gdb"
     # OpenFileGDB requires creating the file on the first layer, then appending the
@@ -189,9 +198,14 @@ def _write_gdb_zip(
     # GeoDataFrames (spatial, one geometry type per layer) and plain DataFrames
     # (non-spatial tables like node_stname / altnames, which have no geometry column).
     for i, (layer_name, gdf) in enumerate(layers):
+        write_kwargs: dict[str, Any] = {}
         if gdf.empty:
-            raise ValueError(f"No rows to export for GDB layer '{layer_name}'")
-        if isinstance(gdf, gpd.GeoDataFrame):
+            if layer_name not in allow_empty:
+                raise ValueError(f"No rows to export for GDB layer '{layer_name}'")
+            # An empty frame carries no geometry to infer from, so name the type.
+            if isinstance(gdf, gpd.GeoDataFrame):
+                write_kwargs["geometry_type"] = "MultiPolygon"
+        elif isinstance(gdf, gpd.GeoDataFrame):
             gdf = _normalize_to_single_geom_type(gdf, layer_name)
         pyogrio.write_dataframe(
             gdf,
@@ -199,6 +213,7 @@ def _write_gdb_zip(
             driver="OpenFileGDB",
             layer=layer_name,
             append=i > 0,
+            **write_kwargs,
         )
     shutil.make_archive(
         str(file_path.with_suffix("")), "zip", tmp_dir, f"{gdb_name}.gdb"
@@ -308,6 +323,7 @@ def export(
 
     for filename, gdb_entries in gdb_groups.items():
         layers = []
+        allow_empty: set[str] = set()
         for output in gdb_entries:
             custom = output.custom or {}
             layer_name = custom.get("layer", output.name)
@@ -325,8 +341,12 @@ def export(
                 # Non-spatial GDB layer (no geometry_type) — read as a plain table.
                 gdf = pg_client.read_table_df(output.name)
             layers.append((layer_name, gdf))
+            if custom.get("allow_empty"):
+                allow_empty.add(layer_name)
         with tempfile.TemporaryDirectory() as tmp_str:
-            _write_gdb_zip(layers, dataset_files_folder / filename, Path(tmp_str))
+            _write_gdb_zip(
+                layers, dataset_files_folder / filename, Path(tmp_str), allow_empty
+            )
 
     if recipe.exports.zip_name:
         zip_path = output_folder / f"{recipe.exports.zip_name}.zip"

--- a/dcpy/lifecycle/builds/load.py
+++ b/dcpy/lifecycle/builds/load.py
@@ -118,12 +118,18 @@ def load_source_data_from_resolved_recipe(
 
     imported_datasets: dict[str, dict[str, ImportedDataset]] = defaultdict(dict)
     for ds in recipe.inputs.datasets:
+        # source_data_versions is keyed by dataset id, so a multi-layer source (one
+        # id imported under several `import_as` names) reports every layer as cached
+        # once any one of them is. Confirm the table is really there before using it.
+        table_name = ds.import_as or ds.id
         use_cached = (
             cache_schema
             and cached_entity_type
             and ds.destination == InputDatasetDestination.postgres
             and cache_source_versions_df is not None
             and dataset_exists_in_schema(ds, cache_source_versions_df)
+            and pg_client is not None
+            and pg_client.table_or_view_exists(table_name, schema=cache_schema)
         )
         if not use_cached:  # business as usual. Pull data and load it.
             file_path = data_loader.pull_dataset(ds, stage=LIFECYCLE_STAGE)
@@ -135,7 +141,6 @@ def load_source_data_from_resolved_recipe(
             logger.info(
                 f"Dataset {ds.dataset} version {ds.version} exists in schema {cache_schema}"
             )
-            table_name = ds.import_as or ds.id
             imported_datasets[ds.id][str(ds.version)] = ImportedDataset.from_input(
                 ds, table_name
             )

--- a/dcpy/test/lifecycle/builds/test_load.py
+++ b/dcpy/test/lifecycle/builds/test_load.py
@@ -179,3 +179,69 @@ class TestGetDataset:
         with load.get_imported_file(self.load_result, "csv") as stream:
             df = pd.read_csv(stream, dtype=str)
         assert df.equals(_test_df)
+
+
+class TestCachedLoad:
+    """The cache is keyed by dataset id, but tables are named by `import_as`."""
+
+    @staticmethod
+    def _recipe():
+        recipe = MagicMock()
+        recipe.name = "Tester"
+        recipe.inputs.datasets = [
+            InputDataset(
+                name="multi_layer_source",
+                import_as="layer_b",
+                version="v1",
+                file_type=recipes.DatasetType.csv,
+                destination=InputDatasetDestination.postgres,
+            )
+        ]
+        return recipe
+
+    def _load(self, table_exists: bool):
+        pg_client = MagicMock()
+        pg_client.table_or_view_exists.return_value = table_exists
+        # source_data_versions reports the *dataset id*, so the cache looks populated
+        # for every layer of a multi-layer source once any one of them is cached.
+        versions = pd.DataFrame(
+            [{"schema_name": "multi_layer_source", "v": "v1", "file_type": "csv"}]
+        )
+        with (
+            patch.object(load.postgres, "PostgresClient", return_value=pg_client),
+            patch.object(load, "get_source_data_versions", return_value=versions),
+            patch.object(load, "setup_build_pg_schema"),
+            patch.object(load.data_loader, "pull_dataset", return_value=CSV),
+            patch.object(
+                load,
+                "import_dataset",
+                return_value=ImportedDataset(
+                    id="multi_layer_source",
+                    version="v1",
+                    file_type=recipes.DatasetType.csv,
+                    destination="layer_b",
+                    destination_type=InputDatasetDestination.postgres,
+                ),
+            ) as import_dataset,
+        ):
+            load.load_source_data_from_resolved_recipe(
+                self._recipe(),
+                cache_schema="recipe_cache",
+                cached_entity_type=load.CachedEntityType.view,
+                target_schema="build_schema",
+                _write_metadata_file=False,
+            )
+        return pg_client, import_dataset
+
+    def test_uses_cache_when_table_present(self):
+        pg_client, import_dataset = self._load(table_exists=True)
+        pg_client.create_view.assert_called_once_with("layer_b", "recipe_cache")
+        import_dataset.assert_not_called()
+
+    def test_falls_back_to_pull_when_table_absent(self):
+        pg_client, import_dataset = self._load(table_exists=False)
+        pg_client.table_or_view_exists.assert_called_once_with(
+            "layer_b", schema="recipe_cache"
+        )
+        pg_client.create_view.assert_not_called()
+        import_dataset.assert_called_once()

--- a/products/cscl/README.md
+++ b/products/cscl/README.md
@@ -133,6 +133,50 @@ python3 poc_validation/prod_data_loader.py pull
 
 This currently sorts the files before comparison, so this isn't quite valid for comparing outputs that actually have some sort of sorting requirement. However for LION and other unordered files, it currently works as a check of total records with issues in the actual output files.
 
+## District boundary gdb
+
+`v26B_Districts.gdb.zip` holds the 43 district polygon feature classes defined by chapter 10 / table 39 of the ETL doc. Models live in `models/product/districts/`, one per feature class, named `gdb_<feature class>`.
+
+Feature class and field names follow **appendix D**, which is stale in places but was confirmed against the shapefiles DCP publishes on BYTES — those use appendix D's names exactly (`AssemDist`, `BoroCD`, `HCentDist`, `SchoolDist`, `StSenDist`). The `name` values in `product-metadata/products/lion/*` are friendly display names, not field names; don't build from them.
+
+Two places where the 2009 doc and the real product disagree, both settled empirically against the published shapefiles:
+
+- **Land is `WATER_FLAG IN ('2', '3', '4')`**, not `('2', '3')` as the doc says. Flag `4` postdates the doc and is land for clipping purposes; including it reproduces the published clipped extent exactly, excluding it falls about 1% short.
+- **Table 39 understates which layers are clipped.** It says layers with no `wi` twin are "extracted exactly as stored", but `nyfb`, `nyfc`, `nyfd`, `nypp`, `nysd`, `nynta2010`, `nynta2020`, `nycdta2020` and `nypuma2010` are all shoreline-clipped in the published product. Only `nyap`, `nyhez` and the internal-only layers are genuinely unclipped.
+
+### How the shoreline clip works
+
+Clipping is done by **subtracting water**, not by intersecting a dissolved land mask. The two are exact complements (4.632e9 + 8.423e9 = 13.055e9 sq ft), but water is 1,875 atomic polygons against land's 66,717, so it is far less geometry to touch.
+
+This matters a lot. Dissolving land into a single mask produced one **7.2M-vertex, 117 MB** geometry: it took ~86 minutes to build, and intersecting every district feature against it exhausted the build server's memory and put Postgres into recovery mode. The water mask builds in ~2 seconds and clips a 38k-feature layer in ~80.
+
+`int__water_mask` subdivides water to 256 vertices per row and GIST-indexes it. Clipped models pair `clip_to_shoreline` (a `LEFT JOIN LATERAL` that unions only the water each feature actually overlaps) with `clipped_geom` (the subtraction) in a `clipped` CTE, then drop rows the clip emptied — that is why e.g. `nycb2020` is shorter than `nycb2020wi`. Use those macros rather than open-coding the difference, and keep the geometry expression identical between the two calls.
+
+### Validating the district gdb
+
+Prod archives the geodatabase alongside the flat files, so this is a direct dev/prod diff:
+
+```bash
+python3 poc_validation/compare_districts.py
+```
+
+It reports per-layer column set, row count and total area against `edm-private/cscl_etl/<version>/v26B_Districts.gdb.zip`, and writes `output/validation_output/district_comparison.csv`. `SHAPE_Length`/`SHAPE_Area` are written by the gdb driver rather than by our models, so they're excluded from the column comparison.
+
+Prod quirks worth knowing before reading a diff:
+
+- **`nyura` carries a stale copy of `nybid`'s schema** (`BIDID`/`BID`/`BOROUGH`) instead of anything urban-renewal related. Both prod and the CSCL source layer are empty, so the mistake never shows up in data. We emit the real URA identifiers, so a structural diff on this one layer is expected and is whitelisted in the comparison script.
+- **`nymcea` is singlepart.** Clipping splits some MCEAs into disjoint pieces and prod writes each as its own feature, so the 115 dissolved (borough, MCEA) groups become 122 features.
+- **`nymc`/`nymcwi` exclude `MUNICOURT = '00'`**, an unassigned placeholder on 6 of the 34 source rows. That's what takes them to 28 features.
+- **`nypuma2020` ships in prod** even though table 39 predates it.
+
+### Open dev/prod diffs
+
+Two differences are unresolved as of 26b — real diffs a reviewer will hit, not settled quirks. Left open deliberately: each needs a decision, not more code.
+
+**`nymcea` fragments to 249 parts (prod: 122).** Prod's singlepart behavior is described above — 115 dissolved (borough, MCEA) groups become 122 features. Our output splits the same groups into **249** parts at the shoreline clip. These aren't slivers: all residual parts are ≥100 sq ft, and the sub-100-sqft filter in `clipped_geom` already gives exact prod part counts on `nycb2010/2020`, `nyct2010/2020`, `nyed`, `nypuma2020`. Total area matches prod (+0.000%) and attributes are correct. We did **not** tune a per-layer threshold to force 122 — that would be fitting noise. Open question for whoever owns MCEA: does prod apply a larger minimum mapping unit for MCEA, or dissolve *after* clipping?
+
+**Sub-0.5% area deltas on unclipped passthroughs:** `nyhez −0.454%`, `nycdwi −0.397%`, `nypp +0.341%`. These layers aren't shoreline-clipped, so clipping can't explain the shift. Working theory is `linearize()` coercing curved source geometry that prod preserves (same mechanism as the LION "Center of curvature" note below). **Unverified** — confirm the cause before sign-off; a 0.4% area shift on straight passthrough data isn't obviously benign.
+
 ## LION - Known data issues
 
 As we've continue to validate the outputs for LION, we've come across a bunch of "known" issues that have either been resolved but may return, or we've accepted that there are diffs, or what have you. A lot of these are documented loosely [here](https://nyco365.sharepoint.com/:w:/r/sites/NYCPLANNING/itd/edm/Shared%20Documents/DOCUMENTATION/GRU/CSCL/ETL/DE%20Pipeline%20-%20Project%20Tracking/Data%20Discrepancy%20Tracking/LION%20Flat%20Files%20%E2%80%93%20Data%20DiscrepancyIssue%20Tracking.docx?d=w60907e50f8044bd9bffe2508a299035f&csf=1&web=1&e=aZ59n8)

--- a/products/cscl/macros/clip_to_shoreline.sql
+++ b/products/cscl/macros/clip_to_shoreline.sql
@@ -1,0 +1,48 @@
+{% macro clip_to_shoreline(geom_column='d.geom') %}
+{#-
+  Join clause pairing a district layer with the water overlapping each feature, for
+  the "clipped to shoreline" half of the district boundary gdb. Use with
+  `clipped_geom` in the select list, which does the actual subtraction.
+
+  LEFT JOIN so features that touch no water survive with no water geometry, and
+  LATERAL so the union covers only the pieces the feature actually intersects
+  rather than the whole city.
+-#}
+LEFT JOIN LATERAL (
+        SELECT st_union(m.geom) AS geom
+        FROM {{ ref('int__water_mask') }} AS m
+        WHERE st_intersects({{ geom_column }}, m.geom)
+    ) AS water ON TRUE
+{%- endmacro %}
+
+
+{% macro clipped_geom(geom_column='d.geom', min_area=100) %}
+{#-
+  The district geometry with water removed, discarding parts below `min_area`.
+
+  District edges and atomic polygon edges are nominally coincident but differ in the
+  last bits, so subtracting water leaves hairline slivers along them — without the
+  filter the difference produces ~109k sub-square-foot fragments across nymcea alone.
+  Part areas fall into two clearly separated groups, nothing between 0.83 and 167
+  square feet, and a 100 sq ft floor reproduces prod's row counts exactly on every
+  affected layer (nycb2010/2020, nyct2010/2020, nyed, nypuma2020).
+
+  Features left with no qualifying part come back empty rather than NULL, so callers
+  can drop them with `WHERE NOT st_isempty(geom)`.
+-#}
+st_multi(coalesce(
+        (
+            SELECT st_union(part.geom)
+            FROM (
+                SELECT (st_dump(st_collectionextract(
+                    st_difference(
+                        {{ geom_column }},
+                        coalesce(water.geom, st_setsrid('POLYGON EMPTY'::geometry, st_srid({{ geom_column }})))
+                    ), 3
+                ))).geom
+            ) AS part
+            WHERE st_area(part.geom) >= {{ min_area }}
+        ),
+        st_setsrid('MULTIPOLYGON EMPTY'::geometry, st_srid({{ geom_column }}))
+    ))
+{%- endmacro %}

--- a/products/cscl/models/intermediate/districts/int__water_mask.sql
+++ b/products/cscl/models/intermediate/districts/int__water_mask.sql
@@ -1,0 +1,26 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+-- Water polygons, subdivided and indexed, used to clip the district layers to the
+-- shoreline by subtraction.
+--
+-- Clipping to land is done by subtracting water rather than intersecting land: the
+-- two are exact complements (4.632e9 + 8.423e9 = 13.055e9 sq ft) but water is 1,875
+-- atomic polygons against land's 66,717, so it is far less geometry to process.
+-- Dissolving land into a single mask instead produced one 7.2M-vertex, 117MB
+-- geometry that took ~86 minutes to build and exhausted the build server's memory
+-- when every district feature was intersected against it.
+--
+-- ST_Subdivide caps each row at 256 vertices so the GIST index stays selective and
+-- each per-feature union touches only nearby pieces.
+--
+-- WATER_FLAG '1' is water; '2' (non-water), '3' (pier) and '4' are land. The ETL
+-- spec predates flag '4' — see the note in the README.
+
+SELECT st_subdivide(geom, 256) AS geom
+FROM {{ ref('stg__atomicpolygons') }}
+WHERE water_flag = '1'

--- a/products/cscl/models/product/districts/_districts.yml
+++ b/products/cscl/models/product/districts/_districts.yml
@@ -1,0 +1,390 @@
+version: 2
+
+# Feature classes of the district boundary geodatabase (ETL spec ch. 10, table 39).
+# Column names and row counts are matched against prod's v26B_Districts.gdb.zip.
+
+models:
+- name: gdb_nyad
+  description: State assembly districts clipped to the shoreline.
+  columns:
+  - name: "'AssemDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyadwi
+  description: State assembly districts, water areas included (as stored in CSCL).
+  columns:
+  - name: "'AssemDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyap
+  description: Atomic polygons, the base geography of the ETL. Near-passthrough of the CSCL source layer.
+  columns:
+  - name: "'ATOMICID'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nybb
+  description: Borough boundaries clipped to the shoreline.
+  columns:
+  - name: "'BoroCode'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nybbwi
+  description: Borough boundaries, water areas included.
+  columns:
+  - name: "'BoroCode'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nybid
+  description: Business improvement districts.
+  columns:
+  - name: "'BIDID'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycb2010
+  description: 2010 census blocks clipped to the shoreline.
+  columns:
+  - name: "'BCTCB2010'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycb2010wi
+  description: 2010 census blocks, water areas included.
+  columns:
+  - name: "'BCTCB2010'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycb2020
+  description: 2020 census blocks clipped to the shoreline.
+  columns:
+  - name: "'BCTCB2020'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycb2020wi
+  description: 2020 census blocks, water areas included.
+  columns:
+  - name: "'BCTCB2020'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycc
+  description: City council districts clipped to the shoreline.
+  columns:
+  - name: "'CounDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyccwi
+  description: City council districts, water areas included.
+  columns:
+  - name: "'CounDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycd
+  description: Community districts clipped to the shoreline.
+  columns:
+  - name: "'BoroCD'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycdta2020
+  description: 2020 community district tabulation areas clipped to the shoreline.
+  columns:
+  - name: "'CDTA2020'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycdwi
+  description: Community districts, water areas included.
+  columns:
+  - name: "'BoroCD'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycg
+  description: Congressional districts clipped to the shoreline.
+  columns:
+  - name: "'CongDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nycgwi
+  description: Congressional districts, water areas included.
+  columns:
+  - name: "'CongDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyct2010
+  description: 2010 census tracts clipped to the shoreline.
+  columns:
+  - name: "'BoroCT2010'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyct2010wi
+  description: 2010 census tracts, water areas included.
+  columns:
+  - name: "'BoroCT2010'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyct2020
+  description: 2020 census tracts clipped to the shoreline.
+  columns:
+  - name: "'BoroCT2020'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyct2020wi
+  description: 2020 census tracts, water areas included.
+  columns:
+  - name: "'BoroCT2020'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyed
+  description: Election districts clipped to the shoreline.
+  columns:
+  - name: "'ElectDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyedwi
+  description: Election districts, water areas included.
+  columns:
+  - name: "'ElectDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyfb
+  description: Fire battalions clipped to the shoreline.
+  columns:
+  - name: "'FireBN'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyfc
+  description: Fire companies clipped to the shoreline.
+  columns:
+  - name: "'FireCoNum'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyfd
+  description: Fire divisions clipped to the shoreline.
+  columns:
+  - name: "'FireDiv'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyha
+  description: Health areas clipped to the shoreline.
+  columns:
+  - name: "'HealthArea'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyhc
+  description: Health center districts clipped to the shoreline.
+  columns:
+  - name: "'HCentDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyhd
+  description: Historic districts.
+  columns:
+  - name: "'LP_NUMBER'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyhez
+  description: Hurricane evacuation zones, water areas included.
+  columns:
+  - name: "'HURRICANE_EVACUATION_ZONE'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nymc
+  description: Municipal court districts clipped to the shoreline, excluding the '00' placeholder.
+  columns:
+  - name: "'MuniCourt'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nymcea
+  description: Minor census economic areas, dissolved from 2000 census tracts, clipped and split to singlepart.
+  columns:
+  - name: "'MCEA'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nymcwi
+  description: Municipal court districts, water areas included, excluding the '00' placeholder.
+  columns:
+  - name: "'MuniCourt'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nynta2010
+  description: 2010 neighborhood tabulation areas clipped to the shoreline.
+  columns:
+  - name: "'NTACode'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nynta2020
+  description: 2020 neighborhood tabulation areas clipped to the shoreline.
+  columns:
+  - name: "'NTA2020'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nypp
+  description: Police precincts clipped to the shoreline.
+  columns:
+  - name: "'Precinct'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nypuma2010
+  description: 2010 public use microdata areas, dissolved from 2010 census tracts and clipped to the shoreline.
+  columns:
+  - name: "'PUMA'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nypuma2020
+  description: 2020 public use microdata areas, dissolved from 2020 census tracts and clipped to the shoreline.
+  columns:
+  - name: "'PUMA'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nysd
+  description: School districts clipped to the shoreline. District 10 is split into one polygon per borough.
+  columns:
+  - name: "'SchoolDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyss
+  description: State senate districts clipped to the shoreline.
+  columns:
+  - name: "'StSenDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nysswi
+  description: State senate districts, water areas included.
+  columns:
+  - name: "'StSenDist'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyura
+  description: Urban renewal areas. The CSCL source layer is currently empty.
+  columns:
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]
+
+- name: gdb_nyzip
+  description: Zip code areas.
+  columns:
+  - name: "'ZIP_CODE'"
+    data_tests: [ not_null ]
+  - name: geom
+    description: Polygon geometry (MultiPolygon, EPSG:2263)
+    data_tests: [ not_null ]

--- a/products/cscl/models/product/districts/gdb_nyad.sql
+++ b/products/cscl/models/product/districts/gdb_nyad.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.assemdist::int AS "AssemDist",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__assemblydistrict') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyadwi.sql
+++ b/products/cscl/models/product/districts/gdb_nyadwi.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.assemdist::int AS "AssemDist",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__assemblydistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nyap.sql
+++ b/products/cscl/models/product/districts/gdb_nyap.sql
@@ -1,0 +1,37 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area",
+    d.borocode AS "BOROUGH",
+    d.censusblock_2000_basic::text AS "CENSUSBLOCK_2000",
+    d.censusblock_2000_suffix AS "CENSUSBLOCK_2000_SUFFIX",
+    d.censustract_2000 AS "CENSUSTRACT_2000",
+    d.censusblock_2010_raw AS "CENSUSBLOCK_2010",
+    d.censusblock_2010_suffix::text AS "CENSUSBLOCK_2010_SUFFIX",
+    d.censustract_2010 AS "CENSUSTRACT_2010",
+    d.censustract_1990 AS "CENSUSTRACT_1990",
+    d.admin_fire_company AS "ADMIN_FIRE_COMPANY",
+    d.water_flag AS "WATER_FLAG",
+    d.assemdist AS "ASSEMDIST",
+    d.electdist AS "ELECTDIST",
+    d.schooldist AS "SCHOOLDIST",
+    d.commdist AS "COMMDIST",
+    d.sb1_volume AS "SB1_VOLUME",
+    d.sb1_page AS "SB1_PAGE",
+    d.sb2_volume AS "SB2_VOLUME",
+    d.sb2_page AS "SB2_PAGE",
+    d.sb3_volume AS "SB3_VOLUME",
+    d.sb3_page AS "SB3_PAGE",
+    d.atomicid AS "ATOMICID",
+    d.atomic_num AS "ATOMIC_NUM",
+    d.hurricane_evacuation_zone AS "HURRICANE_EVACUATION_ZONE",
+    d.censustract_2020 AS "CENSUSTRACT_2020",
+    d.censusblock_2020_basic::text AS "CENSUSBLOCK_2020",
+    d.censusblock_2020_suffix::text AS "CENSUSBLOCK_2020_SUFFIX",
+    d.commercial_waste_zone AS "COMMERCIAL_WASTE_ZONE",
+    d.geom
+FROM {{ ref('stg__atomicpolygons') }} AS d

--- a/products/cscl/models/product/districts/gdb_nybb.sql
+++ b/products/cscl/models/product/districts/gdb_nybb.sql
@@ -1,0 +1,20 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.borocode::int AS "BoroCode",
+        d.boroname AS "BoroName",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__borough') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nybbwi.sql
+++ b/products/cscl/models/product/districts/gdb_nybbwi.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.borocode::int AS "BoroCode",
+    d.boroname AS "BoroName",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__borough') }} AS d

--- a/products/cscl/models/product/districts/gdb_nybid.sql
+++ b/products/cscl/models/product/districts/gdb_nybid.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.bidid::int AS "BIDID",
+    d.bid AS "BID",
+    d.borough AS "BOROUGH",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__businessimprovementdistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nycb2010.sql
+++ b/products/cscl/models/product/districts/gdb_nycb2010.sql
@@ -1,0 +1,24 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.cb AS "CB2010",
+        d.borocode AS "BoroCode",
+        b.boroname AS "BoroName",
+        d.ct AS "CT2010",
+        d.bctcb AS "BCTCB2010",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__censusblock2010') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nycb2010wi.sql
+++ b/products/cscl/models/product/districts/gdb_nycb2010wi.sql
@@ -1,0 +1,16 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.cb AS "CB2010",
+    d.borocode AS "BoroCode",
+    b.boroname AS "BoroName",
+    d.ct AS "CT2010",
+    d.bctcb AS "BCTCB2010",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__censusblock2010') }} AS d
+INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode

--- a/products/cscl/models/product/districts/gdb_nycb2020.sql
+++ b/products/cscl/models/product/districts/gdb_nycb2020.sql
@@ -1,0 +1,25 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.cb AS "CB2020",
+        d.borocode AS "BoroCode",
+        b.boroname AS "BoroName",
+        d.ct AS "CT2020",
+        d.bctcb AS "BCTCB2020",
+        '36' || b.fips || d.ct || d.cb AS "GEOID",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__censusblock2020') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nycb2020wi.sql
+++ b/products/cscl/models/product/districts/gdb_nycb2020wi.sql
@@ -1,0 +1,17 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.cb AS "CB2020",
+    d.borocode AS "BoroCode",
+    b.boroname AS "BoroName",
+    d.ct AS "CT2020",
+    d.bctcb AS "BCTCB2020",
+    '36' || b.fips || d.ct || d.cb AS "GEOID",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__censusblock2020') }} AS d
+INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode

--- a/products/cscl/models/product/districts/gdb_nycc.sql
+++ b/products/cscl/models/product/districts/gdb_nycc.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.coundist::int AS "CounDist",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__citycouncildistrict') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyccwi.sql
+++ b/products/cscl/models/product/districts/gdb_nyccwi.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.coundist::int AS "CounDist",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__citycouncildistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nycd.sql
+++ b/products/cscl/models/product/districts/gdb_nycd.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.commdist::int AS "BoroCD",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__communitydistrict') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nycdta2020.sql
+++ b/products/cscl/models/product/districts/gdb_nycdta2020.sql
@@ -1,0 +1,30 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- Borough is assigned by point-on-surface containment per the ETL spec's centroid
+-- rule; point-on-surface keeps the probe inside concave shapes.
+
+WITH clipped AS (
+    SELECT
+        b.borocode::int AS "BoroCode",
+        b.boroname AS "BoroName",
+        b.fips AS "CountyFIPS",
+        d.cdta_code AS "CDTA2020",
+        cdta.cdta_name AS "CDTAName",
+        cdta.cdta_type AS "CDTAType",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__cdta2020') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b
+        ON st_contains(b.geom, st_pointonsurface(d.geom))
+    LEFT JOIN {{ ref('stg__cdtaequiv2020') }} AS cdta ON d.cdta_code = cdta.cdta_code
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nycdwi.sql
+++ b/products/cscl/models/product/districts/gdb_nycdwi.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.commdist::int AS "BoroCD",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__communitydistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nycg.sql
+++ b/products/cscl/models/product/districts/gdb_nycg.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.congdist::int AS "CongDist",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__congressionaldistrict') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nycgwi.sql
+++ b/products/cscl/models/product/districts/gdb_nycgwi.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.congdist::int AS "CongDist",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__congressionaldistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nyct2010.sql
+++ b/products/cscl/models/product/districts/gdb_nyct2010.sql
@@ -1,0 +1,30 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.ctlabel AS "CTLabel",
+        d.borocode AS "BoroCode",
+        b.boroname AS "BoroName",
+        d.ct AS "CT2010",
+        d.boroct AS "BoroCT2010",
+        d.cd_eligibility AS "CDEligibil",
+        npc.neighborhood_code AS "NTACode",
+        npc.neighborhood_name AS "NTAName",
+        d.puma AS "PUMA",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__censustract2010') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode
+    LEFT JOIN {{ ref('stg__neighborhoodpumacodes') }} AS npc
+        ON d.borocode = npc.borough AND d.ct::int = npc.censustract
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyct2010wi.sql
+++ b/products/cscl/models/product/districts/gdb_nyct2010wi.sql
@@ -1,0 +1,22 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.ctlabel AS "CTLabel",
+    d.borocode AS "BoroCode",
+    b.boroname AS "BoroName",
+    d.ct AS "CT2010",
+    d.boroct AS "BoroCT2010",
+    d.cd_eligibility AS "CDEligibil",
+    npc.neighborhood_code AS "NTACode",
+    npc.neighborhood_name AS "NTAName",
+    d.puma AS "PUMA",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__censustract2010') }} AS d
+INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode
+LEFT JOIN {{ ref('stg__neighborhoodpumacodes') }} AS npc
+    ON d.borocode = npc.borough AND d.ct::int = npc.censustract

--- a/products/cscl/models/product/districts/gdb_nyct2020.sql
+++ b/products/cscl/models/product/districts/gdb_nyct2020.sql
@@ -1,0 +1,50 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- CDTANAME is upper-cased here but mixed-case in nynta2020; that inconsistency is
+-- present in the published product and is preserved deliberately.
+
+WITH clipped AS (
+    SELECT
+        d.ctlabel AS "CTLabel",
+        d.borocode AS "BoroCode",
+        b.boroname AS "BoroName",
+        d.ct AS "CT2020",
+        d.boroct AS "BoroCT2020",
+        d.cd_eligibility AS "CDEligibil",
+        nta.nta_name AS "NTAName",
+        d.neighborhood_code AS "NTA2020",
+        d.cdta_code AS "CDTA2020",
+        cdta.cdta_name AS "CDTANAME",
+        '36' || b.fips || d.ct AS "GEOID",
+        d.puma,
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__censustract2020') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode
+    LEFT JOIN {{ ref('stg__ntaequiv2020') }} AS nta ON d.neighborhood_code = nta.nta_code
+    LEFT JOIN {{ ref('stg__cdtaequiv2020') }} AS cdta ON d.cdta_code = cdta.cdta_code
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+-- columns are listed rather than SELECT * so PUMA lands after the shape fields,
+-- matching prod's field order
+SELECT
+    "CTLabel",
+    "BoroCode",
+    "BoroName",
+    "CT2020",
+    "BoroCT2020",
+    "CDEligibil",
+    "NTAName",
+    "NTA2020",
+    "CDTA2020",
+    "CDTANAME",
+    "GEOID",
+    geom,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area",
+    puma AS "PUMA"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyct2020wi.sql
+++ b/products/cscl/models/product/districts/gdb_nyct2020wi.sql
@@ -1,0 +1,28 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- CDTANAME is upper-cased here but mixed-case in nynta2020; that inconsistency is
+-- present in the published product and is preserved deliberately.
+
+SELECT
+    d.ctlabel AS "CTLabel",
+    d.borocode AS "BoroCode",
+    b.boroname AS "BoroName",
+    d.ct AS "CT2020",
+    d.boroct AS "BoroCT2020",
+    d.cd_eligibility AS "CDEligibil",
+    nta.nta_name AS "NTAName",
+    d.neighborhood_code AS "NTA2020",
+    d.cdta_code AS "CDTA2020",
+    cdta.cdta_name AS "CDTANAME",
+    '36' || b.fips || d.ct AS "GEOID",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area",
+    d.puma AS "PUMA"
+FROM {{ ref('stg__censustract2020') }} AS d
+INNER JOIN {{ ref('stg__borough') }} AS b ON d.borocode = b.borocode
+LEFT JOIN {{ ref('stg__ntaequiv2020') }} AS nta ON d.neighborhood_code = nta.nta_code
+LEFT JOIN {{ ref('stg__cdtaequiv2020') }} AS cdta ON d.cdta_code = cdta.cdta_code

--- a/products/cscl/models/product/districts/gdb_nyed.sql
+++ b/products/cscl/models/product/districts/gdb_nyed.sql
@@ -1,0 +1,21 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- ElectDist packs the assembly district into the high digits (AD 23, ED 003 -> 23003).
+
+WITH clipped AS (
+    SELECT
+        (d.assembly_district::int * 1000 + d.electdist::int) AS "ElectDist",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__electiondistrict') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyedwi.sql
+++ b/products/cscl/models/product/districts/gdb_nyedwi.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- ElectDist packs the assembly district into the high digits (AD 23, ED 003 -> 23003).
+
+SELECT
+    (d.assembly_district::int * 1000 + d.electdist::int) AS "ElectDist",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__electiondistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nyfb.sql
+++ b/products/cscl/models/product/districts/gdb_nyfb.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.battalion::int AS "FireBN",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__firebattalion') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyfc.sql
+++ b/products/cscl/models/product/districts/gdb_nyfc.sql
@@ -1,0 +1,24 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- UNIT_SHORT packs company type and number into one field (e.g. 'E 14').
+
+WITH clipped AS (
+    SELECT
+        split_part(d.unit_short, ' ', 1) AS "FireCoType",
+        split_part(d.unit_short, ' ', 2)::int AS "FireCoNum",
+        d.fire_battalion::int AS "FireBN",
+        d.fire_division::int AS "FireDiv",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__firecompany') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyfd.sql
+++ b/products/cscl/models/product/districts/gdb_nyfd.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.div::int AS "FireDiv",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__firedivision') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyha.sql
+++ b/products/cscl/models/product/districts/gdb_nyha.sql
@@ -1,0 +1,22 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        b.borocode::int AS "BoroCode",
+        b.boroname AS "BoroName",
+        d.healtharea::int AS "HealthArea",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__healtharea') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON d.borough = b.borocode
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyhc.sql
+++ b/products/cscl/models/product/districts/gdb_nyhc.sql
@@ -1,0 +1,25 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- Health center districts are numbered by borough (e.g. 3x = Brooklyn); the source
+-- carries no borough column, so the leading digit is the join key.
+
+WITH clipped AS (
+    SELECT
+        b.borocode::int AS "BoroCode",
+        b.boroname AS "BoroName",
+        d.hcentdist::int AS "HCentDist",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__healthcenterdistrict') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON left(d.hcentdist, 1) = b.borocode
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyhd.sql
+++ b/products/cscl/models/product/districts/gdb_nyhd.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.name AS "NAME",
+    d.lp_number AS "LP_NUMBER",
+    d.designated AS "DESIGNATED",
+    d.borough AS "BOROUGH",
+    d.extension AS "EXTENSION",
+    d.created_by AS "CREATED_BY",
+    d.created_date AS "CREATED_DATE",
+    d.modified_by AS "MODIFIED_BY",
+    d.modified_date AS "MODIFIED_DATE",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__historicdistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nyhez.sql
+++ b/products/cscl/models/product/districts/gdb_nyhez.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.hurricane_evacuation_zone AS "HURRICANE_EVACUATION_ZONE",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__hurricaneevacuationzone') }} AS d
+WHERE d.hurricane_evacuation_zone IS NOT NULL

--- a/products/cscl/models/product/districts/gdb_nymc.sql
+++ b/products/cscl/models/product/districts/gdb_nymc.sql
@@ -1,0 +1,26 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- MUNICOURT '00' is an unassigned placeholder (6 of the 34 source rows) and is
+-- excluded, which is what takes prod to 28 features.
+
+WITH clipped AS (
+    SELECT
+        b.borocode::int AS "BoroCode",
+        b.boroname AS "BoroName",
+        d.municourt AS "MuniCourt",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__municourtdistrict') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON d.borough = b.borocode
+    {{ clip_to_shoreline('d.geom') }}
+    WHERE d.municourt != '00'
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nymcea.sql
+++ b/products/cscl/models/product/districts/gdb_nymcea.sql
@@ -1,0 +1,48 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- Minor Census Economic Areas are not modelled in CSCL; they are dissolved from the
+-- MCEA attribute on 2000 census tracts. Clipping splits some areas into disjoint
+-- pieces and prod writes each as its own feature, so the dissolved groups are
+-- exploded back to singlepart (115 groups -> 122 features). No water-included
+-- version is required.
+
+WITH dissolved AS (
+    SELECT
+        borocode,
+        mcea,
+        st_union(geom) AS geom
+    FROM {{ ref('stg__censustract2000') }}
+    WHERE mcea IS NOT NULL
+    GROUP BY borocode, mcea
+),
+
+clipped AS (
+    SELECT
+        d.borocode,
+        d.mcea,
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM dissolved AS d
+    {{ clip_to_shoreline('d.geom') }}
+),
+
+singlepart AS (
+    SELECT
+        c.borocode AS "BOROCODE",
+        c.mcea AS "MCEA",
+        b.boroname AS "BoroName",
+        st_multi((st_dump(c.geom)).geom) AS geom
+    FROM clipped AS c
+    INNER JOIN {{ ref('stg__borough') }} AS b ON c.borocode = b.borocode
+    WHERE NOT st_isempty(c.geom)
+)
+
+-- prod spells these mixed-case on this layer alone; every other feature class
+-- uses SHAPE_Length/SHAPE_Area
+SELECT
+    *,
+    st_perimeter(geom) AS "Shape_Length",
+    st_area(geom) AS "Shape_Area"
+FROM singlepart

--- a/products/cscl/models/product/districts/gdb_nymcwi.sql
+++ b/products/cscl/models/product/districts/gdb_nymcwi.sql
@@ -1,0 +1,18 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- MUNICOURT '00' is an unassigned placeholder (6 of the 34 source rows) and is
+-- excluded, which is what takes prod to 28 features.
+
+SELECT
+    b.borocode::int AS "BoroCode",
+    b.boroname AS "BoroName",
+    d.municourt AS "MuniCourt",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__municourtdistrict') }} AS d
+INNER JOIN {{ ref('stg__borough') }} AS b ON d.borough = b.borocode
+WHERE d.municourt != '00'

--- a/products/cscl/models/product/districts/gdb_nynta2010.sql
+++ b/products/cscl/models/product/districts/gdb_nynta2010.sql
@@ -1,0 +1,34 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- Borough is assigned by point-on-surface containment per the ETL spec's centroid
+-- rule; point-on-surface keeps the probe inside concave shapes.
+
+WITH clipped AS (
+    SELECT
+        b.borocode::int AS "BoroCode",
+        b.boroname AS "BoroName",
+        b.fips AS "CountyFIPS",
+        d.neighborhood_code AS "NTACode",
+        npc.neighborhood_name AS "NTAName",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__neighborhood') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b
+        ON st_contains(b.geom, st_pointonsurface(d.geom))
+    LEFT JOIN (
+        SELECT DISTINCT
+            neighborhood_code,
+            neighborhood_name
+        FROM {{ ref('stg__neighborhoodpumacodes') }}
+    ) AS npc ON d.neighborhood_code = npc.neighborhood_code
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nynta2020.sql
+++ b/products/cscl/models/product/districts/gdb_nynta2020.sql
@@ -1,0 +1,38 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- Borough is assigned by point-on-surface containment per the ETL spec's centroid
+-- rule; point-on-surface keeps the probe inside concave shapes.
+-- CDTA is matched the same way.
+
+WITH clipped AS (
+    SELECT
+        b.borocode::int AS "BoroCode",
+        b.boroname AS "BoroName",
+        b.fips AS "CountyFIPS",
+        d.neighborhood_code AS "NTA2020",
+        nta.nta_name AS "NTAName",
+        nta.nta_abbrev AS "NTAAbbrev",
+        nta.nta_type AS "NTAType",
+        cdta.cdta_code AS "CDTA2020",
+        cdta_equiv.cdta_name AS "CDTAName",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__nta2020') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b
+        ON st_contains(b.geom, st_pointonsurface(d.geom))
+    LEFT JOIN {{ ref('stg__ntaequiv2020') }} AS nta ON d.neighborhood_code = nta.nta_code
+    LEFT JOIN {{ ref('stg__cdta2020') }} AS cdta
+        ON st_contains(cdta.geom, st_pointonsurface(d.geom))
+    LEFT JOIN {{ ref('stg__cdtaequiv2020') }} AS cdta_equiv
+        ON cdta.cdta_code = cdta_equiv.cdta_code
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nypp.sql
+++ b/products/cscl/models/product/districts/gdb_nypp.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.precinct::int AS "Precinct",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__nypdprecinct') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nypuma2010.sql
+++ b/products/cscl/models/product/districts/gdb_nypuma2010.sql
@@ -1,0 +1,30 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- PUMAs are not modelled in CSCL; they are dissolved from 2010 census tracts.
+
+WITH dissolved AS (
+    SELECT
+        puma,
+        st_union(geom) AS geom
+    FROM {{ ref('stg__censustract2010') }}
+    WHERE puma IS NOT NULL
+    GROUP BY puma
+),
+
+clipped AS (
+    SELECT
+        d.puma AS "PUMA",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM dissolved AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nypuma2020.sql
+++ b/products/cscl/models/product/districts/gdb_nypuma2020.sql
@@ -1,0 +1,31 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- PUMAs are not modelled in CSCL; they are dissolved from 2020 census tracts.
+-- Table 39 predates this feature class but prod ships it.
+
+WITH dissolved AS (
+    SELECT
+        puma,
+        st_union(geom) AS geom
+    FROM {{ ref('stg__censustract2020') }}
+    WHERE puma IS NOT NULL
+    GROUP BY puma
+),
+
+clipped AS (
+    SELECT
+        d.puma AS "PUMA",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM dissolved AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nysd.sql
+++ b/products/cscl/models/product/districts/gdb_nysd.sql
@@ -1,0 +1,41 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.schooldist::int AS "SchoolDist",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__schooldistrict') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+    WHERE d.schooldist::int != 10
+),
+
+-- District 10 spans two boroughs and is written out once per borough, both parts
+-- keeping the same district number (ETL spec ch. 10, table 39 note **).
+district_10_split AS (
+    SELECT
+        d.schooldist::int AS "SchoolDist",
+        {{ clipped_geom('st_intersection(d.geom, b.geom)') }} AS geom
+    FROM {{ ref('stg__schooldistrict') }} AS d
+    INNER JOIN {{ ref('stg__borough') }} AS b ON st_intersects(d.geom, b.geom)
+    {{ clip_to_shoreline('st_intersection(d.geom, b.geom)') }}
+    WHERE d.schooldist::int = 10
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)
+
+UNION ALL
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM district_10_split
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nyss.sql
+++ b/products/cscl/models/product/districts/gdb_nyss.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+WITH clipped AS (
+    SELECT
+        d.stsendist::int AS "StSenDist",
+        {{ clipped_geom('d.geom') }} AS geom
+    FROM {{ ref('stg__statesenatedistrict') }} AS d
+    {{ clip_to_shoreline('d.geom') }}
+)
+
+SELECT
+    *,
+    st_perimeter(geom) AS "SHAPE_Length",
+    st_area(geom) AS "SHAPE_Area"
+FROM clipped
+WHERE NOT st_isempty(geom)

--- a/products/cscl/models/product/districts/gdb_nysswi.sql
+++ b/products/cscl/models/product/districts/gdb_nysswi.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.stsendist::int AS "StSenDist",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__statesenatedistrict') }} AS d

--- a/products/cscl/models/product/districts/gdb_nyura.sql
+++ b/products/cscl/models/product/districts/gdb_nyura.sql
@@ -1,0 +1,21 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+-- Appendix D carries no schema for this layer; per ETL spec ch. 10 the district
+-- identifier is the only required attribute.
+--
+-- Prod's nyura is a stale copy of nybid's schema (BIDID/BID/BOROUGH) rather than
+-- anything urban-renewal related. Both prod and the CSCL source layer are empty, so
+-- the mistake is invisible in the data. The real URA identifiers are emitted here
+-- instead of reproducing that; expect a structural diff on this one layer.
+
+SELECT
+    d.uraid::int AS "URAID",
+    d.uranum::int AS "URANum",
+    d.site_name AS "SiteName",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__urbanrenewalarea') }} AS d

--- a/products/cscl/models/product/districts/gdb_nyzip.sql
+++ b/products/cscl/models/product/districts/gdb_nyzip.sql
@@ -1,0 +1,17 @@
+{{ config(
+    materialized='table',
+    indexes=[{'columns': ['geom'], 'type': 'gist'}]
+) }}
+
+SELECT
+    d.po_name AS "PO_NAME",
+    d.county AS "COUNTY",
+    d.created_by AS "CREATED_BY",
+    d.created_date AS "CREATED_DATE",
+    d.modified_by AS "MODIFIED_BY",
+    d.modified_date AS "MODIFIED_DATE",
+    d.zip_code AS "ZIP_CODE",
+    d.geom,
+    st_perimeter(d.geom) AS "SHAPE_Length",
+    st_area(d.geom) AS "SHAPE_Area"
+FROM {{ ref('stg__zipcode') }} AS d

--- a/products/cscl/models/sources.yml
+++ b/products/cscl/models/sources.yml
@@ -58,6 +58,27 @@ sources:
   - name: dcp_cscl_universalword
   - name: dcp_cscl_zipcode
   - name: dcp_cscl_electiondistrict
+
+  # district boundary gdb source layers (ETL spec ch. 10, table 39)
+  - name: dcp_cscl_assemblydistrict
+  - name: dcp_cscl_borough
+  - name: dcp_cscl_businessimprovementdistrict
+  - name: dcp_cscl_censusblock2010
+  - name: dcp_cscl_censusblock2020
+  - name: dcp_cscl_censustract2000
+  - name: dcp_cscl_citycouncildistrict
+  - name: dcp_cscl_communitydistrict
+  - name: dcp_cscl_congressionaldistrict
+  - name: dcp_cscl_firebattalion
+  - name: dcp_cscl_firedivision
+  - name: dcp_cscl_healthcenterdistrict
+  - name: dcp_cscl_historicdistrict
+  - name: dcp_cscl_hurricaneevacuationzone
+  - name: dcp_cscl_municourtdistrict
+  - name: dcp_cscl_neighborhood
+  - name: dcp_cscl_schooldistrict
+  - name: dcp_cscl_statesenatedistrict
+  - name: dcp_cscl_urbanrenewalarea
   - name: dcp_cscl_neighborhoodpumacodes
 
 # TODO - remove when pipeline is fully operationalized

--- a/products/cscl/models/staging/stg__assemblydistrict.sql
+++ b/products/cscl/models/staging/stg__assemblydistrict.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    assemdist,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_assemblydistrict") }}

--- a/products/cscl/models/staging/stg__atomicpolygons.sql
+++ b/products/cscl/models/staging/stg__atomicpolygons.sql
@@ -7,6 +7,9 @@
 
 SELECT
     atomicid,
+    -- carried through raw for the nyap feature class, which publishes them as stored
+    atomic_num,
+    admin_fire_company,
     borough AS borocode,
     -- census 1990
     censustract_1990,

--- a/products/cscl/models/staging/stg__borough.sql
+++ b/products/cscl/models/staging/stg__borough.sql
@@ -1,0 +1,16 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    borocode,
+    boroname,
+    county,
+    fips,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_borough") }}

--- a/products/cscl/models/staging/stg__businessimprovementdistrict.sql
+++ b/products/cscl/models/staging/stg__businessimprovementdistrict.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    bidid,
+    bid,
+    borough,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_businessimprovementdistrict") }}

--- a/products/cscl/models/staging/stg__cdta2020.sql
+++ b/products/cscl/models/staging/stg__cdta2020.sql
@@ -1,0 +1,14 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    cdta_code,
+
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_cdta2020") }}

--- a/products/cscl/models/staging/stg__cdtaequiv2020.sql
+++ b/products/cscl/models/staging/stg__cdtaequiv2020.sql
@@ -1,0 +1,6 @@
+SELECT
+    cdta_code,
+    cdta_name,
+    cdta_type
+
+FROM {{ source("recipe_sources", "dcp_cscl_cdtaequiv2020") }}

--- a/products/cscl/models/staging/stg__censusblock2010.sql
+++ b/products/cscl/models/staging/stg__censusblock2010.sql
@@ -1,0 +1,17 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    borocode,
+    ct,
+    cb,
+    cb_suffix,
+    bctcb,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_censusblock2010") }}

--- a/products/cscl/models/staging/stg__censusblock2020.sql
+++ b/products/cscl/models/staging/stg__censusblock2020.sql
@@ -1,0 +1,17 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    borocode,
+    ct,
+    cb,
+    cb_suffix,
+    bctcb,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_censusblock2020") }}

--- a/products/cscl/models/staging/stg__censustract2000.sql
+++ b/products/cscl/models/staging/stg__censustract2000.sql
@@ -1,0 +1,21 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    ctlabel,
+    borocode,
+    neighborhood_code,
+    ct,
+    boroct,
+    cd_eligibility,
+    puma,
+    mcea,
+    health_area,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_censustract2000") }}

--- a/products/cscl/models/staging/stg__citycouncildistrict.sql
+++ b/products/cscl/models/staging/stg__citycouncildistrict.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    coundist,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_citycouncildistrict") }}

--- a/products/cscl/models/staging/stg__communitydistrict.sql
+++ b/products/cscl/models/staging/stg__communitydistrict.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    commdist,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_communitydistrict") }}

--- a/products/cscl/models/staging/stg__congressionaldistrict.sql
+++ b/products/cscl/models/staging/stg__congressionaldistrict.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    congdist,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_congressionaldistrict") }}

--- a/products/cscl/models/staging/stg__firebattalion.sql
+++ b/products/cscl/models/staging/stg__firebattalion.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    battalion,
+    division,
+    boroughcommand,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_firebattalion") }}

--- a/products/cscl/models/staging/stg__firecompany.sql
+++ b/products/cscl/models/staging/stg__firecompany.sql
@@ -1,11 +1,17 @@
-WITH source AS (
-    SELECT * FROM {{ source('recipe_sources', 'dcp_cscl_firecompany') }}
-)
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
 
 SELECT
     globalid,
     unit_short,
     boroughcommand AS fire_division,
     battalion AS fire_battalion,
-    geom
-FROM source
+    -- over half the source rows are MultiSurface; curved geometry silently drops
+    -- parts in overlay operations, so linearize as the other polygon staging models do
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source('recipe_sources', 'dcp_cscl_firecompany') }}

--- a/products/cscl/models/staging/stg__firedivision.sql
+++ b/products/cscl/models/staging/stg__firedivision.sql
@@ -1,0 +1,14 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    div,
+    boroughcommand,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_firedivision") }}

--- a/products/cscl/models/staging/stg__healthcenterdistrict.sql
+++ b/products/cscl/models/staging/stg__healthcenterdistrict.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    hcentdist,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_healthcenterdistrict") }}

--- a/products/cscl/models/staging/stg__historicdistrict.sql
+++ b/products/cscl/models/staging/stg__historicdistrict.sql
@@ -1,0 +1,21 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    name,
+    lp_number,
+    designated,
+    extension,
+    borough,
+    created_by,
+    created_date,
+    modified_by,
+    modified_date,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_historicdistrict") }}

--- a/products/cscl/models/staging/stg__hurricaneevacuationzone.sql
+++ b/products/cscl/models/staging/stg__hurricaneevacuationzone.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    hurricane_evacuation_zone,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_hurricaneevacuationzone") }}

--- a/products/cscl/models/staging/stg__municourtdistrict.sql
+++ b/products/cscl/models/staging/stg__municourtdistrict.sql
@@ -1,0 +1,14 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    municourt,
+    borough,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_municourtdistrict") }}

--- a/products/cscl/models/staging/stg__neighborhood.sql
+++ b/products/cscl/models/staging/stg__neighborhood.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    neighborhood_code,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_neighborhood") }}

--- a/products/cscl/models/staging/stg__nta2020.sql
+++ b/products/cscl/models/staging/stg__nta2020.sql
@@ -1,0 +1,14 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    neighborhood_code,
+
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_nta2020") }}

--- a/products/cscl/models/staging/stg__ntaequiv2020.sql
+++ b/products/cscl/models/staging/stg__ntaequiv2020.sql
@@ -1,0 +1,7 @@
+SELECT
+    nta_code,
+    nta_name,
+    nta_abbrev,
+    nta_type
+
+FROM {{ source("recipe_sources", "dcp_cscl_ntaequiv2020") }}

--- a/products/cscl/models/staging/stg__schooldistrict.sql
+++ b/products/cscl/models/staging/stg__schooldistrict.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    schooldist,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_schooldistrict") }}

--- a/products/cscl/models/staging/stg__statesenatedistrict.sql
+++ b/products/cscl/models/staging/stg__statesenatedistrict.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    stsendist,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_statesenatedistrict") }}

--- a/products/cscl/models/staging/stg__urbanrenewalarea.sql
+++ b/products/cscl/models/staging/stg__urbanrenewalarea.sql
@@ -1,0 +1,18 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    uranum,
+    uraid,
+    boro_name,
+    boro_num,
+    site_name,
+    urp,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_urbanrenewalarea") }}

--- a/products/cscl/models/staging/stg__zipcode.sql
+++ b/products/cscl/models/staging/stg__zipcode.sql
@@ -1,0 +1,19 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['geom'], 'type': 'gist'},
+    ]
+) }}
+
+SELECT
+    globalid,
+    zip_code,
+    po_name,
+    county,
+    created_by,
+    created_date,
+    modified_by,
+    modified_date,
+    st_makevalid(linearize(geom)) AS geom,
+    geom AS raw_geom
+FROM {{ source("recipe_sources", "dcp_cscl_zipcode") }}

--- a/products/cscl/poc_validation/compare_districts.py
+++ b/products/cscl/poc_validation/compare_districts.py
@@ -1,0 +1,160 @@
+"""Compare the dev district boundary gdb against the archived prod one.
+
+Run from the products/cscl directory:
+    python poc_validation/compare_districts.py
+
+    dev:  output/dataset_files/v26B_Districts.gdb.zip   (from the local/CI build)
+    prod: edm-private/cscl_etl/<version>/<filename>      (fetched to .data/prod/)
+
+For local iteration without S3 access, pass a local prod copy with --prod.
+
+Report-only: writes output/validation_output/district_comparison.csv and prints a
+report. It never fails the build on a mismatch.
+"""
+
+import csv
+import zipfile
+from pathlib import Path
+
+import geopandas as gpd
+import pyogrio
+import typer
+
+from dcpy.lifecycle.builds import plan
+from dcpy.utils import s3
+
+OUTPUT_DIR = Path("output/validation_output")
+PROD_BUCKET = "edm-private"
+
+# Prod's nyura carries a stale copy of nybid's schema; both are empty, so the
+# structural diff on this layer is expected. See models/product/districts/gdb_nyura.sql.
+KNOWN_STRUCTURAL_DIFFS = {"nyura"}
+
+app = typer.Typer(add_completion=False)
+
+
+def _inner_gdb(zip_path: Path) -> str:
+    """Return the /vsizip/... path to the .gdb inside a zip."""
+    abs_path = str(zip_path.resolve())
+    with zipfile.ZipFile(zip_path) as z:
+        names = z.namelist()
+    for n in names:
+        parts = n.split("/")
+        for i, p in enumerate(parts):
+            if p.endswith(".gdb"):
+                return f"/vsizip/{abs_path}/{'/'.join(parts[: i + 1])}"
+    # Some gdb zips carry the table files at the archive root.
+    return f"/vsizip/{abs_path}"
+
+
+def _layers(gdb: str) -> set[str]:
+    return {str(row[0]) for row in pyogrio.list_layers(gdb)}
+
+
+def _compare(dev_path: Path, prod_path: Path) -> None:
+    dev_gdb, prod_gdb = _inner_gdb(dev_path), _inner_gdb(prod_path)
+    dev_layers, prod_layers = _layers(dev_gdb), _layers(prod_gdb)
+
+    print("=== LAYERS ===")
+    only_prod = sorted(prod_layers - dev_layers)
+    only_dev = sorted(dev_layers - prod_layers)
+    if only_prod:
+        print(f"  missing from dev: {only_prod}")
+    if only_dev:
+        print(f"  extra in dev:     {only_dev}")
+    if not only_prod and not only_dev:
+        print(f"  {len(dev_layers)} layers, identical set")
+    print()
+
+    rows: list[dict] = []
+    for layer in sorted(dev_layers & prod_layers):
+        dev = gpd.read_file(dev_gdb, layer=layer)
+        prod = gpd.read_file(prod_gdb, layer=layer)
+
+        # SHAPE_Length/SHAPE_Area are real fields here: ESRI maintains them in prod,
+        # and our models compute them, so they are compared like any other column.
+        dev_cols = [c for c in dev.columns if c != "geometry"]
+        prod_cols = [c for c in prod.columns if c != "geometry"]
+        missing = sorted(set(prod_cols) - set(dev_cols))
+        extra = sorted(set(dev_cols) - set(prod_cols))
+
+        row_diff = len(dev) - len(prod)
+        dev_area, prod_area = dev.geometry.area.sum(), prod.geometry.area.sum()
+        area_pct = (dev_area - prod_area) / prod_area * 100 if prod_area else 0.0
+
+        flags = []
+        if missing:
+            flags.append(f"missing {missing}")
+        if extra:
+            flags.append(f"extra {extra}")
+        if not missing and not extra and dev_cols != prod_cols:
+            flags.append("column ORDER differs")
+        if row_diff:
+            flags.append(f"rows {row_diff:+,}")
+        if abs(area_pct) > 0.5:
+            flags.append(f"area {area_pct:+.2f}%")
+        note = "; ".join(flags) or "OK"
+        if flags and layer in KNOWN_STRUCTURAL_DIFFS:
+            note = f"KNOWN: {note}"
+
+        print(
+            f"  {layer:12s} dev={len(dev):>7,}  prod={len(prod):>7,}"
+            f"  area={area_pct:+7.3f}%  {note}"
+        )
+        rows.append({
+            "layer": layer, "dev_rows": len(dev), "prod_rows": len(prod),
+            "row_diff": row_diff, "dev_area": round(dev_area), "prod_area": round(prod_area),
+            "area_pct_diff": round(area_pct, 4), "missing_columns": ", ".join(missing),
+            "extra_columns": ", ".join(extra), "note": note,
+        })
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_csv = OUTPUT_DIR / "district_comparison.csv"
+    with out_csv.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    clean = sum(1 for r in rows if r["note"] == "OK")
+    print(f"\n{clean}/{len(rows)} layers match on structure, row count and area")
+    print(f"Per-layer CSV written to {out_csv}")
+
+
+@app.command()
+def run(
+    recipe_path: Path = typer.Option(Path("recipe.yml"), "--recipe", "-r"),
+    prod_version: str | None = typer.Option(None, "--prod-version", "-v"),
+    dev: Path | None = typer.Option(None, "--dev", "-d"),
+    prod: Path | None = typer.Option(None, "--prod", "-p"),
+) -> None:
+    """Compare the dev district gdb against prod, layer by layer."""
+    recipe = plan.recipe_from_yaml(recipe_path)
+    assert recipe.exports, "recipe has no exports"
+
+    filenames = sorted({
+        e.filename
+        for e in recipe.exports.datasets
+        if e.format.value == "gdb" and e.filename and "Districts" in e.filename
+    })
+    if not filenames:
+        print("No district gdb exports in recipe; nothing to compare.")
+        return
+    filename = filenames[0]
+
+    dev_path = dev if dev is not None else Path("output") / "dataset_files" / filename
+    if prod is not None:
+        prod_path = prod
+    else:
+        prod_path = Path(".data/prod") / filename
+        key = f"cscl_etl/{prod_version or recipe.version}/{filename}"
+        if not prod_path.exists():
+            print(f"Fetching prod gdb s3://{PROD_BUCKET}/{key}")
+            s3.download_file(PROD_BUCKET, key, prod_path)
+
+    print(f"dev:  {dev_path.resolve()}")
+    print(f"prod: {prod_path.resolve()}\n")
+    _compare(dev_path, prod_path)
+
+
+if __name__ == "__main__":
+    app()

--- a/products/cscl/poc_validation/compare_districts.py
+++ b/products/cscl/poc_validation/compare_districts.py
@@ -101,12 +101,24 @@ def _compare(dev_path: Path, prod_path: Path) -> None:
             f"  {layer:12s} dev={len(dev):>7,}  prod={len(prod):>7,}"
             f"  area={area_pct:+7.3f}%  {note}"
         )
-        rows.append({
-            "layer": layer, "dev_rows": len(dev), "prod_rows": len(prod),
-            "row_diff": row_diff, "dev_area": round(dev_area), "prod_area": round(prod_area),
-            "area_pct_diff": round(area_pct, 4), "missing_columns": ", ".join(missing),
-            "extra_columns": ", ".join(extra), "note": note,
-        })
+        rows.append(
+            {
+                "layer": layer,
+                "dev_rows": len(dev),
+                "prod_rows": len(prod),
+                "row_diff": row_diff,
+                "dev_area": round(dev_area),
+                "prod_area": round(prod_area),
+                "area_pct_diff": round(area_pct, 4),
+                "missing_columns": ", ".join(missing),
+                "extra_columns": ", ".join(extra),
+                "note": note,
+            }
+        )
+
+    if not rows:
+        print("No layers in common between dev and prod; nothing to report.")
+        return
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     out_csv = OUTPUT_DIR / "district_comparison.csv"
@@ -131,11 +143,13 @@ def run(
     recipe = plan.recipe_from_yaml(recipe_path)
     assert recipe.exports, "recipe has no exports"
 
-    filenames = sorted({
-        e.filename
-        for e in recipe.exports.datasets
-        if e.format.value == "gdb" and e.filename and "Districts" in e.filename
-    })
+    filenames = sorted(
+        {
+            e.filename
+            for e in recipe.exports.datasets
+            if e.format.value == "gdb" and e.filename and "Districts" in e.filename
+        }
+    )
     if not filenames:
         print("No district gdb exports in recipe; nothing to compare.")
         return

--- a/products/cscl/poc_validation/compare_gdb.py
+++ b/products/cscl/poc_validation/compare_gdb.py
@@ -11,7 +11,7 @@ The GDB filename(s) and version are resolved from recipe.yml. By default:
 For local iteration without S3 access, pass a local prod copy with --prod
 (e.g. --prod ../../.task-pipeline/nyclion_26a.zip).
 
-Report-only: writes a per-column CSV to output/validation_output/gdb_comparison.csv
+Report-only: writes a per-column CSV per gdb to output/validation_output/<name>_comparison.csv
 and prints a report to stdout. It never fails the build on a data mismatch.
 """
 
@@ -55,7 +55,7 @@ def _list_layers(gdb_vsi: str) -> dict[str, str | None]:
     return {str(row[0]): (str(row[1]) if row[1] else None) for row in rows}
 
 
-def _compare_layers(dev_path: Path, prod_path: Path) -> None:
+def _compare_layers(dev_path: Path, prod_path: Path, report_name: str) -> None:
     dev_gdb = _inner_gdb(dev_path)
     prod_gdb = _inner_gdb(prod_path)
 
@@ -148,7 +148,7 @@ def _compare_layers(dev_path: Path, prod_path: Path) -> None:
         print()
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    out_csv = OUTPUT_DIR / "gdb_comparison.csv"
+    out_csv = OUTPUT_DIR / f"{report_name}_comparison.csv"
     if all_col_rows:
         with out_csv.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=list(all_col_rows[0].keys()))
@@ -207,7 +207,7 @@ def run(
 
         print(f"\ndev:  {dev_path.resolve()}")
         print(f"prod: {prod_path.resolve()}\n")
-        _compare_layers(dev_path, prod_path)
+        _compare_layers(dev_path, prod_path, Path(filename).name.split(".")[0])
 
 
 if __name__ == "__main__":

--- a/products/cscl/recipe.yml
+++ b/products/cscl/recipe.yml
@@ -190,6 +190,103 @@ inputs:
     custom:
       filename: ETL Working GDB.gdb.zip
       layer_name: NEIGHBORHOODPUMACODES
+
+  # district boundary gdb source layers (ETL spec ch. 10, table 39)
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_assemblydistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: AssemblyDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_borough
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: Borough
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_businessimprovementdistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: BusinessImprovementDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_censusblock2010
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: CensusBlock2010
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_censusblock2020
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: CensusBlock2020
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_censustract2000
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: CensusTract2000
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_citycouncildistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: CityCouncilDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_communitydistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: CommunityDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_congressionaldistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: CongressionalDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_firebattalion
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: FireBattalion
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_firedivision
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: FireDivision
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_healthcenterdistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: HealthCenterDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_historicdistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: HistoricDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_hurricaneevacuationzone
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: HurricaneEvacuationZone
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_municourtdistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: MunicipalCourtDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_neighborhood
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: Neighborhood
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_schooldistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: SchoolDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_statesenatedistrict
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: StateSenateDistrict
+  - name: dcp_cscl_gdb
+    import_as: dcp_cscl_urbanrenewalarea
+    custom:
+      filename: ETL Working GDB.gdb.zip
+      layer_name: UrbanRenewalArea
   missing_versions_strategy: find_latest # TODO - they should all match
 
 exports:
@@ -426,3 +523,179 @@ exports:
     filename: nyclion_26b.zip
     format: gdb
     custom: { layer: altnames }
+
+  # District boundary geodatabase (ETL spec ch. 10, table 39)
+  # filename must match prod's, which embeds the cycle from `version:` above
+  - name: gdb_nyad
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyad, geometry_type: polygons }
+  - name: gdb_nyadwi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyadwi, geometry_type: polygons }
+  - name: gdb_nyap
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyap, geometry_type: polygons }
+  - name: gdb_nybb
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nybb, geometry_type: polygons }
+  - name: gdb_nybbwi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nybbwi, geometry_type: polygons }
+  - name: gdb_nybid
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nybid, geometry_type: polygons }
+  - name: gdb_nycb2010
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycb2010, geometry_type: polygons }
+  - name: gdb_nycb2010wi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycb2010wi, geometry_type: polygons }
+  - name: gdb_nycb2020
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycb2020, geometry_type: polygons }
+  - name: gdb_nycb2020wi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycb2020wi, geometry_type: polygons }
+  - name: gdb_nycc
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycc, geometry_type: polygons }
+  - name: gdb_nyccwi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyccwi, geometry_type: polygons }
+  - name: gdb_nycd
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycd, geometry_type: polygons }
+  - name: gdb_nycdta2020
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycdta2020, geometry_type: polygons }
+  - name: gdb_nycdwi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycdwi, geometry_type: polygons }
+  - name: gdb_nycg
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycg, geometry_type: polygons }
+  - name: gdb_nycgwi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nycgwi, geometry_type: polygons }
+  - name: gdb_nyct2010
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyct2010, geometry_type: polygons }
+  - name: gdb_nyct2010wi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyct2010wi, geometry_type: polygons }
+  - name: gdb_nyct2020
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyct2020, geometry_type: polygons }
+  - name: gdb_nyct2020wi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyct2020wi, geometry_type: polygons }
+  - name: gdb_nyed
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyed, geometry_type: polygons }
+  - name: gdb_nyedwi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyedwi, geometry_type: polygons }
+  - name: gdb_nyfb
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyfb, geometry_type: polygons }
+  - name: gdb_nyfc
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyfc, geometry_type: polygons }
+  - name: gdb_nyfd
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyfd, geometry_type: polygons }
+  - name: gdb_nyha
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyha, geometry_type: polygons }
+  - name: gdb_nyhc
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyhc, geometry_type: polygons }
+  - name: gdb_nyhd
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyhd, geometry_type: polygons }
+  - name: gdb_nyhez
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyhez, geometry_type: polygons }
+  - name: gdb_nymc
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nymc, geometry_type: polygons }
+  - name: gdb_nymcea
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nymcea, geometry_type: polygons }
+  - name: gdb_nymcwi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nymcwi, geometry_type: polygons }
+  - name: gdb_nynta2010
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nynta2010, geometry_type: polygons }
+  - name: gdb_nynta2020
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nynta2020, geometry_type: polygons }
+  - name: gdb_nypp
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nypp, geometry_type: polygons }
+  - name: gdb_nypuma2010
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nypuma2010, geometry_type: polygons }
+  - name: gdb_nypuma2020
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nypuma2020, geometry_type: polygons }
+  - name: gdb_nysd
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nysd, geometry_type: polygons }
+  - name: gdb_nyss
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyss, geometry_type: polygons }
+  - name: gdb_nysswi
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nysswi, geometry_type: polygons }
+  - name: gdb_nyura
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    # the CSCL source layer is empty, but prod still ships the feature class
+    custom: { layer: nyura, geometry_type: polygons, allow_empty: true }
+  - name: gdb_nyzip
+    filename: v26B_Districts.gdb.zip
+    format: gdb
+    custom: { layer: nyzip, geometry_type: polygons }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ processes = -1
 large_file_skip_byte_limit = 40000
 
 # Maximum parse depth (grammar + bracket nesting). Prevents DoS from deeply nested SQL. Set to 0 or empty to disable. Default 255 (Oracle WHERE subquery limit).
-max_parse_depth = 302 # this limit is driven by products/developments/sql/_now.sql
+max_parse_depth = 415 # this limit is driven by products/cscl/models/districts/gdb_nysd.sql
 
 [tool.sqlfluff.templater.placeholder]
 param_style = "colon_optional_quotes"


### PR DESCRIPTION
resolves #1840

## what

- adds the creation of the District Boundaries gdb to the CSCL build
- adds comparison of the dev and prod District Boundaries gdbs
- updates CSCL README to document the open questions related to diffs

## prod vs dev

comparison results on latest build [here](https://github.com/NYCPlanning/data-engineering/actions/runs/30035428472/job/89302142052#step:10:452). 41/43 layers match on structure, row count and area. remaining diffs are documented in the README and are generally understood