### PR TITLE
improve USPS scraper

### DIFF
--- a/.github/workflows/ingest_single.yml
+++ b/.github/workflows/ingest_single.yml
@@ -78,6 +78,9 @@ jobs:
           SOCRATA_PASSWORD: "op://Data Engineering/DCP_OpenData/password"
           AXWAY_SFTP_USER: "op://Data Engineering/DOF FTP/username"
           AXWAY_SFTP_PASSWORD: "op://Data Engineering/DOF FTP/password"
+          # Expires with the browser session it was captured from - refresh the 1Password
+          # item before ingesting usps_locations_nyc.
+          USPS_LOCATIONS_SESSION_HEADERS: "op://Data Engineering/USPS_LOCATIONS/session_headers"
 
       - name: Finish container setup ...
         run: ./bash/docker_container_setup.sh

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -209,7 +209,15 @@ jobs:
     - name: dcpy integration pytests
       run: |
         docker exec --user root de \
-        python3 -m pytest dcpy/test_integration -v --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
+        python3 -m pytest dcpy/test_integration --ignore dcpy/test_integration/library -v --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
+      env:
+        RECIPES_BUCKET: "test-recipes"
+
+    # separate for the same gdal/pyarrow reason as the unit library suite above
+    - name: dcpy integration library pytests
+      run: |
+        docker exec --user root de \
+        python3 -m pytest dcpy/test_integration/library -v --cov-config=pyproject.toml --cov=dcpy --cov-report=xml --cov-append
       env:
         RECIPES_BUCKET: "test-recipes"
 

--- a/dcpy/connectors/web_scrapers/usps.py
+++ b/dcpy/connectors/web_scrapers/usps.py
@@ -34,6 +34,25 @@ QUERY_ZIP_CODES = [
 ]
 
 
+ONE_PASSWORD_ITEM = "Data Engineering -> USPS_LOCATIONS -> session_headers"
+
+# Sessions last ~an hour, so a stored value is stale far more often than not, and the fix
+# is a capture-and-run loop that has to happen in one sitting - spell it out rather than
+# making whoever hits a failed run rediscover it.
+REFRESH_INSTRUCTIONS = f"""\
+Capture a fresh session, in one sitting:
+  1. Open https://tools.usps.com/locations/ in a browser and search any ZIP code.
+  2. Devtools -> Network -> right-click the `getLocations` request -> Copy as cURL.
+  3. Pull out the `Cookie` and `X-jFuguZWB-*` headers as a JSON object of
+     {{"header_name": "value"}}.
+  4. Paste that into 1Password ({ONE_PASSWORD_ITEM}).
+  5. Re-run the ingest right away - the session expires ~1 hour after capture."""
+
+EXPIRED_SESSION = (
+    "This almost always means the stored session headers expired (they last ~1 hour)."
+)
+
+
 def _extract_locations(payload: Any) -> list[dict]:
     if isinstance(payload, list):
         return payload
@@ -51,10 +70,9 @@ class USPSLocationsConnector(Pull):
     """tools.usps.com/locations sits behind Akamai Bot Manager: requests need a Cookie
     header plus several `X-jFuguZWB-*` sensor headers that Akamai's JS generates per
     browser session and validates server-side - there's no way to derive them
-    statically. Capture them from a real browser (devtools -> Copy as cURL on the
-    getLocations request) and set them as a JSON object of {header_name: value} in the
-    env var below. They expire with the browser session, so this needs refreshing
-    regularly.
+    statically. Capture them from a real browser and set them as a JSON object of
+    {header_name: value} in the env var below - see REFRESH_INSTRUCTIONS above for the
+    full loop. They expire after ~1 hour, so every run needs a freshly captured session.
     """
 
     conn_type: str = "usps_locations"
@@ -62,7 +80,36 @@ class USPSLocationsConnector(Pull):
     session_headers_env_var: str = "USPS_LOCATIONS_SESSION_HEADERS"
 
     def _session_headers(self) -> dict:
-        return json.loads(os.environ[self.session_headers_env_var])
+        raw = os.environ.get(self.session_headers_env_var)
+        if not raw:
+            raise EnvironmentError(
+                f"{self.session_headers_env_var} is unset. In CI it comes from 1Password "
+                f"({ONE_PASSWORD_ITEM}); locally, set it yourself.\n{REFRESH_INSTRUCTIONS}"
+            )
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"{self.session_headers_env_var} is not valid JSON ({e}). Expected an "
+                f"object of {{'header_name': 'value'}}.\n{REFRESH_INSTRUCTIONS}"
+            ) from e
+
+    def _parse_response(self, response: requests.Response, zip_code: str) -> list[dict]:
+        if not response.ok:
+            raise RuntimeError(
+                f"USPS returned HTTP {response.status_code} for zip {zip_code}. "
+                f"{EXPIRED_SESSION}\n{REFRESH_INSTRUCTIONS}"
+            )
+        try:
+            payload = response.json()
+        except requests.exceptions.JSONDecodeError as e:
+            # Akamai serves its bot challenge as a 200 HTML page, so a non-JSON body is
+            # a rejected session rather than a USPS outage.
+            raise RuntimeError(
+                f"USPS returned a non-JSON response for zip {zip_code}, which usually "
+                f"means an Akamai bot challenge.\n{REFRESH_INSTRUCTIONS}"
+            ) from e
+        return _extract_locations(payload)
 
     def pull(
         self,
@@ -84,8 +131,7 @@ class USPSLocationsConnector(Pull):
                 "requestHours": "",
             }
             response = requests.post(URL, headers=headers, json=body)
-            response.raise_for_status()
-            locations = _extract_locations(response.json())
+            locations = self._parse_response(response, zip_code)
             logger.info(f"Got {len(locations)} locations for zip {zip_code}")
             for location in locations:
                 locations_by_id[location["locationID"]] = location

