### PR TITLE
bump versions for distribution to open data

### DIFF
--- a/product-metadata/snippets/strings.yml
+++ b/product-metadata/snippets/strings.yml
@@ -59,23 +59,23 @@ bytes_url__zoning_map_index: https://www.nyc.gov/content/planning/pages/resource
 bytes_url__ztl: https://www.nyc.gov/content/planning/pages/resources/datasets/zoning-map-index
 
 # Versions
-current_version_lion: 26b
-current_version_pluto: 26v1
+current_version_lion: 26c
+current_version_pluto: 26v2
 current_version_facilities: 26v1
 current_version_building_elevation_and_subgrade: 202510
 current_version_cdbg: 202503
 current_version_census_equivalency_tract_table:
 current_version_colp: 202610
-current_version_cpdb: 26pre
+current_version_cpdb: 26exec
 current_version_dcm: 20251031
 current_version_designated_areas_m_districts_appendix_j:
-current_version_developments: 25q4
+current_version_developments: 26q2
 current_version_directory_of_land_use_application_fees:
 current_version_e_designations: 20260707
 current_version_fresh_zoning_boundary: 202602
-current_version_inclusionary_housing_designated_areas: 20251031
+current_version_inclusionary_housing_designated_areas: 20260731
 current_version_lower_density_growth_management_areas: 202604
-current_version_mandatory_inclusionary_housing: 20260331
+current_version_mandatory_inclusionary_housing: 20260731
 current_version_new_york_city_neighborhood_name_centroid: 2014.8
 current_version_pops: 25v2
 current_version_projected_sea_level_rise: 201705
@@ -84,7 +84,7 @@ current_version_transit_zones: 202410
 current_version_waterfront_public_access_areas: 202309
 current_version_waterfront_revitalization_program: 2016.1
 current_version_zap: 20260706
-current_version_zoning: 202606
+current_version_zoning: 202607
 current_version_zoning_map_index:
 
 # Test variables for dcpy test suite


### PR DESCRIPTION
based on QA app's distribution page, many datasets on Bytes are ahead of Open Data and can't be distributed until the versions in `product-metadata/` are bumped to align with Bytes