### PR TITLE
CSCL: Fix thinfire keys

### DIFF
--- a/products/cscl/models/product/thinfire/thinfire_by_field.sql
+++ b/products/cscl/models/product/thinfire/thinfire_by_field.sql
@@ -1,6 +1,11 @@
+WITH combined AS (
+    SELECT
+        globalid,
+        {{ apply_text_formatting_from_seed('text_formatting__thinfire_dat') }}
+    FROM {{ ref('thinfire_by_field_unformatted') }}
+)
 SELECT
-    globalid,
-    {{ apply_text_formatting_from_seed('text_formatting__thinfire_dat') }},
-    globalid AS _thinfire_key
-FROM {{ ref('thinfire_by_field_unformatted') }}
+    *,
+    fire_company_type || fire_company_number AS _thinfire_key
+FROM combined
 ORDER BY fire_company_type, fire_company_number


### PR DESCRIPTION
We had GUIDs as thinfire keys, because of a bug I introduced shortly after sending Jonathan the diffs. This puts things back as they should have been.