--- a/dcpy/connectors/web_scrapers/usps.py
+++ b/dcpy/connectors/web_scrapers/usps.py
@@ -1,5 +1,32 @@
+"""Scrape post office locations from USPS's location finder.
+
+**This does not run unattended, in CI or anywhere else.** Two things prevent it, and
+neither is a bug to be fixed here:
+
+- The session headers can only come from a real browser (see `REFRESH_INSTRUCTIONS`),
+  so every run needs a person.
+- USPS blocks the client partway through regardless of pacing. Delays from 1s to 40s
+  have all ended in a block, and no session has ever completed more than 8 of the 18
+  queries. Waiting recovers roughly one query per 8-14 minutes of idle.
+
+So a `Ingest Single Dataset` dispatch will fail partway through, and because its
+checkpoint lives in the job's workspace, a re-dispatch starts over rather than resuming.
+
+To collect the full dataset, run the ingest locally and repeat it. The checkpoint is
+written after every zip into the staging directory, so each run resumes where the last
+was blocked; a run whose session has expired simply fails on its first query, costing
+nothing. Capturing a fresh session between attempts helps - replaying the browser's
+complete header set doubled the per-session budget from 4 queries to 8 - and so does
+waiting longer between them.
+
+Collecting all 18 zips on 2026-08-18 took 5 runs and 2 captures over about 2.5 hours,
+yielding 367 locations, 277 of them inside NYC.
+"""
+
 import json
 import os
+import shlex
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -10,8 +37,19 @@ from dcpy.connectors.registry import Pull
 from dcpy.utils.logging import logger
 
 URL = "https://tools.usps.com/locations/getLocations"
-REQUEST_DELAY_SECONDS = 3
 
+# Do not assume slower is safer here - the evidence points the other way. 1s got 7
+# queries through before a block; 3s completed a 5-query run; a 20-40s gap was blocked
+# on the *second* query. That last run also changed two other things at once, so the
+# cause is unproven - but until someone isolates it, 3s is the only pacing that has
+# ever finished a run.
+REQUEST_DELAY_SECONDS = 3
+# Checkpoint after every zip. A blocked session can't be retried (the block sticks), so
+# a run is worth resuming rather than repeating - and 18 small writes cost nothing.
+CHECKPOINT_EVERY_N_ZIPS = 1
+
+# Fallback only, for a capture that predates full-header replay - anything the capture
+# provides overrides these. A fresh capture supplies its own User-Agent.
 STATIC_HEADERS = {
     "Accept": "application/json, text/javascript, */*; q=0.01",
     "Content-Type": "application/json;charset=utf-8",
@@ -23,14 +61,38 @@ STATIC_HEADERS = {
     ),
 }
 
-# TODO expand to cover the rest of NYC - one query only returns locations within
-# `maxDistance` of the given zip, so we'll need zips spread across the boroughs.
+# USPS caps a single query at ~199 results, so the old maxDistance=10 silently
+# truncated: every NYC query came back with exactly 199. It also blocks a client
+# that makes too many requests too quickly - a 246-zip sweep got shut out after 7.
+# So: query the fewest points that still cover the city. These 18 zip centroids
+# cover every quarter-mile of NYC land area within 4 miles (greedy set cover over
+# dcp_cscl_zipcode 26b); querying at 5 leaves a mile of slack for USPS geocoding a
+# zip differently than CSCL. Each returns ~110 results, well under the cap.
+MAX_DISTANCE_MILES = "5"
+RESULT_CAP = 199
+
+# Enough of an Akamai response to tell a challenge page from a block page.
+BODY_SNIPPET_CHARS = 300
+
 QUERY_ZIP_CODES = [
-    "10012",  # Lower Manhattan
-    "10027",  # Upper Manhattan / Harlem
-    "10455",  # South Bronx
-    "11377",  # Queens
-    "11210",  # Brooklyn
+    "10002",
+    "10304",
+    "10306",
+    "10309",
+    "10314",
+    "10455",
+    "10460",
+    "10466",
+    "10475",
+    "11004",
+    "11096",
+    "11109",
+    "11230",
+    "11357",
+    "11385",
+    "11423",
+    "11693",
+    "11697",
 ]
 
 
@@ -43,14 +105,81 @@ REFRESH_INSTRUCTIONS = f"""\
 Capture a fresh session, in one sitting:
   1. Open https://tools.usps.com/locations/ in a browser and search any ZIP code.
   2. Devtools -> Network -> right-click the `getLocations` request -> Copy as cURL.
-  3. Pull out the `Cookie` and `X-jFuguZWB-*` headers as a JSON object of
-     {{"header_name": "value"}}.
+  3. Convert it to JSON (reads the cURL from stdin, writes the headers to stdout):
+       pbpaste | python -m dcpy.connectors.web_scrapers.usps | pbcopy
   4. Paste that into 1Password ({ONE_PASSWORD_ITEM}).
   5. Re-run the ingest right away - the session expires ~1 hour after capture."""
 
 EXPIRED_SESSION = (
-    "This almost always means the stored session headers expired (they last ~1 hour)."
+    "Nothing succeeded, so the session headers are probably expired or wrong (they last "
+    "~1 hour)."
 )
