### PR TITLE
fix CSCL LDF

### DIFF
--- a/.github/workflows/cscl_build.yml
+++ b/.github/workflows/cscl_build.yml
@@ -64,13 +64,25 @@ jobs:
     - name: Dataloading
       run: dcpy lifecycle builds load load --recipe-path ${{ inputs.recipe_file }}.lock.yml --cache-schema recipe_cache --cached-entity-type view
 
+    - name: Load LDF inputs from the legacy pipeline
+      # The LDF diffs this release against the one before it, and its QA models compare
+      # the result against prod's own LDF. Neither is in edm-recipes, so both come from
+      # the legacy pipeline's outputs. Remove alongside the rest of production_outputs
+      # once the pipeline is operationalized.
+      run: |
+        python3 poc_validation/prod_data_loader.py load_previous_lion
+        python3 poc_validation/prod_data_loader.py load_previous_ldf_header
+        python3 poc_validation/prod_data_loader.py load_prod_ldf
+
     - name: Build
       run: |
         dbt deps
         dbt debug
 
+        ldf_vars="$(python3 scripts/ldf_vars.py)"
+
         echo "Run full dbt build"
-        dbt build --full-refresh
+        dbt build --full-refresh --vars "$ldf_vars"
 
     - name: Export
       run: dcpy lifecycle builds export export --recipe-path ${{ inputs.recipe_file }}.lock.yml

