### PR TITLE
Filter out LPC landmarks with no geometry, add data-quality guardrail

### DIFF
--- a/products/green_fast_track/macros/test_percent_not_null.sql
+++ b/products/green_fast_track/macros/test_percent_not_null.sql
@@ -1,0 +1,20 @@
+-- fails if more than `threshold` fraction of column_name's rows are null (0.01 = 1%)
+
+{% test percent_not_null(model, column_name, threshold) %}
+
+WITH validation AS (
+    SELECT
+        CASE WHEN {{ column_name }} IS NULL THEN 1 ELSE 0 END AS is_null
+    FROM {{ model }}
+),
+
+summary AS (
+    SELECT AVG(is_null) AS null_fraction
+    FROM validation
+)
+
+SELECT *
+FROM summary
+WHERE null_fraction > {{ threshold }}
+
+{% endtest %}

--- a/products/green_fast_track/models/_sources.yml
+++ b/products/green_fast_track/models/_sources.yml
@@ -141,6 +141,14 @@ sources:
     - name: most_curre
     - name: status
     - name: wkb_geometry
+      tests:
+      # ~0.4% of records (historic districts, interior landmarks, and multi-site
+      # designations) have no geometry in the source archive -- stg__lpc_landmarks filters
+      # these out. This guards against that share growing unexpectedly.
+      - percent_not_null:
+          name: lpc_landmarks_wkb_geometry_mostly_not_null
+          arguments:
+            threshold: 0.01
 
   - name: lpc_scenic_landmarks
     columns:

--- a/products/green_fast_track/models/staging/stg__lpc_landmarks.sql
+++ b/products/green_fast_track/models/staging/stg__lpc_landmarks.sql
@@ -1,5 +1,9 @@
 WITH lpc_landmarks AS (
+    -- ~0.4% of records (mostly historic districts, interior landmarks, and multi-site
+    -- designations) have no geometry in the source archive -- see the
+    -- lpc_landmarks_wkb_geometry_mostly_not_null test on models/_sources.yml
     SELECT * FROM {{ source('recipe_sources', 'lpc_landmarks') }}
+    WHERE wkb_geometry IS NOT NULL
 ),
 
 all_landmarks AS (


### PR DESCRIPTION
~0.4% of lpc_landmarks records (historic districts, interior landmarks, and multi-site designations) have no geometry in the source archive. This was failing not_null tests on int_spatial__all downstream (historic_resources, historic_resources_adj, shadow_hist_resources), showing up as a nightly build failure. Filter these out in staging, and add a percent_not_null guardrail test so a bigger jump in the null share doesn't go unnoticed.