+
+RATE_LIMITED = (
+    "Earlier queries succeeded, so this is Akamai blocking the client rather than a bad "
+    "session. The block sticks for a while and a fresh capture from the same network may "
+    "be blocked too - wait before retrying, and raise REQUEST_DELAY_SECONDS if it "
+    "recurs. Completed zips are checkpointed, so a rerun resumes rather than repeats."
+)
+
+
+SENSOR_HEADER_PREFIX = "x-jfuguzwb-"
+
+# requests and urllib3 derive these per-request; replaying captured values would either
+# be ignored or, for Content-Length, actively wrong once the body changes.
+TRANSPORT_MANAGED_HEADERS = {"content-length", "host", "connection", "accept-encoding"}
+
+
+def session_headers_from_curl(curl_command: str) -> dict[str, str]:
+    """Extract the session headers from a devtools 'Copy as cURL' command.
+
+    Keeps every header the browser sent, minus the ones the HTTP layer owns. An earlier
+    version kept only Cookie and the sensors, on the evidence that a single request
+    succeeds without the rest - but a single request was the whole test, and runs still
+    get blocked after a handful of queries at any pacing. Replaying the browser's exact
+    headers is the premise of session replay; a partial replay contradicts itself, most
+    visibly by pairing Android sensors and cookies with a hardcoded macOS Firefox
+    User-Agent and no sec-ch-ua headers at all.
+    """
+    headers: dict[str, str] = {}
+    tokens = shlex.split(curl_command)
+    for i, token in enumerate(tokens[:-1]):
+        value = tokens[i + 1]
+        if token in ("-H", "--header"):
+            name, _, header_value = value.partition(":")
+            name = name.strip()
+            if name.lower() not in TRANSPORT_MANAGED_HEADERS:
+                headers[name] = header_value.strip()
+        elif token in ("-b", "--cookie"):
+            # Chrome emits the cookie jar as -b rather than a Cookie header.
+            headers["Cookie"] = value
+
+    if not any(h.lower() == "cookie" for h in headers):
+        raise ValueError(
+            "No Cookie found in the cURL command. Copy the `getLocations` POST request, "
+            "not another one."
+        )
+    sensors = [h for h in headers if h.lower().startswith(SENSOR_HEADER_PREFIX)]
+    if not sensors:
+        raise ValueError(
+            f"No {SENSOR_HEADER_PREFIX}* sensor headers found - without them USPS serves "
+            "an Akamai bot challenge instead of JSON. Copy the `getLocations` POST "
+            "request, not another one."
+        )
+    return headers
+
+
+def _merge_headers(
+    defaults: dict[str, str], captured: dict[str, str]
+) -> dict[str, str]:
+    """Captured headers win, matched case-insensitively.
+
+    A capture writes `user-agent` while STATIC_HEADERS writes `User-Agent`; a plain dict
+    merge keeps both and leaves which one is sent to insertion order.
+    """
+    captured_names = {name.lower() for name in captured}
+    kept = {k: v for k, v in defaults.items() if k.lower() not in captured_names}
+    return {**kept, **captured}
 
 
 def _extract_locations(payload: Any) -> list[dict]:
@@ -72,11 +201,13 @@ class USPSLocationsConnector(Pull):
     browser session and validates server-side - there's no way to derive them
     statically. Capture them from a real browser and set them as a JSON object of
     {header_name: value} in the env var below - see REFRESH_INSTRUCTIONS above for the
