### PR TITLE
refresh GRU page and expand source data section

### DIFF
--- a/apps/qa/src/pages/gru/components.py
+++ b/apps/qa/src/pages/gru/components.py
@@ -18,7 +18,12 @@ from .constants import (
     bucket,
     qa_checks,
 )
-from .helpers import behind_sources, get_geosupport_versions, get_source_status
+from .helpers import (
+    behind_sources,
+    get_geosupport_versions,
+    get_source_status,
+    public_url,
+)
 
 SOURCE_COLUMNS = {
     "dataset": "Source",
@@ -135,10 +140,7 @@ def check_table(
             if not running:
                 with sources:
                     try:
-                        path = s3.get_presigned_get_url(
-                            bucket, f"{s3_folder}/versions.csv", 5
-                        )
-                        versions = pd.read_csv(path)
+                        versions = pd.read_csv(public_url(f"{s3_folder}/versions.csv"))
                         st.download_button(
                             label="\n".join(check["sources"]),
                             data=versions.to_csv(index=False).encode("utf-8"),
@@ -154,16 +156,9 @@ def check_table(
 
                 filenames = sorted(s3.get_filenames(bucket, s3_folder))
 
-                def get_url(f: str) -> str:
-                    """
-                    page refreshes every 10 min as set in gru.py
-                    urls valid just past that
-                    """
-                    return s3.get_presigned_get_url(bucket, f"{s3_folder}/{f}", 610)
-
                 files = "  \n".join(
                     [
-                        f"[{filename}]({get_url(filename)})"
+                        f"[{filename}]({public_url(f'{s3_folder}/{filename}')})"
                         for filename in filenames
                         if filename != "versions.csv"
                     ]

--- a/apps/qa/src/pages/gru/components.py
+++ b/apps/qa/src/pages/gru/components.py
@@ -9,8 +9,25 @@ from shared.components.github import dispatch_workflow_button
 from dcpy.utils import s3
 from dcpy.utils.git import github
 
-from .constants import bucket, qa_checks
-from .helpers import get_geosupport_versions, get_source_versions
+from .constants import (
+    CHECKS_REPO,
+    CHECKS_WORKFLOW,
+    INGEST_REPO,
+    INGEST_WORKFLOW,
+    INGEST_WORKFLOW_URL,
+    bucket,
+    qa_checks,
+)
+from .helpers import behind_sources, get_geosupport_versions, get_source_status
+
+SOURCE_COLUMNS = {
+    "dataset": "Source",
+    "archived_version": "Archived",
+    "archived_on": "Archived on",
+    "latest_version": "Latest at origin",
+    "status": "Status",
+    "refreshed_by": "How it refreshes",
+}
 
 
 def status_details(workflow_run: github.WorkflowRun) -> None:
@@ -36,17 +53,63 @@ def status_details(workflow_run: github.WorkflowRun) -> None:
 
 
 def source_table() -> None:
-    column_widths = (4, 5, 3)
-    cols = st.columns(column_widths)
-    fields = ["Name", "Latest version archived by DE", "Date of archival"]
-    for col, field_name in zip(cols, fields):
-        col.write(f"**{field_name}**")
-    source_versions = get_source_versions()
-    for source in source_versions:
-        col1, col2, col3 = st.columns(column_widths)
-        col1.write(source)
-        col2.write(source_versions[source]["version"])
-        col3.write(source_versions[source]["timestamp"].strftime("%Y-%m-%d"))
+    status = get_source_status()
+    st.dataframe(
+        status,
+        width="stretch",
+        hide_index=True,
+        column_config=SOURCE_COLUMNS,
+    )
+
+    last_dispatch = st.session_state.get("last_ingest_dispatch")
+    if last_dispatch:
+        st.success(
+            f"Dispatched ingest for {last_dispatch}. Track it in "
+            f"[GitHub Actions]({INGEST_WORKFLOW_URL}). This table refreshes once the run "
+            "archives the new version."
+        )
+
+    behind = behind_sources(status)
+    if behind.empty:
+        st.info(
+            "Every source is archived at the newest version its origin offers, so the checks "
+            "below will run against current data."
+        )
+        return
+
+    st.warning(
+        f"**{len(behind)} of these are behind.** A check run now compares against the archived "
+        "version, not the one at the origin. Ingest them first."
+    )
+
+    def record_dispatch(dataset: str) -> None:
+        st.session_state["last_ingest_dispatch"] = dataset
+
+    for row in behind.itertuples():
+        summary, button = st.columns((6, 1), vertical_alignment="center")
+        with summary:
+            st.markdown(
+                f"**{row.dataset}**: archived `{row.archived_version}`, "
+                f"origin has `{row.latest_version}`"
+            )
+            st.caption(row.refreshed_by)
+        with button:
+            dispatch_workflow_button(
+                INGEST_REPO,
+                INGEST_WORKFLOW,
+                key=f"ingest-{row.dataset}",
+                label="Ingest",
+                run_after=lambda dataset=row.dataset: record_dispatch(dataset),
+                dataset=row.dataset,
+                # Pinned to the version this page actually read, so the run archives what the
+                # table claims. Bytes and DevDB templates need it: their source is a raw
+                # versioned URL that resolves to nothing without one.
+                version=row.latest_version,
+                latest=True,
+                # Sent explicitly rather than relying on the workflow default, so a change to
+                # that default can't turn a click here into a dev-image run.
+                dev_image=False,
+            )
 
 
 def check_table(
@@ -115,19 +178,17 @@ def check_table(
             name.write(check["display_name"])
             with column:
                 st.info(
-                    format(
-                        f"Check has not been run yet for Geosupport {geosupport_version}"
-                    )
+                    f"Check has not been run yet for Geosupport {geosupport_version}"
                 )
             running = False
 
         with run:
             dispatch_workflow_button(
-                "db-gru-qaqc",
-                "main.yml",
+                CHECKS_REPO,
+                CHECKS_WORKFLOW,
                 disabled=running,
                 key=check["action_name"],
                 name=check["action_name"],
                 geosupport_version=get_geosupport_versions()[geosupport_version],
                 run_after=lambda: time.sleep(2),
-            )  ## refresh after 2 so that status has hopefully
+            )  ## refresh after 2 so that status has hopefully changed

--- a/apps/qa/src/pages/gru/constants.py
+++ b/apps/qa/src/pages/gru/constants.py
@@ -1,6 +1,18 @@
+from dataclasses import dataclass
+
 import pandas as pd
 
 bucket = "edm-publishing"
+
+CHECKS_REPO = "db-gru-qaqc"
+CHECKS_WORKFLOW = "main.yml"
+
+INGEST_REPO = "data-engineering"
+INGEST_WORKFLOW = "ingest_single.yml"
+INGEST_WORKFLOW_URL = (
+    f"https://github.com/NYCPlanning/{INGEST_REPO}/actions/workflows/{INGEST_WORKFLOW}"
+)
+
 qa_checks = pd.DataFrame(
     [
         (
@@ -43,16 +55,120 @@ qa_checks = pd.DataFrame(
     columns=["display_name", "action_name", "sources"],
 )
 
-readme_markdown_text = """### Source Data Info
-+ Quarterly load to data-library using [dataloading workflow](https://github.com/NYCPlanning/db-gru-qaqc/blob/main/.github/workflows/dataloading.yml) included in this repo
-+ **`dcp_addresspoints`**: Uploaded to edm-publishing data staging by GIS
-+ **`dcp_atomicpolygons`**: Pulled from Bytes of the Big Apple
-+ **`dcp_pad`**: Pulled from Bytes of the Big Apple and parsed through a [python script](https://github.com/NYCPlanning/db-data-library/blob/main/library/script/dcp_pad.py)
-+ **`dcp_dcmstreetcenterline`**: Uploaded to edm-publishing data staging by GIS
-+ **`dcp_saf`**: Uploaded to edm-publishing data staging by GIS. These files get read directly from the upload location, and are not loaded to data-library.
-+ Requires manual reloading to data-library
-+ **`doitt_buildingfootprints`**: Pulled from [OpenData](https://data.cityofnewyork.us/Housing-Development/Building-Footprints/nqwf-w8eh) and parsed through a [python script](https://github.com/NYCPlanning/db-data-library/blob/main/library/script/doitt_buildingfootprints.py). Due to instability, this data update is not get included in the batch update workflow.
-+ **`dcp_developments`**: Gets published to data-library upon rebuilding using a [workflow](https://github.com/NYCPlanning/data-engineering/blob/main/.github/workflows/developments_publish.yml) in the db-developments repo. No other update necessary.
+
+@dataclass(frozen=True)
+class SourceDataset:
+    """A source dataset the checks read, and where its newest version comes from."""
+
+    id: str
+    refresh: str
+    """How a new version reaches edm-recipes, in a reviewer's terms."""
+
+    upstream_kind: str | None = None
+    """Which connector holds the newest version at the origin: "template" (ask the ingest
+    template's own source connector), "bytes", or "publishing".
+
+    None means there is no archive step that can fall behind, so there is nothing to compare
+    against. Only dcp_saf, which the checks read straight out of edm-publishing.
+    """
+
+    upstream_key: str | None = None
+    """Key for that connector, where it differs from the dataset id."""
+
+
+BYTES_QUARTERLY = "Bytes quarterly release. Archived by ingest_bytes_quarterly.yml, dispatched by hand."
+GIS_UPLOAD = (
+    "GIS drops a new version to edm-publishing/datasets. Archiving it is manual."
+)
+OPEN_DATA_WEEKLY = (
+    "Open Data. Archived automatically by ingest_open_data.yml every Sunday."
+)
+
+source_datasets = {
+    source.id: source
+    for source in [
+        SourceDataset(
+            id="dcp_addresspoints",
+            upstream_kind="template",
+            refresh=GIS_UPLOAD,
+        ),
+        SourceDataset(
+            id="dcp_atomicpolygons",
+            upstream_kind="bytes",
+            upstream_key="lion.atomic_polygons",
+            refresh=BYTES_QUARTERLY,
+        ),
+        SourceDataset(
+            id="dcp_dcmstreetcenterline",
+            upstream_kind="template",
+            refresh=GIS_UPLOAD,
+        ),
+        SourceDataset(
+            id="dcp_developments",
+            upstream_kind="publishing",
+            upstream_key="db-developments",
+            refresh=(
+                "Published by a DevDB build. Archiving it is manual: the workflow that used "
+                "to do it, developments_publish.yml, is in .github/workflows/archive."
+            ),
+        ),
+        SourceDataset(
+            id="dcp_pad",
+            upstream_kind="bytes",
+            upstream_key="lion.property_address_directory",
+            refresh=BYTES_QUARTERLY,
+        ),
+        SourceDataset(
+            id="dcp_saf",
+            refresh=(
+                "GIS uploads to edm-publishing/gru/dcp_saf. The checks read it from there, so "
+                "it is never archived to edm-recipes and cannot fall behind a newer version."
+            ),
+        ),
+        SourceDataset(
+            id="doitt_buildingfootprints",
+            upstream_kind="template",
+            refresh=OPEN_DATA_WEEKLY,
+        ),
+        SourceDataset(
+            id="doitt_buildingfootprints_historical",
+            upstream_kind="template",
+            refresh=OPEN_DATA_WEEKLY,
+        ),
+    ]
+}
+
+readme_markdown_text = """### Source data
+
+The checks read source data from `edm-recipes`, archived there by ingest in the
+[data-engineering](https://github.com/NYCPlanning/data-engineering) repo. This repo only runs the
+checks themselves. The table above compares what is archived against the newest version at each
+origin, so a stale source shows up before a check runs on it rather than after.
+
+Three of the eight need a person to archive them:
+
++ **`dcp_addresspoints`** and **`dcp_dcmstreetcenterline`** land in `edm-publishing/datasets` when
+  the GIS team drops them. Nothing archives them on a schedule.
++ **`dcp_developments`** comes from a DevDB build published to `edm-publishing`. The workflow that
+  used to archive it on publish now sits in `.github/workflows/archive`.
+
+The rest are on a schedule:
+
++ **`dcp_atomicpolygons`** and **`dcp_pad`** come from Bytes of the Big Apple, once a quarter.
+  [`ingest_bytes_quarterly.yml`](https://github.com/NYCPlanning/data-engineering/actions/workflows/ingest_bytes_quarterly.yml)
+  archives both, along with LION and the district boundary files, but someone has to dispatch it
+  with the new quarter.
++ **`doitt_buildingfootprints`** and **`doitt_buildingfootprints_historical`** come from Open Data
+  and are archived every Sunday by
+  [`ingest_open_data.yml`](https://github.com/NYCPlanning/data-engineering/actions/workflows/ingest_open_data.yml).
+  Nothing to run by hand.
++ **`dcp_saf`** is a GIS upload to `edm-publishing/gru/dcp_saf`. The checks read it straight from
+  there, so it is never archived and never behind.
+
+The Ingest buttons above dispatch
+[`ingest_single.yml`](https://github.com/NYCPlanning/data-engineering/actions/workflows/ingest_single.yml)
+on `main` for one dataset at the version shown, so an out of date source can be refreshed without
+leaving this page.
 
 ### PAD checks
 

--- a/apps/qa/src/pages/gru/constants.py
+++ b/apps/qa/src/pages/gru/constants.py
@@ -47,7 +47,7 @@ qa_checks = pd.DataFrame(
             ["dcp_dcmstreetcenterline"],
         ),
         (
-            "Generic SAF Addresses vs PAD Roadbed SAF Addresses vs PAD",
+            "Gen/RB SAF Addresses vs PAD & GRID",
             "saf-vs-pad",
             ["dcp_saf"],
         ),
@@ -165,6 +165,11 @@ The rest are on a schedule:
 + **`dcp_saf`** is a GIS upload to `edm-publishing/gru/dcp_saf`. The checks read it straight from
   there, so it is never archived and never behind.
 
+Not every source a check name mentions is a dataset in this table. The checks named "vs PAD"
+get PAD from the Geosupport release they run against, not from the archived `dcp_pad`: each
+run's `versions.csv` lists only Geosupport and the dataset it compares. `dcp_pad` is read as a
+dataset by one check, PAD BINs vs Footprint BINs.
+
 The Ingest buttons above dispatch
 [`ingest_single.yml`](https://github.com/NYCPlanning/data-engineering/actions/workflows/ingest_single.yml)
 on `main` for one dataset at the version shown, so an out of date source can be refreshed without
@@ -194,7 +199,10 @@ This check merges PAD addresses on DOITT building footprints using BIN. Records 
 
 #### Check that SAF addresses exist in PAD
 
-The output of this check contains SAF records that were not successfully geocoded with
+This one check produces both of the SAF reports GR circulates, **Gen/RB SAF Addresses vs PAD**
+and **Gen/RB SAF Addresses vs GRID**, so the check table above lists it as a single row.
+
+The output contains SAF records that were not successfully geocoded with
 geosupport function 1, 1A, or 1R. SAF records come from the following files:
 
 + GenericABCEGNPX
@@ -206,8 +214,9 @@ geosupport function 1, 1A, or 1R. SAF records come from the following files:
 + RoadbedOV
 + RoadbedS
 
-Results are organized into 6 files -- three for generic and three for roadbed.
-Within these six, two geocode using 1A, two use 1, and two use 1 with the roadbed switch.
+Results are organized into 6 files -- three for generic and three for roadbed:
+`GN_SAFs_vs_PAD.csv`, `GN_SAFs_vs_GRID1G.csv`, `GN_SAFs_vs_GRID1R.csv`, and the matching `RB_`
+files. Within these six, two geocode using 1A, two use 1, and two use 1 with the roadbed switch.
 
 ### TPAD checks
 

--- a/apps/qa/src/pages/gru/gru.py
+++ b/apps/qa/src/pages/gru/gru.py
@@ -4,7 +4,7 @@ def gru():
     import streamlit as st
 
     from .components import check_table, source_table
-    from .constants import qa_checks, readme_markdown_text
+    from .constants import CHECKS_REPO, qa_checks, readme_markdown_text
     from .helpers import (
         get_geosupport_versions,
         get_qaqc_runs,
@@ -23,13 +23,13 @@ def gru():
 
     st.header("GRU QAQC")
     st.write(
-        """This page runs automated QAQC checks for various GRU-maintained files, displays source data info and makes outputs available for download.  \n
+        f"""This page runs automated QAQC checks for various GRU-maintained files, shows how current their source data is, and makes outputs available for download.  \n
 Checks are performed either by comparing files to each other or by comparing a file to the latest Geosupport release.
-To perform a check, hit a button in the table below. The status column has a link to the latest Github workflow run for a given check  \n
-Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
+To perform a check, hit a button in the check table below. The status column has a link to the latest Github workflow run for a given check.  \n
+The checks live in [{CHECKS_REPO}](https://github.com/NYCPlanning/{CHECKS_REPO}/). The source data they read is archived by ingest in [data-engineering](https://github.com/NYCPlanning/data-engineering/), which is what the source table below reports on."""
     )
 
-    st.header("Latest Source Data")
+    st.header("Source data")
     source_table()
 
     st.header(f"QAQC Checks - Geosupport {geosupport_version}")

--- a/apps/qa/src/pages/gru/helpers.py
+++ b/apps/qa/src/pages/gru/helpers.py
@@ -1,7 +1,9 @@
+import os
 import re
 import time
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import quote
 
 import pandas as pd
 import requests
@@ -39,6 +41,12 @@ UP_TO_DATE = "up to date"
 BEHIND = "behind"
 UNKNOWN = "unknown"
 READ_IN_PLACE = "read in place"
+
+
+def public_url(key: str) -> str:
+    """Unsigned, non-expiring link. QAQC outputs are uploaded public-read."""
+    endpoint = os.environ["AWS_S3_ENDPOINT"].rstrip("/")
+    return f"{endpoint}/{bucket}/{quote(key)}"
 
 
 def _read_in_place(source: SourceDataset) -> tuple[str, datetime | None]:

--- a/apps/qa/src/pages/gru/helpers.py
+++ b/apps/qa/src/pages/gru/helpers.py
@@ -1,45 +1,158 @@
 import re
 import time
+from datetime import datetime
+from pathlib import Path
 
+import pandas as pd
 import requests
 import streamlit as st
+from app_globals import ROOT_PATH
 
+from dcpy.configuration import INGEST_DEF_DIR
+from dcpy.connectors.edm import publishing
+from dcpy.lifecycle.connector_registry import connectors
+from dcpy.lifecycle.ingest import plan
 from dcpy.lifecycle.ingest.connectors import get_processed_datastore_connector
+from dcpy.lifecycle.scripts.version_compare import render_version
 from dcpy.utils import s3
 from dcpy.utils.git import github
 
-from .constants import qa_checks
+from .constants import (
+    CHECKS_REPO,
+    CHECKS_WORKFLOW,
+    SourceDataset,
+    bucket,
+    qa_checks,
+    source_datasets,
+)
+
+# TEMPLATE_DIR isn't set in the app container and its default is relative to the working
+# directory, which streamlit doesn't set to the repo root. The repo is mounted whole, so fall
+# back to a path off the app's own location.
+INGEST_TEMPLATE_DIR = (
+    Path(INGEST_DEF_DIR)
+    if Path(INGEST_DEF_DIR).is_dir()
+    else ROOT_PATH / "ingest_templates"
+)
+
+UP_TO_DATE = "up to date"
+BEHIND = "behind"
+UNKNOWN = "unknown"
+READ_IN_PLACE = "read in place"
 
 
-def get_source_version(dataset: str) -> dict:
-    if dataset == "dcp_saf":
-        bucket = "edm-publishing"
-        prefix = "gru/dcp_saf/"
-        folders = s3.get_subfolders(bucket, prefix)
-        if "latest" in folders:
-            folders.remove("latest")
-        version = max(folders)
-        timestamp = s3.get_metadata(
-            bucket, f"{prefix}{version}/dcp_saf.zip"
-        ).last_modified
-        return {"name": dataset, "version": version, "timestamp": timestamp}
-    else:
-        config = get_processed_datastore_connector().get_sparse_config(
-            key=dataset, version="latest"
+def _read_in_place(source: SourceDataset) -> tuple[str, datetime | None]:
+    """The version of a GIS upload the checks would read out of edm-publishing.
+
+    Nothing archives these to edm-recipes, so there is no config to ask for a version. The
+    upload timestamp is the closest thing to an archival date.
+    """
+    prefix = f"gru/{source.id}/"
+    folders = s3.get_subfolders(bucket, prefix)
+    if "latest" in folders:
+        folders.remove("latest")
+    version = max(folders)
+    timestamp = s3.get_metadata(
+        bucket, f"{prefix}{version}/{source.id}.zip"
+    ).last_modified
+    return version, timestamp
+
+
+def _archived(source: SourceDataset) -> tuple[str, datetime | None]:
+    if source.upstream_kind is None:
+        return _read_in_place(source)
+    config = get_processed_datastore_connector().get_sparse_config(
+        key=source.id, version="latest"
+    )
+    return config.version, config.run_timestamp
+
+
+def _upstream(source: SourceDataset) -> str | None:
+    """The newest version at the origin, or None where the connector can't report one.
+
+    Bytes datasets need an explicit key: their templates fetch a raw versioned URL rather than
+    going through the bytes connector, so asking the template's own source yields nothing.
+    """
+    match source.upstream_kind:
+        case "template":
+            definition = plan.read_definition_file(
+                INGEST_TEMPLATE_DIR / f"{source.id}.yml"
+            )
+            return plan.get_version(definition.source)
+        case "bytes":
+            return connectors["bytes"].get_latest_version(source.upstream_key)
+        case "publishing":
+            return publishing.get_latest_version(source.upstream_key)
+        case _:
+            return None
+
+
+def classify(
+    source: SourceDataset,
+    archived_version: str | Exception | None,
+    upstream_version: str | Exception | None,
+) -> str:
+    """How the archived version stands against what the origin offers.
+
+    A version we failed to fetch is `unknown`, never `behind`: an unreachable origin says
+    nothing about whether the archive is current, and calling it stale would send someone to
+    re-ingest data that is already fine.
+    """
+    if source.upstream_kind is None:
+        return READ_IN_PLACE
+    if isinstance(archived_version, Exception) or isinstance(
+        upstream_version, Exception
+    ):
+        return UNKNOWN
+    if not archived_version or not upstream_version:
+        return UNKNOWN
+    # Both strings come from the same origin in the same format, so they compare directly. This
+    # is not the Bytes-against-Open-Data case that version_compare has to fuzzy-match.
+    return UP_TO_DATE if archived_version == upstream_version else BEHIND
+
+
+@st.cache_data(ttl=600, show_spinner="Checking source data versions ...")
+def get_source_status() -> pd.DataFrame:
+    """What is archived for each source, against what the origin currently offers.
+
+    Cached for the same 10 minutes the page waits before rerunning itself, so an idle page
+    refetches once a cycle rather than on every rerun.
+    """
+    rows = []
+    for source in source_datasets.values():
+        archived_version: str | Exception | None = None
+        archived_on: datetime | None = None
+        upstream_version: str | Exception | None = None
+
+        try:
+            archived_version, archived_on = _archived(source)
+        except Exception as error:
+            archived_version = error
+        try:
+            upstream_version = _upstream(source)
+        except Exception as error:
+            upstream_version = error
+
+        rows.append(
+            {
+                "dataset": source.id,
+                "archived_version": render_version(archived_version),
+                "archived_on": archived_on.date() if archived_on else None,
+                "latest_version": render_version(upstream_version),
+                "status": classify(source, archived_version, upstream_version),
+                "refreshed_by": source.refresh,
+            }
         )
-        return {
-            "name": dataset,
-            "version": config.version,
-            "timestamp": config.run_timestamp,
-        }
+    return pd.DataFrame(rows)
 
 
-@st.cache_data(ttl=120)
-def get_source_versions() -> dict[str, dict]:
-    versions = {}
-    for dataset in [source for sources in qa_checks["sources"] for source in sources]:
-        versions[dataset] = get_source_version(dataset)
-    return versions
+def behind_sources(status: pd.DataFrame) -> pd.DataFrame:
+    """Rows an ingest run would actually fix.
+
+    Deliberately excludes `unknown`: a version we failed to fetch is not evidence of a stale
+    archive, and dispatching without a version we trust would archive under the wrong one.
+    """
+    return status[status["status"] == BEHIND]
 
 
 def map_geosupport_version(patched_version: str) -> str:
@@ -56,8 +169,8 @@ def get_qaqc_runs(geosupport_version: str) -> dict[str, github.WorkflowRun]:
         page == 0 or (len(raw_workflow_runs) > 0)
     ):
         raw_workflow_runs = github.get_workflow_runs(
-            "db-gru-qaqc",
-            "main.yml",
+            CHECKS_REPO,
+            CHECKS_WORKFLOW,
             page_start=page,  ## specifies manually so we can exit sooner if requirements met
         )
         if len(raw_workflow_runs) == 0:
@@ -83,8 +196,8 @@ def run_all_workflows(actions: list[str], geosupport_version: str) -> bool:
     def on_click():
         for action in actions:
             github.dispatch_workflow(
-                "db-gru-qaqc",
-                "main.yml",
+                CHECKS_REPO,
+                CHECKS_WORKFLOW,
                 name=action,
                 geosupport_version=get_geosupport_versions()[geosupport_version],
             )
@@ -100,7 +213,7 @@ def get_geosupport_versions() -> dict[str, str]:
     ).json()["results"]
     images_by_code = {}
     for image in images:
-        if re.match("^\d+\.\d+\.\d+$", image["name"]):
+        if re.match(r"^\d+\.\d+\.\d+$", image["name"]):
             major, minor, _ = image["name"].split(".")
             code = f"{major}{chr(int(minor) + 96)}"
             if code not in images_by_code:

--- a/apps/qa/tests/test_gru.py
+++ b/apps/qa/tests/test_gru.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import pytest
+from pages.gru import helpers
+from pages.gru.constants import SourceDataset, source_datasets
+
+
+def _source(upstream_kind: str | None = "template") -> SourceDataset:
+    return SourceDataset(id="dcp_pad", refresh="", upstream_kind=upstream_kind)
+
+
+def test_matching_versions_are_up_to_date():
+    assert helpers.classify(_source(), "26c", "26c") == helpers.UP_TO_DATE
+
+
+def test_differing_versions_are_behind():
+    assert helpers.classify(_source(), "26b", "26c") == helpers.BEHIND
+
+
+@pytest.mark.parametrize(
+    "archived,upstream",
+    [
+        (ValueError("no config"), "26c"),
+        ("26b", ValueError("origin unreachable")),
+        # file_download templates have no connector that reports a version, so a source added
+        # without an explicit upstream_key resolves to None rather than raising.
+        ("26b", None),
+    ],
+)
+def test_an_unreadable_version_is_unknown_not_behind(archived, upstream):
+    """Sending someone to re-ingest over a failed fetch is worse than saying nothing."""
+    assert helpers.classify(_source(), archived, upstream) == helpers.UNKNOWN
+
+
+def test_a_source_with_no_archive_step_is_read_in_place():
+    """dcp_saf is read straight out of edm-publishing, so it can never be behind."""
+    assert helpers.classify(_source(upstream_kind=None), "26C", None) == (
+        helpers.READ_IN_PLACE
+    )
+
+
+def test_only_behind_rows_are_offered_an_ingest():
+    status = pd.DataFrame(
+        [
+            {"dataset": "a", "status": helpers.BEHIND},
+            {"dataset": "b", "status": helpers.UP_TO_DATE},
+            {"dataset": "c", "status": helpers.UNKNOWN},
+            {"dataset": "d", "status": helpers.READ_IN_PLACE},
+        ]
+    )
+    assert list(helpers.behind_sources(status)["dataset"]) == ["a"]
+
+
+def test_every_dataset_the_checks_read_has_a_source_entry():
+    """A check naming a source the registry doesn't know would silently drop it from the table."""
+    from pages.gru.constants import qa_checks
+
+    named = {source for sources in qa_checks["sources"] for source in sources}
+    assert named <= set(source_datasets)
+
+
+def test_bytes_sources_carry_an_explicit_key():
+    """Their templates fetch a raw versioned URL, so the bytes connector needs the key spelled out."""
+    for source in source_datasets.values():
+        if source.upstream_kind == "bytes":
+            assert source.upstream_key, source.id

--- a/apps/qa/tests/test_gru.py
+++ b/apps/qa/tests/test_gru.py
@@ -63,3 +63,13 @@ def test_bytes_sources_carry_an_explicit_key():
     for source in source_datasets.values():
         if source.upstream_kind == "bytes":
             assert source.upstream_key, source.id
+
+
+def test_public_url_is_unsigned(monkeypatch):
+    monkeypatch.setenv("AWS_S3_ENDPOINT", "https://nyc3.digitaloceanspaces.com/")
+    url = helpers.public_url("db-gru-qaqc/26c/housing/latest/versions.csv")
+    assert url == (
+        "https://nyc3.digitaloceanspaces.com/edm-publishing/"
+        "db-gru-qaqc/26c/housing/latest/versions.csv"
+    )
+    assert "?" not in url


### PR DESCRIPTION
## what

- refresh the "Source data" section of the GR page in the QA app
- add archived vs origin version checks for source data
- add buttons to run ingest for stale source data
- match check names to what GR calls their reports
- drop the signatures from output links so they stop expiring

## why

motivated by a recent round of running GR QA reports for Geosupport 26C

when GR (formerly GRU) uploads files to DO and then needs us to archive data and run the reports, we have to check which source data isn't up-to-date, go to the DE repo to individually run the ingest action, and then run the checks. it's easy to accidentally run the checks with old source data

the page also carried stale info: it linked workflows that no longer exist, said building footprints aren't batch-updated (they're on a weekly cron), and said developments needs no manual update (its publish workflow is archived)

## notes

unsigned output links depend on NYCPlanning/db-gru-qaqc#280, which is merged and makes future runs upload public-read objects. the 812 existing objects under `db-gru-qaqc/{version}/` were set public-read separately, and the older top-level prefixes were left private

7 of 8 check names already matched GR's list. their ninth report isn't a missing check: `saf-vs-pad` writes both the vs-PAD and vs-GRID files, so it stays one row

## screenshot of GRU page in local app run

<img width="1384" height="760" alt="Screenshot 2026-08-31 at 9 08 37 AM" src="https://github.com/user-attachments/assets/8e915a1d-0490-4aaf-950a-1f0bcd7929ce" />

