### PR TITLE
improve scheduled action failure issues

### DIFF
--- a/.github/issue_metadata.yml
+++ b/.github/issue_metadata.yml
@@ -74,15 +74,17 @@ products:
     label: db-zoningtaxlots
     patterns: ['\bztl\b', '\bzoning[- ]?tax[- ]?lots?\b']
 
-# Non-product labels, keyed by the label name itself. Only applied when no
-# product pattern matched — `platform` means work that isn't a data product,
-# so `PLUTO docker image` stays PLUTO's.
+# Non-product labels, keyed by the label name itself. `exclusive` means the
+# label can't sit alongside a db-* one — `platform` is work that isn't a data
+# product, so `PLUTO docker image` stays PLUTO's. Stage labels say where in the
+# pipeline a product broke, so they stack with it.
 #
 # Patterns are deliberately narrow: proper nouns and tool names, not the
 # generic words (build, test, ingest, library, app) that every product issue
 # also uses.
 labels:
   platform:
+    exclusive: true
     patterns:
       - '\bdcpy\b'
       - '\bazure\b'
@@ -99,6 +101,18 @@ labels:
       - '\bcredential management\b'
       - '\bbuild engine\b'
       - '\bqa ?/? ?qc app\b'
+      - '\bcompile python requirements\b'
+      - '\bstale build artifacts\b'
+  ingest/library:
+    patterns:
+      - '^Scheduled Action Failure - (Ingest|Data Library) - '
+      - '^Scheduled Action Failure - DevDB - Data Sync'
+      - '^Scheduled Action Failure - PLUTO Inputs\b'
+      - '^Scheduled Action Failure - ZAP - Weekly Export'
+      - '^Scheduled Action Failure - .*\bDEP CATS permits\b'
+  QA:
+    patterns:
+      - '^Scheduled Action Failure - .*\bNightly QA\b'
 
 # Issue types are org-level and already the team's convention (Bug is the most
 # used), so bug tracking lives here rather than in a `bug` label. Only applied

--- a/.github/workflows/ceqr_dep_monthly.yml
+++ b/.github/workflows/ceqr_dep_monthly.yml
@@ -67,3 +67,4 @@ jobs:
           github.run_id }}
       with:
         filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md
+        update_existing: true

--- a/.github/workflows/developments_datasync.yml
+++ b/.github/workflows/developments_datasync.yml
@@ -129,3 +129,4 @@ jobs:
           BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md
+          update_existing: true

--- a/.github/workflows/pluto_inputs.yml
+++ b/.github/workflows/pluto_inputs.yml
@@ -56,3 +56,4 @@ jobs:
         BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       with:
         filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md
+        update_existing: true

--- a/.github/workflows/python_compile_requirements.yml
+++ b/.github/workflows/python_compile_requirements.yml
@@ -67,3 +67,4 @@ jobs:
         BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       with:
         filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md
+        update_existing: true

--- a/.github/workflows/stale_builds.yml
+++ b/.github/workflows/stale_builds.yml
@@ -57,3 +57,4 @@ jobs:
           BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md
+          update_existing: true

--- a/.github/workflows/zap_export.yml
+++ b/.github/workflows/zap_export.yml
@@ -129,3 +129,4 @@ jobs:
           BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           filename: .github/ISSUE_TEMPLATE/scheduled_action_failure.md
+          update_existing: true

--- a/admin/ops/issue_metadata.py
+++ b/admin/ops/issue_metadata.py
@@ -26,11 +26,12 @@ LIST_FIELDS = "number,title,labels,issueType"
 
 
 Rules = list[tuple[str, re.Pattern]]
+TopicRules = list[tuple[str, re.Pattern, bool]]
 
 
 @lru_cache(maxsize=1)
-def _rules() -> tuple[Rules, Rules, Rules]:
-    """(label, pattern) pairs for products then topics, then (issue type, pattern)."""
+def _rules() -> tuple[Rules, TopicRules, Rules]:
+    """(label, pattern) for products and types; topics also carry their exclusivity."""
     config = yaml.safe_load(CONFIG_PATH.read_text())
 
     def compile_specs(specs, key):
@@ -39,25 +40,33 @@ def _rules() -> tuple[Rules, Rules, Rules]:
             for name, spec in specs.items()
         ]
 
+    topics = [
+        (name, pattern, config["labels"][name].get("exclusive", False))
+        for name, pattern in compile_specs(config.get("labels", {}), None)
+    ]
     return (
         compile_specs(config["products"], "label"),
-        compile_specs(config.get("labels", {}), None),
+        topics,
         compile_specs(config.get("types", {}), None),
     )
 
 
 def match_labels(title: str) -> list[str]:
-    """Product labels if any match, else topic labels.
+    """Product labels, plus every topic label that matches.
 
-    Topic labels describe work that isn't a data product, so a title naming a
-    product can't also be one — otherwise `PLUTO docker image` reads as platform
-    work rather than PLUTO's.
+    An `exclusive` topic is dropped when a product matched too: `platform` means
+    work that isn't a data product, so `PLUTO docker image` stays PLUTO's. Stage
+    labels like `ingest/library` describe *where* in the pipeline a product
+    broke, so they stack with the product label.
     """
     products, topics, _ = _rules()
-    matched = [label for label, pattern in products if pattern.search(title)]
-    if not matched:
-        matched = [label for label, pattern in topics if pattern.search(title)]
-    return sorted(matched)
+    from_product = [label for label, pattern in products if pattern.search(title)]
+    from_topic = [
+        label
+        for label, pattern, exclusive in topics
+        if pattern.search(title) and not (exclusive and from_product)
+    ]
+    return sorted(from_product + from_topic)
 
 
 def match_type(title: str) -> str | None:


### PR DESCRIPTION
- **scheduled action failures now get a pipeline-stage label** — `ingest/library` for source-data pulls (ingest routines, DevDB data sync, PLUTO inputs, ZAP export, DEP CATS), `QA` for nightly QA. 216 issues backfilled
- **stage labels stack with product labels** — a DevDB ingest failure is both `db-developments` and `ingest/library`. only `platform` stays exclusive, since it means "not a data product"
- **repeat failures update one issue instead of opening a new one** — six workflows never set `update_existing`; now all eight do