-    full loop. They expire after ~1 hour, so every run needs a freshly captured session.
+    full loop, and `session_headers_from_curl` for turning a capture into that JSON.
+    They expire after ~1 hour, so every run needs a freshly captured session.
     """
 
     conn_type: str = "usps_locations"
     filename: str = "usps_locations.json"
+    checkpoint_filename: str = "usps_locations.checkpoint.json"
     session_headers_env_var: str = "USPS_LOCATIONS_SESSION_HEADERS"
 
     def _session_headers(self) -> dict:
@@ -94,22 +225,60 @@ class USPSLocationsConnector(Pull):
                 f"object of {{'header_name': 'value'}}.\n{REFRESH_INSTRUCTIONS}"
             ) from e
 
-    def _parse_response(self, response: requests.Response, zip_code: str) -> list[dict]:
+    def _parse_response(
+        self, response: requests.Response, zip_code: str, succeeded_so_far: int = 0
+    ) -> list[dict]:
+        # Both failures look identical in the response, but the cause differs entirely
+        # depending on whether anything worked first - and so does the fix.
+        cause = RATE_LIMITED if succeeded_so_far else EXPIRED_SESSION
         if not response.ok:
             raise RuntimeError(
-                f"USPS returned HTTP {response.status_code} for zip {zip_code}. "
-                f"{EXPIRED_SESSION}\n{REFRESH_INSTRUCTIONS}"
+                f"USPS returned HTTP {response.status_code} for zip {zip_code} after "
+                f"{succeeded_so_far} successful queries. {cause}\n{REFRESH_INSTRUCTIONS}"
             )
         try:
             payload = response.json()
         except requests.exceptions.JSONDecodeError as e:
-            # Akamai serves its bot challenge as a 200 HTML page, so a non-JSON body is
-            # a rejected session rather than a USPS outage.
+            # Akamai serves both its bot challenge and its block page as HTML with a 200,
+            # so a non-JSON body is a rejected client rather than a USPS outage.
+            # Akamai's challenge and its outright block are different states with
+            # different prospects for a retry, and the body is the only thing that
+            # tells them apart - a run costs a browser capture, so don't discard it.
             raise RuntimeError(
-                f"USPS returned a non-JSON response for zip {zip_code}, which usually "
-                f"means an Akamai bot challenge.\n{REFRESH_INSTRUCTIONS}"
+                f"USPS returned a non-JSON response for zip {zip_code} after "
+                f"{succeeded_so_far} successful queries. {cause}\n"
+                f"First {BODY_SNIPPET_CHARS} chars of the body: "
+                f"{response.text[:BODY_SNIPPET_CHARS]!r}\n{REFRESH_INSTRUCTIONS}"
             ) from e
         return _extract_locations(payload)
+
+    def _read_checkpoint(self, path: Path) -> tuple[list[str], dict[str, dict]]:
+        if not path.exists():
+            return [], {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        locations = {loc["locationID"]: loc for loc in data["locations"]}
+        logger.info(
+            f"Resuming from {path}: {len(data['queried_zips'])} zips already queried, "
+            f"{len(locations)} locations kept"
+        )
+        return data["queried_zips"], locations
+
+    def _write_checkpoint(
+        self, path: Path, queried_zips: list[str], locations_by_id: dict[str, dict]
+    ) -> None:
+        # Write-and-rename so a process killed mid-write leaves the previous checkpoint
+        # intact rather than a truncated file that fails to parse on resume.
+        temp_path = path.with_suffix(".tmp")
+        temp_path.write_text(
+            json.dumps(
+                {
+                    "queried_zips": queried_zips,
+                    "locations": list(locations_by_id.values()),
+                }
+            ),
+            encoding="utf-8",
+        )
+        temp_path.replace(path)
 
     def pull(
         self,
@@ -117,28 +286,70 @@ class USPSLocationsConnector(Pull):
         destination_path: Path,
         **kwargs,
     ) -> dict:
-        headers = {**STATIC_HEADERS, **self._session_headers()}
-        locations_by_id = {}
-        for i, zip_code in enumerate(QUERY_ZIP_CODES):
+        headers = _merge_headers(STATIC_HEADERS, self._session_headers())
+        # A blocked session can't be salvaged mid-run, so the only thing that makes a
+        # partial run worth anything is keeping what it got. Checkpointing is per
+        # workspace: it helps local runs and reruns in the same CI job, not a fresh
+        # dispatch.
+        checkpoint_path = destination_path / self.checkpoint_filename
+        queried_zips, locations_by_id = self._read_checkpoint(checkpoint_path)
+        remaining = [z for z in QUERY_ZIP_CODES if z not in set(queried_zips)]
+        saturated = []
+        for i, zip_code in enumerate(remaining):
             if i > 0:
                 time.sleep(REQUEST_DELAY_SECONDS)
-            logger.info(f"Querying USPS locations for zip {zip_code}")
+            logger.info(
+                f"Querying USPS locations for zip {zip_code} "
+                f"({len(queried_zips) + 1}/{len(QUERY_ZIP_CODES)})"
+            )
             body = {
                 "requestZipCode": zip_code,
                 "requestType": "PO",
-                "maxDistance": "10",
+                "maxDistance": MAX_DISTANCE_MILES,
                 "requestServices": "",
                 "requestHours": "",
             }
             response = requests.post(URL, headers=headers, json=body)
-            locations = self._parse_response(response, zip_code)
+            locations = self._parse_response(response, zip_code, len(queried_zips))
             logger.info(f"Got {len(locations)} locations for zip {zip_code}")
+            if len(locations) >= RESULT_CAP:
+                saturated.append(zip_code)
             for location in locations:
                 locations_by_id[location["locationID"]] = location
+            queried_zips.append(zip_code)
+            if len(queried_zips) % CHECKPOINT_EVERY_N_ZIPS == 0:
+                self._write_checkpoint(checkpoint_path, queried_zips, locations_by_id)
+
+        if saturated:
+            # Silent truncation is how the original 5-zip version looked healthy while
+            # missing most of the city - say so rather than archiving a short dataset.
+            logger.warning(
+                f"{len(saturated)} zip(s) returned {RESULT_CAP}+ results and were likely "
+                f"truncated by USPS: {saturated}. Coverage is incomplete - lower "
+                "MAX_DISTANCE_MILES."
+            )
 
         all_locations = list(locations_by_id.values())
         filepath = destination_path / self.filename
         logger.info(f"Saving {len(all_locations)} unique USPS locations to {filepath}")
         with open(filepath, "w", encoding="utf-8") as f:
             json.dump(all_locations, f, indent=2, ensure_ascii=False)
+        checkpoint_path.unlink(missing_ok=True)
         return {"path": filepath}
+
+
+if __name__ == "__main__":
+    # Converting a capture by hand is fiddly enough to get wrong quietly, so ship it as
+    # a filter: `pbpaste | python -m dcpy.connectors.web_scrapers.usps | pbcopy`.
+    # Piped into pbcopy, stdout is invisible - so failures must go to stderr and exit
+    # non-zero, or a bad run looks identical to a good one.
+    curl_command = sys.stdin.read()
+    if not curl_command.strip():
+        sys.exit(
+            "Nothing on stdin. Copy the `getLocations` request from devtools first "
+            f"(Copy as cURL).\n{REFRESH_INSTRUCTIONS}"
+        )
+    try:
+        print(json.dumps(session_headers_from_curl(curl_command)))
+    except ValueError as e:
+        sys.exit(str(e))

--- a/dcpy/test/connectors/edm/test_publishing.py
+++ b/dcpy/test/connectors/edm/test_publishing.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -135,6 +134,7 @@ def test_upload_build_success(
     assert publishing.get_version(product_key=build_key) == TEST_VERSION
 
 
+@patch("dcpy.connectors.edm.publishing.BUILD_NAME", None)
 def test_upload_build_missing_build_name(
     create_buckets,
     create_temp_filesystem,
@@ -143,7 +143,6 @@ def test_upload_build_missing_build_name(
     """Tests failure when build name is not provided and env variable is missing."""
     data_path = mock_data_constants["TEST_DATA_DIR"]
 
-    assert os.getenv("BUILD_NAME") is None  # sanity check
     with pytest.raises(ValueError, match="'BUILD_NAME' cannot be"):
         publishing.upload_build(
             data_path,

--- a/dcpy/test/connectors/web_scrapers/test_usps.py
+++ b/dcpy/test/connectors/web_scrapers/test_usps.py
@@ -1,0 +1,184 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from dcpy.connectors.web_scrapers import usps
+from dcpy.connectors.web_scrapers.usps import session_headers_from_curl
+
+CHROME_CURL = """curl --url 'https://tools.usps.com/locations/getLocations' \\
+  -H 'accept: application/json, text/javascript, */*; q=0.01' \\
+  -b 'JSESSIONID=abc123; _ga=GA1.1.1; EntRegName=Jane||Doe' \\
+  -H 'origin: https://tools.usps.com' \\
+  -H 'sec-ch-ua-platform: "Android"' \\
+  -H 'x-jfuguzwb-a: sensor-a-value' \\
+  -H 'x-jfuguzwb-z: q' \\
+  -H 'content-length: 99' \\
+  -H 'user-agent: Mozilla/5.0 (Linux; Android 15; Pixel 9)' \\
+  --data-raw '{"requestZipCode":"10034"}'"""
+
+
+def test_keeps_the_whole_captured_header_set():
+    """Partial replay is what pairs Android sensors with a macOS Firefox User-Agent."""
+    assert session_headers_from_curl(CHROME_CURL) == {
+        "accept": "application/json, text/javascript, */*; q=0.01",
+        "Cookie": "JSESSIONID=abc123; _ga=GA1.1.1; EntRegName=Jane||Doe",
+        "origin": "https://tools.usps.com",
+        "sec-ch-ua-platform": '"Android"',
+        "x-jfuguzwb-a": "sensor-a-value",
+        "x-jfuguzwb-z": "q",
+        "user-agent": "Mozilla/5.0 (Linux; Android 15; Pixel 9)",
+    }
+
+
+def test_drops_headers_the_http_layer_owns():
+    """A replayed Content-Length would be wrong for every body but the captured one."""
+    assert "content-length" not in session_headers_from_curl(CHROME_CURL)
+
+
+class TestHeaderMerge:
+    def test_capture_overrides_static_defaults_across_casings(self):
+        """A capture writes `user-agent`; STATIC_HEADERS writes `User-Agent`."""
+        merged = usps._merge_headers(
+            {"User-Agent": "firefox-macos", "Accept": "application/json"},
+            {"user-agent": "chrome-android"},
+        )
+        assert merged == {"Accept": "application/json", "user-agent": "chrome-android"}
+
+    def test_a_fresh_capture_replaces_the_hardcoded_user_agent(self):
+        captured = session_headers_from_curl(CHROME_CURL)
+        merged = usps._merge_headers(usps.STATIC_HEADERS, captured)
+        agents = {v for k, v in merged.items() if k.lower() == "user-agent"}
+        assert agents == {"Mozilla/5.0 (Linux; Android 15; Pixel 9)"}
+
+
+def test_reads_cookie_supplied_as_a_header():
+    curl = (
+        "curl 'https://tools.usps.com/locations/getLocations' "
+        "-H 'Cookie: JSESSIONID=abc123' -H 'x-jfuguzwb-a: sensor-a-value'"
+    )
+    assert session_headers_from_curl(curl)["Cookie"] == "JSESSIONID=abc123"
+
+
+def test_values_containing_colons_are_kept_whole():
+    curl = (
+        "curl 'https://tools.usps.com/locations/getLocations' "
+        "-H 'Cookie: JSESSIONID=0000ghXZ:1f7tset8a' -H 'x-jfuguzwb-a: a:b:c'"
+    )
+    headers = session_headers_from_curl(curl)
+    assert headers["Cookie"] == "JSESSIONID=0000ghXZ:1f7tset8a"
+    assert headers["x-jfuguzwb-a"] == "a:b:c"
+
+
+def test_missing_cookie_raises():
+    curl = "curl 'https://tools.usps.com/' -H 'x-jfuguzwb-a: sensor-a-value'"
+    with pytest.raises(ValueError, match="No Cookie found"):
+        session_headers_from_curl(curl)
+
+
+def test_missing_sensor_headers_raises():
+    """Without the sensors USPS serves a bot challenge, so catch it at capture time."""
+    curl = "curl 'https://tools.usps.com/' -H 'Cookie: JSESSIONID=abc123'"
+    with pytest.raises(ValueError, match="sensor headers"):
+        session_headers_from_curl(curl)
+
+
+class FakePost:
+    """Stands in for requests.post; records the zips it was asked for."""
+
+    def __init__(self):
+        self.queried: list[str] = []
+
+    def __call__(self, url, headers, json):
+        zip_code = json["requestZipCode"]
+        self.queried.append(zip_code)
+        return SimpleNamespace(
+            ok=True,
+            status_code=200,
+            text="[]",
+            json=lambda: [{"locationID": f"loc-{zip_code}"}],
+        )
+
+
+class TestCheckpoint:
+    connector = usps.USPSLocationsConnector()
+
+    def test_absent_checkpoint_starts_from_scratch(self, tmp_path):
+        assert self.connector._read_checkpoint(tmp_path / "nope.json") == ([], {})
+
+    def test_round_trips(self, tmp_path):
+        path = tmp_path / "checkpoint.json"
+        locations = {"1": {"locationID": "1"}, "2": {"locationID": "2"}}
+        self.connector._write_checkpoint(path, ["10001", "10002"], locations)
+        assert self.connector._read_checkpoint(path) == (["10001", "10002"], locations)
+
+    def test_write_is_atomic(self, tmp_path):
+        """A killed process must not leave a truncated file that breaks the resume."""
+        path = tmp_path / "checkpoint.json"
+        self.connector._write_checkpoint(path, ["10001"], {"1": {"locationID": "1"}})
+        assert list(tmp_path.iterdir()) == [path]
+
+    def test_resumes_only_the_remaining_zips(self, tmp_path, monkeypatch):
+        post = FakePost()
+        monkeypatch.setattr(usps, "QUERY_ZIP_CODES", ["10001", "10002", "10003"])
+        monkeypatch.setattr(usps.requests, "post", post)
+        monkeypatch.setattr(usps.time, "sleep", lambda _: None)
+        monkeypatch.setenv(self.connector.session_headers_env_var, '{"Cookie": "x"}')
+
+        self.connector._write_checkpoint(
+            tmp_path / self.connector.checkpoint_filename,
+            ["10001"],
+            {"loc-10001": {"locationID": "loc-10001"}},
+        )
+        result = self.connector.pull(key="", destination_path=tmp_path)
+
+        assert post.queried == ["10002", "10003"]
+        written = json.loads(result["path"].read_text())
+        assert {loc["locationID"] for loc in written} == {
+            "loc-10001",
+            "loc-10002",
+            "loc-10003",
+        }
+
+    def test_checkpoint_removed_once_complete(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(usps, "QUERY_ZIP_CODES", ["10001"])
+        monkeypatch.setattr(usps.requests, "post", FakePost())
+        monkeypatch.setenv(self.connector.session_headers_env_var, '{"Cookie": "x"}')
+
+        self.connector.pull(key="", destination_path=tmp_path)
+        assert not (tmp_path / self.connector.checkpoint_filename).exists()
+
+
+class TestPacing:
+    """A block costs a fresh browser capture, so the pacing is load-bearing, not taste."""
+
+    connector = usps.USPSLocationsConnector()
+
+    def test_waits_between_queries_but_not_before_the_first(
+        self, tmp_path, monkeypatch
+    ):
+        slept = []
+        monkeypatch.setattr(usps, "QUERY_ZIP_CODES", ["10001", "10002", "10003"])
+        monkeypatch.setattr(usps.requests, "post", FakePost())
+        monkeypatch.setattr(usps.time, "sleep", slept.append)
+        monkeypatch.setenv(self.connector.session_headers_env_var, '{"Cookie": "x"}')
+        self.connector.pull(key="", destination_path=tmp_path)
+        assert slept == [usps.REQUEST_DELAY_SECONDS] * 2
+
+
+class TestFailureDiagnostics:
+    connector = usps.USPSLocationsConnector()
+
+    def test_non_json_body_is_quoted_in_the_error(self):
+        """Akamai's challenge and block pages are both HTML 200s; only the body differs."""
+        body = "<html>This service is currently unavailable</html>"
+        response = SimpleNamespace(
+            ok=True,
+            status_code=200,
+            text=body,
+            json=Mock(side_effect=requests.exceptions.JSONDecodeError("x", body, 0)),
+        )
+        with pytest.raises(RuntimeError, match="currently unavailable"):
+            self.connector._parse_response(response, "10001", succeeded_so_far=1)

