### PR TITLE
improve CI tests and use new issue label

### DIFF
--- a/.github/issue_metadata.yml
+++ b/.github/issue_metadata.yml
@@ -74,6 +74,32 @@ products:
     label: db-zoningtaxlots
     patterns: ['\bztl\b', '\bzoning[- ]?tax[- ]?lots?\b']
 
+# Non-product labels, keyed by the label name itself. Only applied when no
+# product pattern matched — `platform` means work that isn't a data product,
+# so `PLUTO docker image` stays PLUTO's.
+#
+# Patterns are deliberately narrow: proper nouns and tool names, not the
+# generic words (build, test, ingest, library, app) that every product issue
+# also uses.
+labels:
+  platform:
+    patterns:
+      - '\bdcpy\b'
+      - '\bazure\b'
+      - '\bdocker\b'
+      - '\bdev ?container\b'
+      - '\bcontainer instances?\b'
+      - '\bblob storage\b'
+      - '\bci/cd\b'
+      - '\borchestration tool\b'
+      - '\bsqlfluff\b'
+      - '\bpre-commit\b'
+      - '\bgdal\b'
+      - '\bconnector\b'
+      - '\bcredential management\b'
+      - '\bbuild engine\b'
+      - '\bqa ?/? ?qc app\b'
+
 # Issue types are org-level and already the team's convention (Bug is the most
 # used), so bug tracking lives here rather than in a `bug` label. Only applied
 # to issues that have no type yet — a human's classification always wins.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
               - .github/workflows/test_helper.yml
             template:
               - .github/workflows/test.yml
+              - .github/workflows/test_helper.yml
               - .github/workflows/build.yml
               - .github/workflows/template_test.yml
               - products/template/**
@@ -61,6 +62,27 @@ jobs:
               - admin/run_environment/**
             zap:
               - products/zap-opendata/**
+              - admin/run_environment/**
+            cdbg:
+              - products/cdbg/**
+              - admin/run_environment/**
+            ceqr:
+              - products/ceqr/**
+              - admin/run_environment/**
+            cpdb:
+              - products/cpdb/**
+              - admin/run_environment/**
+            cscl:
+              - products/cscl/**
+              - admin/run_environment/**
+            green_fast_track:
+              - products/green_fast_track/**
+              - admin/run_environment/**
+            pluto:
+              - products/pluto/**
+              - admin/run_environment/**
+            zoningtaxlots:
+              - products/zoningtaxlots/**
               - admin/run_environment/**
             docker:
               - admin/run_environment/**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
               - dcpy/**
               - pyproject.toml
               - admin/run_environment/**
+              - .github/workflows/test.yml
+              - .github/workflows/test_helper.yml
             template:
               - .github/workflows/test.yml
               - .github/workflows/build.yml

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -50,8 +50,32 @@ jobs:
         sqlfluff lint products/knownprojects/sql --templater=jinja
         sqlfluff lint products/pluto/pluto_build/sql/
 
+  set_dbt_matrix:
+    name: Setup dbt tests
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.set-dbt-matrix.outputs.matrix }}
+      matrix_raw: ${{ steps.set-dbt-matrix.outputs.matrix_raw }}
+    steps:
+    # path_filter is JSON from paths-filter, or empty on pushes, where everything runs.
+    - name: Confirm changes and set matrix for dbt
+      id: set-dbt-matrix
+      env:
+        CHANGED: ${{ inputs.path_filter }}
+      run: |
+        # Not every products/*/dbt_project.yml is here; the rest aren't migrated far enough to test.
+        projects=$(jq -cn \
+          --argjson all '["template","cdbg","ceqr","cpdb","cscl","green_fast_track","pluto","zoningtaxlots"]' \
+          --argjson changed "${CHANGED:-null}" \
+          '$all | map(select($changed == null or IN($changed[])))')
+        echo "dbt projects to test: $projects"
+        echo "matrix_raw=$projects" >> $GITHUB_OUTPUT
+        echo "matrix={\"project\":$projects}" >> $GITHUB_OUTPUT
+
   dbt:
     name: dbt tests
+    needs: set_dbt_matrix
+    if: needs.set_dbt_matrix.outputs.matrix_raw != '[]'
     runs-on: ubuntu-22.04
     container:
       image: nycplanning/dev:${{ inputs.image_tag }}
