### PR TITLE
fix pandas 3 nan handling in doi evictions year extraction

### DIFF
--- a/dcpy/lifecycle/scripts/doi_evictions_geocode.py
+++ b/dcpy/lifecycle/scripts/doi_evictions_geocode.py
@@ -124,7 +124,7 @@ def process_evictions(df: pd.DataFrame) -> pd.DataFrame:
     evictions = df.copy()
 
     # Extract year from executed_date (last 4 characters)
-    evictions["year"] = evictions.executed_date.apply(lambda x: x[-4:] if x else None)
+    evictions["year"] = evictions.executed_date.str[-4:]
 
     # Get current year and exclude those records (incomplete data)
     current_year = str(datetime.now().year)


### PR DESCRIPTION
@alexrichey not sure if this was an issue with EDDE recently since this is related to the version bump to pandas [3 weeks ago](https://github.com/NYCPlanning/data-engineering/commit/4a7551ed9ddb959d219989681bc042fb261ada0f). you probably ran ingest for `doi_evictions_geocode` before that