### PR TITLE
fix qa app imports

### DIFF
--- a/.github/workflows/qa_deploy.yml
+++ b/.github/workflows/qa_deploy.yml
@@ -1,12 +1,33 @@
 name: Deploy DE Tools to DO
 
 on:
+  # The droplet mounts the repo and editable-installs dcpy at container start, so the app only
+  # picks up merged changes once it is redeployed. Deliberately excludes
+  # admin/run_environment/** and pyproject.toml: those rebuild the qa-streamlit image via
+  # docker_publish.yml, and deploy.sh pulls that image — triggering here would race the build
+  # and could deploy the previous one. Dependency changes stay a manual dispatch.
+  push:
+    branches:
+      - main
+    paths:
+      - apps/**
+      - dcpy/**
+      - product-metadata/**
+      - '!**/test/**'
+      - '!**/tests/**'
+      - '!**/*.md'
   workflow_dispatch:
     inputs:
       data_engineering_branch:
         description: 'Data Engineering branch to deploy'
         required: true
         default: 'main'
+
+# Deploys ssh into one droplet and mutate it in place, so they must not overlap. Queue rather
+# than cancel: a cancelled run could leave the checkout reset but the containers not recreated.
+concurrency:
+  group: qa-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/apps/qa/src/pages/checkbook/checkbook.py
+++ b/apps/qa/src/pages/checkbook/checkbook.py
@@ -1,7 +1,7 @@
 def checkbook():
     import streamlit as st
-    from src.shared.components import build_outputs, sidebar
-    from src.shared.utils import publishing
+    from shared.components import build_outputs, sidebar
+    from shared.utils import publishing
 
     from .components import output_map
 

--- a/apps/qa/src/pages/colp/colp.py
+++ b/apps/qa/src/pages/colp/colp.py
@@ -1,6 +1,6 @@
 def colp():
     import streamlit as st
-    from src.shared.components import build_outputs, sidebar
+    from shared.components import build_outputs, sidebar
 
     from .components.agency_usetype_report import (
         RecordsByAgency,

--- a/apps/qa/src/pages/cpdb/cpdb.py
+++ b/apps/qa/src/pages/cpdb/cpdb.py
@@ -2,8 +2,8 @@ def cpdb():
     import plotly.express as px
     import plotly.graph_objects as go
     import streamlit as st
-    from src.shared.components import build_outputs, sidebar
-    from src.shared.constants import COLOR_SCHEME
+    from shared.components import build_outputs, sidebar
+    from shared.constants import COLOR_SCHEME
 
     from .components.adminbounds import adminbounds
     from .components.geometry_visualization_report import (

--- a/apps/qa/src/pages/devdb/devdb.py
+++ b/apps/qa/src/pages/devdb/devdb.py
@@ -1,6 +1,6 @@
 def devdb():
     import streamlit as st
-    from src.shared.components import build_outputs, sidebar
+    from shared.components import build_outputs, sidebar
 
     from .components.complete_quarters_report import CompleteQuartersReport
     from .components.field_distribution_report import FieldDistributionReport

--- a/apps/qa/src/pages/pluto/pluto.py
+++ b/apps/qa/src/pages/pluto/pluto.py
@@ -1,6 +1,6 @@
 def pluto():
     import streamlit as st
-    from src.shared.components import sidebar
+    from shared.components import sidebar
 
     from .components.changes_report import ChangesReport
     from .components.version_comparison_report import version_comparison_report

--- a/apps/qa/tests/test_imports.py
+++ b/apps/qa/tests/test_imports.py
@@ -7,19 +7,82 @@ collection-time failure. Complements the container boot smoke test (which checks
 serve", not "does every page import").
 """
 
+import ast
 import importlib
 import pathlib
 
 import pytest
 
 _SRC = pathlib.Path(__file__).resolve().parent.parent / "src"
-_MODULES = sorted(
-    ".".join(p.relative_to(_SRC).with_suffix("").parts)
-    for p in _SRC.rglob("*.py")
-    if "__pycache__" not in p.parts
-)
+_FILES = sorted(p for p in _SRC.rglob("*.py") if "__pycache__" not in p.parts)
+_MODULES = sorted(".".join(p.relative_to(_SRC).with_suffix("").parts) for p in _FILES)
 
 
 @pytest.mark.parametrize("module", _MODULES)
 def test_module_imports(module: str) -> None:
     importlib.import_module(module)
+
+
+def _absolute_imports(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Every module a file imports, as an absolute dotted name, relative imports resolved.
+
+    Walks the syntax tree rather than importing, so imports nested inside a function body count
+    too. Page modules put nearly every import inside their page function, so those are invisible
+    to `test_module_imports` above — which is how a bad import reaches production: it only fires
+    when a user opens that page.
+    """
+    package = path.relative_to(_SRC).parts[:-1]
+    found = []
+    for node in ast.walk(ast.parse(path.read_text(), filename=str(path))):
+        if isinstance(node, ast.Import):
+            found.extend((node.lineno, alias.name) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0:
+                if node.module:
+                    found.append((node.lineno, node.module))
+            else:
+                base = package[: len(package) - node.level + 1]
+                found.append(
+                    (
+                        node.lineno,
+                        ".".join([*base, *([node.module] if node.module else [])]),
+                    )
+                )
+    return found
+
+
+def _resolves_under_src(module: str) -> bool:
+    path = _SRC.joinpath(*module.split("."))
+    return path.is_dir() or path.with_suffix(".py").is_file()
+
+
+@pytest.mark.parametrize("path", _FILES, ids=lambda p: str(p.relative_to(_SRC)))
+def test_no_src_prefixed_imports(path: pathlib.Path) -> None:
+    """`src` is not importable in production, so `from src.shared...` is always wrong.
+
+    Deployment runs `streamlit run .../apps/qa/src/index.py`, which puts `src/` itself on
+    sys.path — never its parent — and there is no `__init__.py` to make `src` a package. Such an
+    import only resolves when `apps/qa` happens to be on sys.path, which is true when a developer
+    runs from that directory and false in the container (`WORKDIR /app`).
+    """
+    offenders = [
+        f"{path.relative_to(_SRC)}:{line} imports {module}"
+        for line, module in _absolute_imports(path)
+        if module == "src" or module.startswith("src.")
+    ]
+    assert not offenders, "import relative to src/ instead: " + "; ".join(offenders)
+
+
+@pytest.mark.parametrize("path", _FILES, ids=lambda p: str(p.relative_to(_SRC)))
+def test_first_party_imports_resolve(path: pathlib.Path) -> None:
+    """A first-party import must point at something that exists under src/.
+
+    Catches a moved or renamed module even where the import sits inside a page function, which
+    `test_module_imports` cannot reach.
+    """
+    broken = [
+        f"{path.relative_to(_SRC)}:{line} imports {module}"
+        for line, module in _absolute_imports(path)
+        if _resolves_under_src(module.split(".")[0]) and not _resolves_under_src(module)
+    ]
+    assert not broken, "no such module under src/: " + "; ".join(broken)


### PR DESCRIPTION
some pages are working locally but not in the deployed app. for example the error below is from the PLUTO page

```bash
ModuleNotFoundError: No module named 'src'
Traceback:
File "/repos/data-engineering/apps/qa/src/index.py", line 40, in <module>
    run()
    ~~~^^
File "/repos/data-engineering/apps/qa/src/index.py", line 36, in run
    dataset_page()
    ~~~~~~~~~~~~^^
File "/repos/data-engineering/apps/qa/src/pages/pluto/pluto.py", line 3, in pluto
    from src.shared.components import sidebar
```