--- a/dcpy/test/utils/test_s3.py
+++ b/dcpy/test/utils/test_s3.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from dcpy.test.conftest import (
     PUBLISHING_BUCKET,
@@ -191,3 +192,45 @@ def test_copy_folder_across_regions(bucket_region, create_buckets, put_test_obje
         target_bucket=PUBLISHING_BUCKET,
     )
     assert s3.get_filenames(PUBLISHING_BUCKET, "") == set(TEST_OBJECTS[:2])
+
+
+MISSING_KEY = "no-such-folder/no-such-file"
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: s3.download_file(TEST_BUCKET, MISSING_KEY, Path("unused")),
+        lambda: s3.get_file(TEST_BUCKET, MISSING_KEY),
+        lambda: s3.get_file_as_stream(TEST_BUCKET, MISSING_KEY),
+        lambda: s3.get_file_as_text(TEST_BUCKET, MISSING_KEY),
+        lambda: s3.get_metadata(TEST_BUCKET, MISSING_KEY),
+        lambda: s3.get_custom_metadata(TEST_BUCKET, MISSING_KEY),
+    ],
+    ids=[
+        "download_file",
+        "get_file",
+        "get_file_as_stream",
+        "get_file_as_text",
+        "get_metadata",
+        "get_custom_metadata",
+    ],
+)
+def test_missing_object_names_itself(create_buckets, call):
+    """A missing object reports its bucket and key, not a bare botocore 404."""
+    with pytest.raises(FileNotFoundError, match=f"s3://{TEST_BUCKET}/{MISSING_KEY}"):
+        call()
+
+
+def test_object_exists_false_when_missing(create_buckets):
+    assert not s3.object_exists(TEST_BUCKET, MISSING_KEY)
+
+
+@patch("dcpy.utils.s3.client")
+def test_object_exists_raises_on_access_denied(mock_client):
+    """A permissions failure must not be reported as a missing object."""
+    mock_client.return_value.head_object.side_effect = ClientError(
+        {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadObject"
+    )
+    with pytest.raises(ClientError):
+        s3.object_exists(TEST_BUCKET, MISSING_KEY)

--- a/dcpy/utils/s3.py
+++ b/dcpy/utils/s3.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -133,13 +134,37 @@ def list_objects(bucket: str, prefix: str) -> list[dict]:
     return objects
 
 
+MISSING_OBJECT_CODES = {"404", "NoSuchKey"}
+
+
+@contextmanager
+def _named(bucket: str, key: str):
+    """
+    Report a missing object as FileNotFoundError naming it.
+
+    Botocore raises a bare 404 against whatever verb it happened to use, which never
+    says which object was missing and often points at an unrelated-looking call: a
+    download reports HeadObject, because the size lookup runs first.
+    """
+    try:
+        yield
+    except ClientError as e:
+        if e.response["Error"]["Code"] in MISSING_OBJECT_CODES:
+            raise FileNotFoundError(f"s3://{bucket}/{key}") from e
+        raise
+
+
 def object_exists(bucket: str, key: str) -> bool:
     """Returns true if an object with given bucket and key exists"""
     try:
         client().head_object(Bucket=bucket, Key=key)
         return True
-    except ClientError:
-        return False
+    except ClientError as e:
+        # Only a missing object answers this question. Anything else (403 on a bucket we
+        # can't read, expired credentials) would otherwise read as "not there".
+        if e.response["Error"]["Code"] in MISSING_OBJECT_CODES:
+            return False
+        raise
 
 
 def folder_exists(bucket: str, prefix: str) -> bool:
@@ -149,12 +174,14 @@ def folder_exists(bucket: str, prefix: str) -> bool:
 
 
 def get_custom_metadata(bucket: str, key: str) -> dict:
-    return client().head_object(Bucket=bucket, Key=key)["Metadata"]
+    with _named(bucket, key):
+        return client().head_object(Bucket=bucket, Key=key)["Metadata"]
 
 
 def get_metadata(bucket: str, key: str) -> Metadata:
     """Gets custom metadata as well as three standard s3 fields"""
-    response = client().head_object(Bucket=bucket, Key=key)
+    with _named(bucket, key):
+        response = client().head_object(Bucket=bucket, Key=key)
     return Metadata(
         last_modified=response["LastModified"],
         content_length=response["ContentLength"],
@@ -176,10 +203,11 @@ def get_file(
     key: str,
 ) -> StreamingBody:
     """Downloads a file from S3"""
-    obj = client().get_object(
-        Bucket=bucket,
-        Key=key,
-    )
+    with _named(bucket, key):
+        obj = client().get_object(
+            Bucket=bucket,
+            Key=key,
+        )
     return obj["Body"]
 
 
@@ -194,7 +222,7 @@ def download_file(
     else:
         path.parent.mkdir(parents=True, exist_ok=True)
         filepath = path
-    with _progress() as progress:
+    with _named(bucket, key), _progress() as progress:
         size = get_metadata(bucket, key).content_length
         task = progress.add_task(
             f"[green]Downloading [bold]{Path(key).name}[/bold]", total=size
@@ -502,13 +530,15 @@ def get_subfolders(bucket: str, prefix: str, index=1) -> list[str]:
 
 def get_file_as_stream(bucket: str, path: str) -> BytesIO:
     stream = BytesIO()
-    client().download_fileobj(Bucket=bucket, Key=path, Fileobj=stream)
+    with _named(bucket, path):
+        client().download_fileobj(Bucket=bucket, Key=path, Fileobj=stream)
     stream.seek(0)
     return stream
 
 
 def get_file_as_text(bucket: str, path: str) -> str:
-    resp = client().get_object(Bucket=bucket, Key=path).get("Body")
+    with _named(bucket, path):
+        resp = client().get_object(Bucket=bucket, Key=path).get("Body")
     if resp:
         return resp.read().decode()
     else:

--- a/products/cscl/README.md
+++ b/products/cscl/README.md
@@ -271,7 +271,12 @@ GR archives their own `LDF.dat` and `LDF.header` in `edm-private/cscl_etl/<versi
 this output has direct ground truth — unlike most others, no separate prod pull is needed.
 The build loads all three inputs itself: the prior release's LION and LDF header (both
 defaulting to `custom.ldf.previous_version`) and prod's own LDF for this release, which
-`qa__ldf_diffs` and `qa__ldf_summary` compare against. To load them by hand:
+`qa__ldf_diffs` and `qa__ldf_summary` compare against.
+
+Each load records what it wrote in `production_outputs.load_log` and is skipped when that
+table already holds the version being asked for, since the citywide LION load alone runs
+about eleven minutes. A release bump reloads on its own; pass `--force` to reload anyway.
+To load them by hand:
 
 ```bash
 python3 poc_validation/prod_data_loader.py load_previous_lion -p 26a

--- a/products/cscl/README.md
+++ b/products/cscl/README.md
@@ -35,7 +35,7 @@ Basically, for a new file output, you must
   - create a "dat" formatting csv in `./seeds/formatting`.
     - if this is not a "dat" file with formatting rules for fields, strict field lengths, etc, you might need to make a tweak to `./poc_validation/prod_data_loader.py`. Look at cases like "enders", "last_word" in both `recipe.yml` and how they're handled (based on file format, and formatting) in prod_data_loader.
   - add them as an export in `recipe.yml`. See others as examples. The custom formatting field should point to the formatting csv seed (and is not actually used by dcpy export utilities).
-  - load production data into `db-cscl.production_outputs` by running `python3 poc_validation/prod_data_loader.py -v {version} -d {dataset_name}`.
+  - load production data into `db-cscl.production_outputs` by running `python3 poc_validation/prod_data_loader.py load -v {version} -d {dataset_name}`. LION is the exception: its five borough files are loaded as one citywide table by `load_prod_lion`, which `load` doesn't do.
 - [transform](#write-the-actual-transformations)
   - add any new source layers to `recipe.yml` if needed.
   - add staging and int tables as needed to actually perform transformations as required by the etl docs.

--- a/products/cscl/README.md
+++ b/products/cscl/README.md
@@ -241,14 +241,42 @@ GR's tool takes this number as operator input; ours derives it from the previous
 header instead. That difference matters — see
 [data_issues.md → CSCL-LDF-03](./data_issues.md#cscl-ldf-03).
 
+### Release inputs
+
+Four header fields aren't in the source data: the two release IDs and the dates each was
+deployed. GR's tool prompts an operator for all four. We record them in `recipe.yml`:
+
+```yaml
+version: 26b
+custom:
+  ldf:
+    previous_version: 26a
+    old_release_date: 2026-02-09
+    new_release_date: 2026-04-22
+```
+
+`scripts/ldf_vars.py` turns that block into dbt vars, so any build including the LDF needs:
+
+```bash
+dbt build --vars "$(python3 scripts/ldf_vars.py)"
+```
+
+Without them `int__ldf_header` errors instead of emitting a header with wrong dates.
+`previous_version` also picks the LION release the node records diff against, so all four
+move together when the release changes.
+
 ### Validating
 
 GR archives their own `LDF.dat` and `LDF.header` in `edm-private/cscl_etl/<version>/`, so
 this output has direct ground truth — unlike most others, no separate prod pull is needed.
-Load the prior release's LION first, since the node records diff against it:
+The build loads all three inputs itself: the prior release's LION and LDF header (both
+defaulting to `custom.ldf.previous_version`) and prod's own LDF for this release, which
+`qa__ldf_diffs` and `qa__ldf_summary` compare against. To load them by hand:
 
 ```bash
 python3 poc_validation/prod_data_loader.py load_previous_lion -p 26a
+python3 poc_validation/prod_data_loader.py load_previous_ldf_header -p 26a
+python3 poc_validation/prod_data_loader.py load_prod_ldf -v 26b
 ```
 
 ## LION - Known data issues

--- a/products/cscl/dbt_project.yml
+++ b/products/cscl/dbt_project.yml
@@ -40,8 +40,10 @@ models:
         node_color: "#3e5c76"
 
 # LDF header fields. Nothing in the source data identifies a LION release or the date it
-# was deployed - GR's extract tool takes all four as operator input, and so do we. Pass
-# them per release, e.g. --vars '{ldf_new_release: 26B, ldf_new_release_date: 2026-04-22}'.
+# was deployed - GR's extract tool takes all four as operator input, and so do we. They're
+# recorded in recipe.yml and passed in with
+# `dbt build --vars "$(python3 scripts/ldf_vars.py)"`; the nulls below make a build that
+# omits them fail in int__ldf_header rather than emit a wrong header.
 vars:
   ldf_old_release: null
   ldf_old_release_date: null # ISO YYYY-MM-DD

--- a/products/cscl/poc_validation/exports.py
+++ b/products/cscl/poc_validation/exports.py
@@ -1,0 +1,29 @@
+"""
+Which of a build's exports have a production counterpart to diff against.
+
+Both validation paths need this rule: validate_outputs.sh compares a build's local
+output, run_validation.py compares one already published. Keeping the rule here stops
+the two from disagreeing about what gets compared.
+"""
+
+from pathlib import Path
+
+from dcpy.lifecycle.builds import plan
+
+COMPARE_FILE = "compare_file"
+
+
+def compares_to_prod(export) -> bool:
+    """Whether an export is diffed against the production file of the same name."""
+    return (export.custom or {}).get(COMPARE_FILE, True)
+
+
+def excluded_filenames(recipe_path: Path = Path("recipe.yml")) -> set[str]:
+    """Filenames of exports with no production counterpart to compare against."""
+    recipe = plan.recipe_from_yaml(recipe_path)
+    assert recipe.exports
+    return {
+        export.filename
+        for export in recipe.exports.datasets
+        if export.filename and not compares_to_prod(export)
+    }

--- a/products/cscl/poc_validation/prod_data_loader.py
+++ b/products/cscl/poc_validation/prod_data_loader.py
@@ -114,13 +114,72 @@ def load_datasets(datasets: list[str], folder: Path):
         CLIENT.insert_dataframe(dat_df, dataset.name)
 
 
-def load_citywide_lion(version: str, table_name: str, local_folder: Path):
+LOAD_LOG = "load_log"
+
+
+def _ensure_load_log() -> None:
+    CLIENT.execute_query(
+        f"""
+            CREATE TABLE IF NOT EXISTS {LOAD_LOG} (
+                table_name text PRIMARY KEY,
+                version text NOT NULL,
+                loaded_at timestamptz NOT NULL
+            );
+        """
+    )
+
+
+def already_loaded(table_name: str, version: str) -> bool:
+    """
+    Whether table_name already holds this version of the legacy pipeline's output.
+
+    These loads run into the minutes and every build asks for the same version, so
+    without this each one repeats the last one's work. Keyed on version rather than on
+    the table existing, so a release bump still reloads rather than leaving stale data
+    behind.
+
+    production_outputs is shared across builds, so skipping also keeps concurrent builds
+    from blocking each other while they rewrite it with identical data.
+    """
+    _ensure_load_log()
+    logged = CLIENT.execute_select_query(
+        f"SELECT version FROM {LOAD_LOG} WHERE table_name = :table_name",
+        table_name=table_name,
+    )
+    return not logged.empty and logged["version"].iloc[0] == version
+
+
+def record_load(table_name: str, version: str) -> None:
+    """
+    Written after the data lands, so an interrupted load repeats rather than being
+    skipped as though it finished.
+    """
+    _ensure_load_log()
+    CLIENT.execute_query(
+        f"""
+            INSERT INTO {LOAD_LOG} (table_name, version, loaded_at)
+            VALUES (:table_name, :version, now())
+            ON CONFLICT (table_name) DO UPDATE
+            SET version = excluded.version, loaded_at = excluded.loaded_at;
+        """,
+        table_name=table_name,
+        version=version,
+    )
+
+
+def load_citywide_lion(
+    version: str, table_name: str, local_folder: Path, force: bool = False
+):
     """
     Load one release's five borough LION .dat files as a single citywide table.
 
     The .dat files are parsed and concatenated here rather than unioned from the
     per-borough tables, so this works without `load` having run first.
     """
+    if not force and already_loaded(table_name, version):
+        print(f"{table_name} already holds LION {version}, skipping")
+        return
+
     lion_datasets = [
         d for d in datasets_by_name.values() if d.name.endswith("_lion_dat")
     ]
@@ -142,6 +201,7 @@ def load_citywide_lion(version: str, table_name: str, local_folder: Path):
     df = pd.concat(frames, ignore_index=True)
     print(f"loading {len(df)} rows from LION {version} to {CLIENT.schema}.{table_name}")
     CLIENT.insert_dataframe(df, table_name)
+    record_load(table_name, version)
 
 
 def create_citywide_table(file: str):
@@ -358,6 +418,7 @@ def _load_prod_lion(
     version: str | None = typer.Option(version, "--version", "-v"),
     local_folder: Path = typer.Option(LOAD_FOLDER, "--folder", "-f"),
     table_name: str = typer.Option("citywide_lion_dat", "--table", "-t"),
+    force: bool = typer.Option(False, "--force", "-F"),
 ):
     """
     Load this release's production LION into the build db, citywide.
@@ -367,7 +428,7 @@ def _load_prod_lion(
     if not version:
         raise Exception("Specify version with '-v'")
 
-    load_citywide_lion(version, table_name, local_folder)
+    load_citywide_lion(version, table_name, local_folder, force)
 
 
 @app.command("load_previous_lion")
@@ -377,6 +438,7 @@ def _load_previous_lion(
     ),
     local_folder: Path = typer.Option(LOAD_FOLDER, "--folder", "-f"),
     table_name: str = typer.Option("previous_citywide_lion_dat", "--table", "-t"),
+    force: bool = typer.Option(False, "--force", "-F"),
 ):
     """
     Load the *prior* release's production LION into the build db.
@@ -391,7 +453,7 @@ def _load_previous_lion(
             "If running in CI, this defaults to custom.ldf.previous_version in recipe.yml"
         )
 
-    load_citywide_lion(previous_version, table_name, local_folder)
+    load_citywide_lion(previous_version, table_name, local_folder, force)
 
 
 @app.command("load_previous_ldf_header")
@@ -401,6 +463,7 @@ def _load_previous_ldf_header(
     ),
     local_folder: Path = typer.Option(LOAD_FOLDER, "--folder", "-f"),
     table_name: str = typer.Option("previous_ldf_header", "--table", "-t"),
+    force: bool = typer.Option(False, "--force", "-F"),
 ):
     """
     Load the *prior* LDF edition's header record.
@@ -415,6 +478,10 @@ def _load_previous_ldf_header(
             "If running in CI, this defaults to custom.ldf.previous_version in recipe.yml"
         )
 
+    if not force and already_loaded(table_name, previous_version):
+        print(f"{table_name} already holds LDF {previous_version}, skipping")
+        return
+
     file_name = "LDF.header"
     local_path = local_folder / previous_version / file_name
     s3.download_file(
@@ -428,12 +495,14 @@ def _load_previous_ldf_header(
 
     print(f"loading LDF {previous_version} header to {CLIENT.schema}.{table_name}")
     CLIENT.insert_dataframe(df, table_name)
+    record_load(table_name, previous_version)
 
 
 @app.command("load_prod_ldf")
 def _load_prod_ldf(
     version: str | None = typer.Option(version, "--version", "-v"),
     local_folder: Path = typer.Option(LOAD_FOLDER, "--folder", "-f"),
+    force: bool = typer.Option(False, "--force", "-F"),
 ):
     """
     Load the production LDF for this release, for dev/prod comparison.
@@ -448,6 +517,10 @@ def _load_prod_ldf(
         ("LDF.dat", "ldf_base"),
         ("LDF.header", "ldf_header"),
     ]:
+        if not force and already_loaded(table_name, version):
+            print(f"{table_name} already holds LDF {version}, skipping")
+            continue
+
         local_path = local_folder / version / file_name
         s3.download_file("edm-private", f"cscl_etl/{version}/{file_name}", local_path)
         with open(local_path) as f:
@@ -460,6 +533,7 @@ def _load_prod_ldf(
             f"loading {len(df)} rows from {file_name} to {CLIENT.schema}.{table_name}"
         )
         CLIENT.insert_dataframe(df, table_name)
+        record_load(table_name, version)
 
 
 if __name__ == "__main__":

--- a/products/cscl/poc_validation/prod_data_loader.py
+++ b/products/cscl/poc_validation/prod_data_loader.py
@@ -111,6 +111,36 @@ def load_datasets(datasets: list[str], folder: Path):
         CLIENT.insert_dataframe(dat_df, dataset.name)
 
 
+def load_citywide_lion(version: str, table_name: str, local_folder: Path):
+    """
+    Load one release's five borough LION .dat files as a single citywide table.
+
+    The .dat files are parsed and concatenated here rather than unioned from the
+    per-borough tables, so this works without `load` having run first.
+    """
+    lion_datasets = [
+        d for d in datasets_by_name.values() if d.name.endswith("_lion_dat")
+    ]
+    assert len(lion_datasets) == 5, (
+        f"expected 5 borough LION exports in recipe.yml, found {len(lion_datasets)}"
+    )
+
+    frames = []
+    for dataset in lion_datasets:
+        local_path = local_folder / version / dataset.file_name
+        s3.download_file(
+            "edm-private",
+            f"cscl_etl/{version}/{dataset.file_name}",
+            local_path,
+        )
+        assert dataset.formatting_path, f"{dataset.name} has no formatting csv"
+        frames.append(parse_file(local_path, formatting_path=dataset.formatting_path))
+
+    df = pd.concat(frames, ignore_index=True)
+    print(f"loading {len(df)} rows from LION {version} to {CLIENT.schema}.{table_name}")
+    CLIENT.insert_dataframe(df, table_name)
+
+
 def create_citywide_table(file: str):
     CLIENT.execute_query(
         f"""
@@ -286,13 +316,11 @@ def _load(
 
     load_datasets(datasets, local_folder)
 
-    boro_level_files = {"lion", "face_code"}
-    assert False, (
-        "Hello, this is Alex from the past with a message for you. You NEED to fix the citywide table code for the flatfiles next time you load."
-    )
-    for file in boro_level_files:
-        if any(dataset.endswith(f"_{file}") for dataset in datasets):
-            create_citywide_table(file)
+    # Citywide LION is `load_prod_lion`, which parses the .dat files directly. A union of
+    # the per-borough tables written above can't build it: they're named for their recipe
+    # exports (bronx_lion_dat), not the bronx_lion that create_citywide_table expects.
+    if any(dataset.endswith("_face_code") for dataset in datasets):
+        create_citywide_table("face_code")
 
 
 @app.command("pull")
@@ -317,6 +345,23 @@ def _pull(
         )
 
 
+@app.command("load_prod_lion")
+def _load_prod_lion(
+    version: str | None = typer.Option(version, "--version", "-v"),
+    local_folder: Path = typer.Option(LOAD_FOLDER, "--folder", "-f"),
+    table_name: str = typer.Option("citywide_lion_dat", "--table", "-t"),
+):
+    """
+    Load this release's production LION into the build db, citywide.
+
+    The `qa__lion_dat_*` models compare our LION against this table.
+    """
+    if not version:
+        raise Exception("Specify version with '-v'")
+
+    load_citywide_lion(version, table_name, local_folder)
+
+
 @app.command("load_previous_lion")
 def _load_previous_lion(
     previous_version: str | None = typer.Option(
@@ -338,29 +383,7 @@ def _load_previous_lion(
             "If running in CI, this defaults to custom.ldf.previous_version in recipe.yml"
         )
 
-    lion_datasets = [
-        d for d in datasets_by_name.values() if d.name.endswith("_lion_dat")
-    ]
-    assert len(lion_datasets) == 5, (
-        f"expected 5 borough LION exports in recipe.yml, found {len(lion_datasets)}"
-    )
-
-    frames = []
-    for dataset in lion_datasets:
-        local_path = local_folder / previous_version / dataset.file_name
-        s3.download_file(
-            "edm-private",
-            f"cscl_etl/{previous_version}/{dataset.file_name}",
-            local_path,
-        )
-        assert dataset.formatting_path, f"{dataset.name} has no formatting csv"
-        frames.append(parse_file(local_path, formatting_path=dataset.formatting_path))
-
-    df = pd.concat(frames, ignore_index=True)
-    print(
-        f"loading {len(df)} rows from LION {previous_version} to {CLIENT.schema}.{table_name}"
-    )
-    CLIENT.insert_dataframe(df, table_name)
+    load_citywide_lion(previous_version, table_name, local_folder)
 
 
 @app.command("load_previous_ldf_header")

--- a/products/cscl/poc_validation/prod_data_loader.py
+++ b/products/cscl/poc_validation/prod_data_loader.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+import exports
 import pandas as pd
 import typer
 
@@ -35,6 +36,7 @@ class OutputDataset:
     file_name: str
     file_format: Literal["dat", "csv"]
     formatting_path: Path | None = None
+    compare_file: bool = True
 
 
 try:
@@ -60,6 +62,7 @@ try:
             file_name=export.filename,
             file_format=export.format.value,  # type: ignore
             formatting_path=f_path,
+            compare_file=exports.compares_to_prod(export),
         )
         datasets_by_filename[export.filename] = dataset
         datasets_by_name[export.name] = dataset
@@ -339,9 +342,14 @@ def _pull(
         )
 
     for dataset in datasets:
-        file_name = datasets_by_name[dataset].file_name
+        output = datasets_by_name[dataset]
+        if not output.compare_file:
+            print(f"skipping {output.file_name}: compare_file is off in recipe.yml")
+            continue
         s3.download_file(
-            "edm-private", f"cscl_etl/{version}/{file_name}", local_folder / file_name
+            "edm-private",
+            f"cscl_etl/{version}/{output.file_name}",
+            local_folder / output.file_name,
         )
 
 

--- a/products/cscl/poc_validation/prod_data_loader.py
+++ b/products/cscl/poc_validation/prod_data_loader.py
@@ -40,6 +40,7 @@ class OutputDataset:
 try:
     recipe = plan.recipe_from_yaml(Path("./recipe.yml"))
     version = recipe.version
+    previous_version = (recipe.custom or {}).get("ldf", {}).get("previous_version")
     assert recipe.exports
 
     for export in recipe.exports.datasets:
@@ -318,7 +319,9 @@ def _pull(
 
 @app.command("load_previous_lion")
 def _load_previous_lion(
-    previous_version: str = typer.Option(..., "--previous-version", "-p"),
+    previous_version: str | None = typer.Option(
+        previous_version, "--previous-version", "-p"
+    ),
     local_folder: Path = typer.Option(LOAD_FOLDER, "--folder", "-f"),
     table_name: str = typer.Option("previous_citywide_lion_dat", "--table", "-t"),
 ):
@@ -329,6 +332,12 @@ def _load_previous_lion(
     script - which loads the current release for dev/prod comparison - this pulls the
     release before it. Boroughs are concatenated because the LDF is citywide.
     """
+    if not previous_version:
+        raise Exception(
+            "Specify the previous release with '-p'. "
+            "If running in CI, this defaults to custom.ldf.previous_version in recipe.yml"
+        )
+
     lion_datasets = [
         d for d in datasets_by_name.values() if d.name.endswith("_lion_dat")
     ]
@@ -356,7 +365,9 @@ def _load_previous_lion(
 
 @app.command("load_previous_ldf_header")
 def _load_previous_ldf_header(
-    previous_version: str = typer.Option(..., "--previous-version", "-p"),
+    previous_version: str | None = typer.Option(
+        previous_version, "--previous-version", "-p"
+    ),
     local_folder: Path = typer.Option(LOAD_FOLDER, "--folder", "-f"),
     table_name: str = typer.Option("previous_ldf_header", "--table", "-t"),
 ):
@@ -367,6 +378,12 @@ def _load_previous_ldf_header(
     start where the last one stopped. The prior header carries both numbers we need:
     its own cumulative number and its record count.
     """
+    if not previous_version:
+        raise Exception(
+            "Specify the previous release with '-p'. "
+            "If running in CI, this defaults to custom.ldf.previous_version in recipe.yml"
+        )
+
     file_name = "LDF.header"
     local_path = local_folder / previous_version / file_name
     s3.download_file(

--- a/products/cscl/poc_validation/run_validation.py
+++ b/products/cscl/poc_validation/run_validation.py
@@ -14,6 +14,7 @@ The prod version is read from the build metadata by default; override with --pro
 import csv
 from pathlib import Path
 
+import exports
 import typer
 
 # TODO: publishing connector refactor - replace with: from dcpy.lifecycle.builds import builds
@@ -86,9 +87,14 @@ def run(
 
     # TODO: publishing connector refactor - replace with: builds.get_filenames(build_key.product, build_key.build)
     all_filenames = publishing.get_filenames(build_key)
+    excluded = exports.excluded_filenames()
     cscl_output_filenames = sorted(
-        f for f in all_filenames if "/" not in f and f not in BUILD_METADATA_FILES
+        f
+        for f in all_filenames
+        if "/" not in f and f not in BUILD_METADATA_FILES and f not in excluded
     )
+    for filename in sorted(excluded & all_filenames):
+        print(f"Skipping {filename}, no production file to compare against")
     print(f"\nValidating {len(cscl_output_filenames)} files...")
 
     VALIDATION_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/products/cscl/poc_validation/validate_outputs.sh
+++ b/products/cscl/poc_validation/validate_outputs.sh
@@ -2,10 +2,11 @@
 
 # Compares dev build output files against production files and writes per-file diff results.
 #
-# NOTE: This script is a legacy local tool. The primary method for generating diffs is
-# poc_validation/run_validation.py, which streams files from S3 without requiring local
-# copies and is used by both the nightly build and the QA app.
-# Use this script only if you have local copies of both output/ and .data/prod/ already.
+# NOTE: This is what the build runs (see cscl_build.yml), and the QA app reads the
+# validation_output/ files it writes. It needs local copies of both output/ and
+# .data/prod/, so it only works during or just after a build.
+# poc_validation/run_validation.py runs the same comparison against a build that has
+# already been published, streaming both sides from S3.
 #
 # For each file in output/, performs a line-level comparison against the matching file in
 # .data/prod/ and writes the mismatched (dev-only) rows to output/validation_output/<filename>.
@@ -27,6 +28,13 @@ for filepath in output/dataset_files/*; do
     if [[ "$file" =~ "zip" ]] || [[ -d "$filepath" ]]; then
         continue
     fi
+    # Outputs marked compare_file: false in recipe.yml are never pulled, so there is
+    # nothing to compare against. The LDF is one: see qa__ldf_summary instead.
+    if [ ! -f ".data/prod/$file" ]; then
+        echo "Skipping $file, no production file to compare against"
+        continue
+    fi
+
     echo "Validating $file"
 
     prod_row_count="$(cat .data/prod/$file | wc -l | awk '{print $1}')"

--- a/products/cscl/recipe.yml
+++ b/products/cscl/recipe.yml
@@ -334,13 +334,18 @@ exports:
     format: dat
     custom: { formatting: lion_dat }
 
-  # LDF - formatting is applied inside the models, since the record file mixes layouts
+  # LDF - formatting is applied inside the models, since the record file mixes layouts.
+  # compare_file is off because positions 91-100 carry a cumulative record number that
+  # diverges from prod's (data_issues.md CSCL-LDF-03), so a whole-line file diff reports
+  # every record after the first divergence. qa__ldf_summary compares positions 1-90.
   - name: ldf_base
     filename: LDFBASE.dat
     format: dat
+    custom: { compare_file: false }
   - name: ldf_header
     filename: LDFHEADER.dat
     format: dat
+    custom: { compare_file: false }
 
   # SAF
   - name: saf_abcegnpx_generic

--- a/products/cscl/recipe.yml
+++ b/products/cscl/recipe.yml
@@ -2,6 +2,20 @@ name: CSCL
 product: cscl
 version: 26b
 
+# The LDF documents the change between two LION releases. `previous_version` is the one
+# being diffed against, and the dates are when each release was deployed. Nothing in the
+# source data records either, so they're entered here and passed to dbt by
+# scripts/ldf_vars.py.
+#
+# These belong under `env`, not `custom`, once CSCL's dbt build moves into `stage_config`.
+# dcpy exports recipe `env` into the process it launches build commands in, so dbt would
+# read them with `env_var()` and scripts/ldf_vars.py would no longer be needed.
+custom:
+  ldf:
+    previous_version: 26a
+    old_release_date: 2026-02-09
+    new_release_date: 2026-04-22
+
 inputs:
   dataset_defaults:
     destination: postgres

--- a/products/cscl/scripts/ldf_vars.py
+++ b/products/cscl/scripts/ldf_vars.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Emit the LDF header's release vars as JSON, for dbt's --vars.
+
+The LDF header names the two LION releases the edition spans and the dates each was
+deployed. Nothing in the source data records them, so they live in recipe.yml under
+custom.ldf and are read from there rather than typed into the dbt command per release.
+
+Usage:
+    dbt build --vars "$(python3 scripts/ldf_vars.py)"
+
+This script is a stopgap. It exists because CSCL invokes `dbt build` as its own workflow
+step, so nothing carries recipe values into dbt's process. Products that declare their
+build under `stage_config` (green_fast_track, pluto, lift) have dcpy launch dbt, and dcpy
+exports recipe `env` into that process. When CSCL moves to `stage_config`, these four
+values move from `custom.ldf` to `env`, dbt_project.yml reads them with `env_var()`, and
+this script goes away.
+"""
+
+import json
+from pathlib import Path
+
+from dcpy.lifecycle.builds import plan
+
+REQUIRED = ["previous_version", "old_release_date", "new_release_date"]
+
+
+def ldf_vars(recipe_path: Path = Path("recipe.yml")) -> dict[str, str]:
+    recipe = plan.recipe_from_yaml(recipe_path)
+    assert recipe.version, f"{recipe_path} has no version"
+
+    ldf = (recipe.custom or {}).get("ldf", {})
+    missing = [key for key in REQUIRED if not ldf.get(key)]
+    assert not missing, f"{recipe_path} custom.ldf is missing {', '.join(missing)}"
+
+    return {
+        # The LDF writes releases uppercase ('26B'); recipe versions are lowercase.
+        "ldf_old_release": str(ldf["previous_version"]).upper(),
+        "ldf_old_release_date": str(ldf["old_release_date"]),
+        "ldf_new_release": recipe.version.upper(),
+        "ldf_new_release_date": str(ldf["new_release_date"]),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(ldf_vars()))


### PR DESCRIPTION
related to https://github.com/NYCPlanning/data-engineering/issues/2522
[all builds on this branch](https://github.com/NYCPlanning/data-engineering/actions/workflows/build.yml?query=branch%3Adm-cscl-ldf)

- **LDF header release IDs and dates come from `recipe.yml`.** All four were unset, so `int__ldf_header` raised at compile time. Output now matches prod's published 26b header exactly: `26A / 02092026 / 26B / 04222026`.
- **The build loads its own LDF inputs.** Previous-release LION, the previous LDF header, and prod's LDF were only ever loaded by hand into the shared `production_outputs` schema, so nothing kept them there.
- **Those loads are skipped when they would rewrite what's already there.** `production_outputs.load_log` records the version each table holds, cutting about 11 minutes from every build after the first. a release bump reloads on its own, and `--force` overrides.
- **Citywide prod LION can be loaded again.** `load` has aborted on a deliberate `assert False` since July: the citywide union reads `bronx_lion`, but the tables are named `bronx_lion_dat`. Nine QA models source the table it builds.
- **The LDF is excluded from output file validation.** Positions 91-100 carry a cumulative record number that diverges from prod's (CSCL-LDF-03), so a whole-line diff flags every record after the first divergence. `qa__ldf_summary` already compares positions 1-90. Both validation paths read the exclusion from `recipe.yml`, so they can't disagree about what gets compared.
- **A missing S3 object reports `s3://bucket/key`** instead of `ClientError: 404 HeadObject`. `object_exists` no longer reports a 403 as "not found". Eight tests added.