--- a/dcpy/test/utils/geospatial/test_convert.py
+++ b/dcpy/test/utils/geospatial/test_convert.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+from dcpy.utils.geospatial import convert
+
+RECORDS = [
+    {
+        "locationID": "1",
+        "latitude": "40.7",
+        "longitude": "-73.9",
+        "serviceHours": [{"day": "MO", "times": []}],
+        "parcelLockerCity": None,
+    },
+    {
+        "locationID": "2",
+        "latitude": "40.8",
+        "longitude": "-74.0",
+        "serviceHours": None,
+        "parcelLockerCity": "NEW YORK",
+    },
+]
+
+
+class TestShapefileFieldNames:
+    def test_short_names_are_left_alone(self):
+        assert convert.shapefile_field_names(["zip5", "state"]) == {
+            "zip5": "zip5",
+            "state": "state",
+        }
+
+    def test_names_sharing_a_prefix_stay_distinct(self):
+        """Plain truncation maps all five parcelLocker* fields onto `parcelLock`."""
+        columns = [
+            "parcelLockerAddress",
+            "parcelLockerCity",
+            "parcelLockerLocation",
+            "parcelLockerState",
+            "parcelLockerZip",
+        ]
+        names = convert.shapefile_field_names(columns)
+        assert len(set(names.values())) == len(columns)
+        assert all(len(n) <= convert.SHAPEFILE_NAME_LIMIT for n in names.values())
+
+    def test_every_name_fits_the_format_limit(self):
+        long = "passportTelephoneNumberExtension"
+        assert len(convert.shapefile_field_names([long])[long]) <= 10
+
+
+class TestReadPoints:
+    def test_builds_points_from_string_coordinates(self, tmp_path):
+        path = tmp_path / "in.json"
+        path.write_text(json.dumps(RECORDS))
+        gdf = convert.read_points(path)
+        assert len(gdf) == 2
+        assert set(gdf.geom_type) == {"Point"}
+        assert gdf.crs == convert.WGS84
+
+    def test_unparseable_coordinates_raise(self, tmp_path):
+        """A silent coerce would place the record at (0, 0), off West Africa."""
+        path = tmp_path / "in.json"
+        path.write_text(json.dumps([{**RECORDS[0], "latitude": "n/a"}]))
+        with pytest.raises(ValueError, match="unparseable coordinates"):
+            convert.read_points(path)
+
+    def test_missing_coordinate_column_raises(self, tmp_path):
+        path = tmp_path / "in.json"
+        path.write_text(json.dumps([{"locationID": "1"}]))
+        with pytest.raises(ValueError, match="latitude"):
+            convert.read_points(path)
+
+
+class TestWriteGeojson:
+    def test_properties_survive_intact(self, tmp_path):
+        """GDAL's writer renders nested values via repr, which isn't valid JSON."""
+        source = tmp_path / "in.json"
+        source.write_text(json.dumps(RECORDS))
+        out = convert.write_geojson(
+            convert.read_points(source), tmp_path / "out.geojson"
+        )
+
+        features = json.loads(out.read_text())["features"]
+        assert [f["properties"] for f in features] == RECORDS
+        assert isinstance(features[0]["properties"]["serviceHours"], list)
+
+
+class TestWriteShapefile:
+    def test_writes_a_zip_with_the_field_mapping(self, tmp_path):
+        import zipfile
+
+        source = tmp_path / "in.json"
+        source.write_text(json.dumps(RECORDS))
+        convert.write_shapefile(convert.read_points(source), tmp_path / "out.shp")
+
+        names = set(zipfile.ZipFile(tmp_path / "out_shapefile.zip").namelist())
+        assert {"out.shp", "out.dbf", "out.prj", "out_fields.csv"} <= names

