### PR TITLE
fix PLUTO and DevDB

### DIFF
--- a/dcpy/lifecycle/data_loader.py
+++ b/dcpy/lifecycle/data_loader.py
@@ -76,13 +76,27 @@ def _sanitize_columns(df: pd.DataFrame) -> pd.DataFrame:
     )
 
 
+# The loader owns these two columns: it appends ogc_fid as the surrogate primary key
+# and data_library_version as the version loaded. A product that re-imports its own
+# published output (see the edm.publishing.published sources in products/*/recipe.yml)
+# gets them back as data, and re-adding them then fails on a duplicate column. Drop
+# them on the way in so the loader's own values are the ones that land.
+LOADER_OWNED_COLUMNS = ["ogc_fid", "data_library_version"]
+
+
+def _drop_loader_owned_columns(df: pd.DataFrame) -> pd.DataFrame:
+    return df.drop(columns=LOADER_OWNED_COLUMNS, errors="ignore")
+
+
 def _load_df(
     df: pd.DataFrame,
     ds_table_name: str,
     pg_client: postgres.PostgresClient,
     include_ogc_fid_col: bool = True,
 ):
-    pg_client.insert_dataframe(_sanitize_columns(df), ds_table_name)
+    pg_client.insert_dataframe(
+        _drop_loader_owned_columns(_sanitize_columns(df)), ds_table_name
+    )
 
     if include_ogc_fid_col:
         # This maybe should be applicable to pg_dumps, but they tend to have this column already
@@ -104,7 +118,7 @@ def _load_parquet_chunked(
         geoparquet.iter_batches_df(local_dataset_path, PARQUET_LOAD_BATCH_SIZE)
     ):
         pg_client.insert_dataframe(
-            _sanitize_columns(batch),
+            _drop_loader_owned_columns(_sanitize_columns(batch)),
             ds_table_name,
             if_exists="replace" if i == 0 else "append",
         )

--- a/dcpy/test/lifecycle/test_data_loader.py
+++ b/dcpy/test/lifecycle/test_data_loader.py
@@ -45,3 +45,20 @@ def test_load_parquet_chunked_skips_pk_when_not_requested(monkeypatch):
         )
 
     pg_client.add_pk.assert_not_called()
+
+
+def test_load_df_drops_loader_owned_columns():
+    pg_client = MagicMock()
+    df = pd.DataFrame(
+        {
+            "ogc_fid": [1, 2],
+            "version": ["25Q4", "26Q2"],
+            "data_library_version": ["20240101", "20240101"],
+        }
+    )
+
+    data_loader._load_df(df, "my_table", pg_client)
+
+    inserted = pg_client.insert_dataframe.call_args.args[0]
+    assert list(inserted.columns) == ["version"]
+    pg_client.add_pk.assert_called_once_with("my_table", "ogc_fid")

--- a/products/developments/bash/05_export.sh
+++ b/products/developments/bash/05_export.sh
@@ -28,7 +28,9 @@ mkdir -p output
     csv_export FINAL_qaqc &
     csv_export HNY_no_match & 
     csv_export qaqc_app &
-    csv_export qaqc_historic
+    # qaqc_historic is re-imported from the published output on the next build,
+    # so it must not carry the loader's own ogc_fid / data_library_version columns.
+    csv_export_drop_columns qaqc_historic "'ogc_fid', 'data_library_version'"
     pg_dump -d $BUILD_ENGINE -t qaqc_historic -f qaqc_historic.sql
     csv_export qaqc_field_distribution &
     csv_export qaqc_quarter_check &

--- a/products/pluto/pluto_build/sql/create_rpad_geo.sql
+++ b/products/pluto/pluto_build/sql/create_rpad_geo.sql
@@ -7,7 +7,11 @@ UPDATE stg__pluto_input_geocodes
 SET
     xcoord = ST_X(ST_TRANSFORM(geom, 2263))::integer,
     ycoord = ST_Y(ST_TRANSFORM(geom, 2263))::integer,
-    ct2010 = (CASE WHEN ct2010::numeric = 0 THEN NULL ELSE ct2010 END);
+    ct2010 = (CASE WHEN ct2010::numeric = 0 THEN NULL ELSE ct2010 END),
+    -- Geosupport occasionally returns a non-numeric placeholder here, which would
+    -- otherwise reach the numeric cast in export.sql. Null lets the zip code
+    -- boundary spatial join fill the value instead.
+    zipcode = (CASE WHEN zipcode ~ '^[0-9]{5}$' THEN zipcode END);
 
 DROP TABLE IF EXISTS pluto_rpad_geo;
 CREATE TABLE pluto_rpad_geo AS (


### PR DESCRIPTION
related to https://github.com/NYCPlanning/data-engineering/issues/2522

fixes PLUTO and DevDB. the DevDB fix involves a dcpy change but this is simpler than a DevDB-specific recipe preprocessor, modifying a published 26Q2 csv in S3, or changing how primary keys are generated