@@ -81,16 +105,7 @@ jobs:
         - 5432:5432
     strategy:
       fail-fast: false
-      matrix:
-        project:
-        - template
-        - cdbg
-        - ceqr
-        - cpdb
-        - cscl
-        - green_fast_track
-        - pluto
-        - zoningtaxlots
+      matrix: ${{ fromJson(needs.set_dbt_matrix.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v4
     - name: setup

--- a/.github/workflows/test_helper.yml
+++ b/.github/workflows/test_helper.yml
@@ -161,7 +161,7 @@ jobs:
   pytest_dcpy:
     name: Pytest - dcpy
     runs-on: ubuntu-22.04
-    #if: (inputs.path_filter == '') || contains(inputs.path_filter, 'dcpy')
+    if: (inputs.path_filter == '') || contains(inputs.path_filter, 'dcpy')
     env:
       GHP_TOKEN: ${{ github.GITHUB_TOKEN }}
       RECIPES_BUCKET: edm-recipes

--- a/admin/ops/issue_metadata.py
+++ b/admin/ops/issue_metadata.py
@@ -1,4 +1,4 @@
-"""Apply `db-*` product labels and issue types to issues by matching their titles.
+"""Apply `db-*` product labels, topic labels, and issue types by matching issue titles.
 
 Both were applied by hand for years and landed on a minority of the issues they
 should have — product labels on 18% of the issues naming a product, the Bug type
@@ -25,9 +25,12 @@ REPO = "NYCPlanning/data-engineering"
 LIST_FIELDS = "number,title,labels,issueType"
 
 
+Rules = list[tuple[str, re.Pattern]]
+
+
 @lru_cache(maxsize=1)
-def _rules() -> tuple[list[tuple[str, re.Pattern]], list[tuple[str, re.Pattern]]]:
-    """(label, pattern) and (issue type, pattern) pairs, one pattern per target."""
+def _rules() -> tuple[Rules, Rules, Rules]:
+    """(label, pattern) pairs for products then topics, then (issue type, pattern)."""
     config = yaml.safe_load(CONFIG_PATH.read_text())
 
     def compile_specs(specs, key):
@@ -38,17 +41,28 @@ def _rules() -> tuple[list[tuple[str, re.Pattern]], list[tuple[str, re.Pattern]]
 
     return (
         compile_specs(config["products"], "label"),
+        compile_specs(config.get("labels", {}), None),
         compile_specs(config.get("types", {}), None),
     )
 
 
 def match_labels(title: str) -> list[str]:
-    return sorted(label for label, pattern in _rules()[0] if pattern.search(title))
+    """Product labels if any match, else topic labels.
+
+    Topic labels describe work that isn't a data product, so a title naming a
+    product can't also be one — otherwise `PLUTO docker image` reads as platform
+    work rather than PLUTO's.
+    """
+    products, topics, _ = _rules()
+    matched = [label for label, pattern in products if pattern.search(title)]
+    if not matched:
+        matched = [label for label, pattern in topics if pattern.search(title)]
+    return sorted(matched)
 
 
 def match_type(title: str) -> str | None:
     """First matching issue type, or None. Types are mutually exclusive."""
-    return next((name for name, p in _rules()[1] if p.search(title)), None)
+    return next((name for name, p in _rules()[2] if p.search(title)), None)
 
 
 def _gh(*args: str) -> str:


### PR DESCRIPTION
- **`maintenance` issue label renamed to `platform`** — `Related to tooling and infrastructure`. half the issues it tagged were new work, not upkeep
- **applied automatically now** — title patterns in `issue_metadata.yml`, like the `db-*` labels. 67 issues carry it, up from 21
- **`python` label deleted** — dependabot's, never used on an issue
- **dcpy tests only run when dcpy changes** — the condition was already there, just commented out. the full suite ran on every PR, 5 min of a 6 min run
- **dbt tests only run for changed products** — all 8 projects ran every time

## notes

issues that match a product label don't also get `platform`, so `PLUTO docker image` stays PLUTO's.

dbt test jobs across the last 120 merged PRs: 960 → 85. half of those PRs touch exactly one dbt project.

the new `ceqr` path filter turns on a pytest job that has never run — it may fail.