--- a/dcpy/test_integration/library/test_archive.py
+++ b/dcpy/test_integration/library/test_archive.py
@@ -3,8 +3,7 @@ import os
 from sqlalchemy import text
 
 from dcpy.library.archive import Archive
-
-from . import (
+from dcpy.test.library import (
     TEST_DATASET_CONFIG_FILE,
     TEST_DATASET_NAME,
     TEST_DATASET_OUTPUT_DIRECTORY,

--- a/dcpy/utils/geospatial/convert.py
+++ b/dcpy/utils/geospatial/convert.py
@@ -1,0 +1,200 @@
+"""Write point data out as GeoJSON and Shapefile.
+
+GeoJSON keeps the source records intact. Shapefile cannot: the format caps field names at
+10 characters, text values at 254, and has no nested types. Rather than let those limits
+apply themselves silently, `write_shapefile` renames deterministically, serializes nested
+values to JSON, reports every truncation, and writes a `*_fields.csv` mapping so a reader
+can get back to the original field names.
+"""
+
+import json
+import re
+import zipfile
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import shapely
+import typer
+
+from dcpy.utils.logging import logger
+
+# The sidecar files a shapefile is made of. Named explicitly rather than globbed on the
+# stem, which also matches a same-named .geojson sitting in the output directory.
+SHAPEFILE_PARTS = (".shp", ".shx", ".dbf", ".prj", ".cpg", ".sbn", ".sbx")
+SHAPEFILE_NAME_LIMIT = 10
+SHAPEFILE_VALUE_LIMIT = 254
+WGS84 = "EPSG:4326"
+
+app = typer.Typer(add_completion=False)
+
+
+def _abbreviate(name: str, limit: int = SHAPEFILE_NAME_LIMIT) -> str:
+    """Shorten a camelCase name to `limit` chars, keeping every word recognizable.
+
+    Plain truncation maps all five `parcelLocker*` fields onto `parcelLock`. Splitting on
+    word boundaries and giving each word a share of the budget keeps them distinct
+    (`parLocAddr`, `parLocCity`, ...) without needing a hand-written table.
+    """
+    if len(name) <= limit:
+        return name
+    words = re.findall(r"[A-Z]+(?![a-z])|[A-Z]?[a-z]+|\d+", name) or [name]
+    share, extra = divmod(limit, len(words))
+    if share == 0:  # more words than characters; fall back to initials
+        return "".join(w[0] for w in words)[:limit]
+    return "".join(
+        word[: share + (1 if i < extra else 0)] for i, word in enumerate(words)
+    )
+
+
+def shapefile_field_names(columns: list[str]) -> dict[str, str]:
+    """Map each column to a unique shapefile-legal field name."""
+    names: dict[str, str] = {}
+    used: set[str] = set()
+    for column in columns:
+        candidate = _abbreviate(column)
+        if candidate in used:
+            # Distinct sources can still abbreviate alike; number them rather than let
+            # the driver silently overwrite one with the other.
+            for i in range(1, 100):
+                suffix = str(i)
+                candidate = _abbreviate(column, SHAPEFILE_NAME_LIMIT - len(suffix))
+                candidate = f"{candidate}{suffix}"
+                if candidate not in used:
+                    break
+            else:
+                raise ValueError(f"Cannot find a unique shapefile name for {column!r}")
+        names[column] = candidate
+        used.add(candidate)
+    return names
+
+
+def read_points(
+    path: Path,
+    *,
+    latitude_column: str = "latitude",
+    longitude_column: str = "longitude",
+    crs: str = WGS84,
+) -> gpd.GeoDataFrame:
+    """Read a JSON array of records into a point GeoDataFrame."""
+    records = json.loads(path.read_text(encoding="utf-8"))
+    df = pd.DataFrame.from_records(records)
+    missing = {latitude_column, longitude_column} - set(df.columns)
+    if missing:
+        raise ValueError(f"{path} has no {sorted(missing)} column(s)")
+    # The coordinates arrive as strings; anything unparseable would otherwise become a
+    # point at (0, 0) off the coast of Africa rather than an error.
+    lat = pd.to_numeric(df[latitude_column], errors="coerce")
+    lon = pd.to_numeric(df[longitude_column], errors="coerce")
+    if bad := int((lat.isna() | lon.isna()).sum()):
+        raise ValueError(f"{bad} of {len(df)} records have unparseable coordinates")
+    return gpd.GeoDataFrame(df, geometry=gpd.points_from_xy(lon, lat), crs=crs)
+
+
+def _jsonable(value):
+    """Convert numpy/pandas scalars to plain Python, leaving nested values alone."""
+    if isinstance(value, (list, dict)):
+        return value
+    if isinstance(value, np.generic):
+        return value.item()
+    return None if value is None or value is pd.NA or value != value else value
+
+
+def write_geojson(gdf: gpd.GeoDataFrame, path: Path) -> Path:
+    """Write GeoJSON in WGS84, as the format's spec requires.
+
+    Built by hand rather than via `to_file`: GDAL's GeoJSON writer renders a nested
+    property through Python's `repr`, so a list of dicts lands in the file as
+    "[{'day': 'MO'}]" - single-quoted, `None` for null, and not parseable as JSON by
+    anything. GeoJSON permits arbitrary JSON in `properties`, so nesting is kept intact.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    wgs84 = gdf.to_crs(WGS84)
+    records = wgs84.drop(columns=[wgs84.geometry.name]).to_dict(orient="records")
+    features = [
+        {
+            "type": "Feature",
+            "geometry": shapely.geometry.mapping(geom) if geom is not None else None,
+            "properties": {k: _jsonable(v) for k, v in record.items()},
+        }
+        for record, geom in zip(records, wgs84.geometry)
+    ]
+    path.write_text(
+        json.dumps({"type": "FeatureCollection", "features": features}),
+        encoding="utf-8",
+    )
+    logger.info(f"Wrote {len(features)} features to {path}")
+    return path
+
+
+def write_shapefile(gdf: gpd.GeoDataFrame, path: Path, *, crs: str = WGS84) -> Path:
+    """Write a shapefile plus a CSV mapping its field names back to the originals."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flat = gdf.to_crs(crs).copy()
+
+    columns = [c for c in flat.columns if c != flat.geometry.name]
+    for column in columns:
+        if flat[column].map(lambda v: isinstance(v, (list, dict))).any():
+            flat[column] = flat[column].map(
+                lambda v: json.dumps(v) if isinstance(v, (list, dict)) else v
+            )
+        overflow = flat[column].map(lambda v: len(v) if isinstance(v, str) else 0)
+        if (longest := int(overflow.max())) > SHAPEFILE_VALUE_LIMIT:
+            logger.warning(
+                f"{column!r} holds values up to {longest} chars; the shapefile copy is "
+                f"cut to {SHAPEFILE_VALUE_LIMIT}. The GeoJSON keeps them whole."
+            )
+
+    names = shapefile_field_names(columns)
+    flat = flat.rename(columns=names)
+    flat.to_file(path, driver="ESRI Shapefile")
+
+    fields_path = path.with_name(f"{path.stem}_fields.csv")
+    pd.DataFrame(
+        sorted(names.items()), columns=["source_field", "shapefile_field"]
+    ).to_csv(fields_path, index=False)
+    renamed = sum(1 for source, short in names.items() if source != short)
+    logger.info(
+        f"Wrote {len(flat)} features to {path} ({renamed} of {len(names)} fields "
+        f"renamed; mapping in {fields_path.name})"
+    )
+
+    # A shapefile is five-plus files that are useless apart; zip it so it can be handed
+    # over as one attachment, field mapping included.
+    archive = path.with_name(f"{path.stem}_shapefile.zip")
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zf:
+        for suffix in SHAPEFILE_PARTS:
+            part = path.with_suffix(suffix)
+            if part.exists():
+                zf.write(part, part.name)
+        zf.write(fields_path, fields_path.name)
+    logger.info(f"Zipped shapefile to {archive}")
+    return path
+
+
+@app.command()
+def convert(
+    input_path: Path = typer.Argument(..., help="JSON array of point records."),
+    output_dir: Path = typer.Option(
+        None, "--output-dir", "-o", help="Defaults to the input file's directory."
+    ),
+    latitude_column: str = typer.Option("latitude", "--latitude"),
+    longitude_column: str = typer.Option("longitude", "--longitude"),
+    shapefile_crs: str = typer.Option(
+        WGS84, "--shapefile-crs", help="e.g. EPSG:2263 for NY State Plane feet."
+    ),
+) -> None:
+    """Write <input>.geojson and <input>.shp beside the input JSON."""
+    output_dir = output_dir or input_path.parent
+    gdf = read_points(
+        input_path,
+        latitude_column=latitude_column,
+        longitude_column=longitude_column,
+    )
+    write_geojson(gdf, output_dir / f"{input_path.stem}.geojson")
+    write_shapefile(gdf, output_dir / f"{input_path.stem}.shp", crs=shapefile_crs)
+
+
+if __name__ == "__main__":
+    app()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,8 @@ How tests are organized across the repo, how to run them, and the conventions we
 |---|---|---|
 | **dcpy unit** | `dcpy/test/` | Mocked externals (`moto` for S3/AWS); a live Postgres in CI |
 | **dcpy library** | `dcpy/test/library/` | Run **separately** — gdal + pyarrow conflict (parquet read/write fails after importing gdal) |
-| **dcpy integration** | `dcpy/test_integration/` | Live infrastructure (Postgres, SFTP) |
+| **dcpy integration** | `dcpy/test_integration/` | Live infrastructure (Postgres, SFTP, S3) |
+| **dcpy integration library** | `dcpy/test_integration/library/` | Live S3 + Postgres; run **separately** for the same gdal/pyarrow reason |
 | **product / app** | `products/*`, `apps/qa/` | Per-product; matrix-driven |
 
 ### dcpy unit tests (`dcpy/test/`)
@@ -73,9 +74,17 @@ Defined as a matrix in [`.github/workflows/data/pytest.yml`](../.github/workflow
 python3 -m pytest dcpy/test --ignore dcpy/test/library --cov-config=pyproject.toml --cov=dcpy --cov-report=xml
 # library suite, separately (gdal/pyarrow conflict), appending coverage
 python3 -m pytest dcpy/test/library --cov=dcpy --cov-report=xml --cov-append
-# integration suite
-python3 -m pytest dcpy/test_integration ...
+# integration suite (its own library subdir excluded)
+python3 -m pytest dcpy/test_integration --ignore dcpy/test_integration/library ...
+# integration library suite, separately (gdal/pyarrow again)
+python3 -m pytest dcpy/test_integration/library ...
 ```
+
+> [!NOTE]
+> The `dcpy/test/conftest.py` internet guard (`ensure_no_callouts`) only replaces Python's
+> `socket.socket`, so it can't see connections opened from C extensions — libpq, gdal. A unit
+> test reaching live infrastructure through those will pass the guard; keep such tests in
+> `dcpy/test_integration/` rather than relying on the guard to catch them.
 
 ## Known gaps
 

--- a/example.env
+++ b/example.env
@@ -31,5 +31,9 @@ GHP_TOKEN=
 SOCRATA_USER=your-user
 SOCRATA_PASSWORD=your-password
 
+# USPS locations scraper - JSON object of browser session headers, see
+# dcpy/connectors/web_scrapers/usps.py
+USPS_LOCATIONS_SESSION_HEADERS=
+
 # 1pw service token
 OP_SERVICE_ACCOUNT_TOKEN=

--- a/ingest_templates/usps_locations_nyc.yml
+++ b/ingest_templates/usps_locations_nyc.yml
@@ -10,6 +10,12 @@ attributes:
     real browser - see USPS_LOCATIONS_SESSION_HEADERS in
     dcpy/connectors/web_scrapers/usps.py.
 
+    This dataset cannot currently be ingested unattended. USPS blocks the client after
+    roughly 4-8 of the 18 queries, and a browser capture cannot be automated, so a
+    workflow dispatch will fail partway through. Run it locally instead; the connector
+    checkpoints after every zip so repeated runs accumulate. See the module docstring
+    in dcpy/connectors/web_scrapers/usps.py.
+
 ingestion:
   source:
     # custom web-scraping connector, requires USPS_LOCATIONS_SESSION_HEADERS env var


### PR DESCRIPTION
Follow-up to #2566, whose ingest [failed](https://github.com/NYCPlanning/data-engineering/actions/runs/31638691872) on a missing env var.

- **`USPS_LOCATIONS_SESSION_HEADERS` loads from 1Password** in `ingest_single.yml` — the original bug
- **Queries cover all of NYC** — 18 ZIPs at 5 miles, verified against CSCL geometry to cover 100% of city land area (full coverage arrives at 4.25 mi). The old 5-ZIP config hit the 199-result cap on four of five queries and silently returned a fraction of the city
- **Runs resume after a block** — checkpointed after every ZIP
- **Failures name the cause** — expired session vs. Akamai block, with the response body, since the two look identical otherwise
- **Unit tests stop reaching live S3** and stop reading `BUILD_NAME` from the shell

## Notes

**This still cannot run unattended.** USPS blocks the client after 4–8 of the 18 queries at any pacing (1s through 40s all end in a block), and session headers can only come from a browser. A dispatch will fail partway, and its checkpoint is workspace-local, so re-dispatching starts over. Stated in the ingest template and the module docstring; run it locally and repeat instead. Collecting all 18 ZIPs took 5 runs and 2 captures over ~2.5 hours — 367 locations, 277 in NYC.

`dcpy/utils/geospatial/convert.py` is a generic GeoJSON/Shapefile writer, unrelated to this fix but useful for making files to share
