### PR TITLE
stabilize ArcGIS ingest output

### DIFF
--- a/.github/workflows/ingest_single.yml
+++ b/.github/workflows/ingest_single.yml
@@ -32,6 +32,11 @@ on:
         description: "dev bucket to use in place of recipes. If name of bucket is 'de-dev-a' simply put 'a'"
         type: string
         required: false
+      overwrite:
+        description: "Overwrite the archived version if it already exists (requires version)"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   dataloading:
@@ -90,4 +95,5 @@ jobs:
           latest: ${{ github.event.inputs.latest == 'true' && '--latest' || '' }}
           version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || '' }}
           mode: ${{ github.event.inputs.mode && format('--mode {0}', github.event.inputs.mode) || '' }}
-        run: python3 -m dcpy lifecycle scripts ingest_or_library_archive ${{ inputs.dataset }} $latest $version $mode --push-to-s3
+          overwrite: ${{ github.event.inputs.overwrite == 'true' && '--overwrite' || '' }}
+        run: python3 -m dcpy lifecycle scripts ingest_or_library_archive ${{ inputs.dataset }} $latest $version $mode $overwrite --push-to-s3

--- a/dcpy/connectors/esri/arcgis_feature_service.py
+++ b/dcpy/connectors/esri/arcgis_feature_service.py
@@ -158,7 +158,13 @@ def get_layer(layer: FeatureServerLayer, crs: int, chunk_size=100) -> dict:
     obj_params = params.copy()
     obj_params["returnIdsOnly"] = True
     object_id_resp = query_layer(layer, obj_params)
-    object_ids = cast(list[int], object_id_resp["properties"]["objectIds"])
+    # The server returns ids in arbitrary order, and returns features within a chunk in
+    # arbitrary order too. Sorting both keeps the output stable run-to-run, so a diff
+    # against a previously archived version reflects real edits rather than reshuffling.
+    object_ids = sorted(cast(list[int], object_id_resp["properties"]["objectIds"]))
+    object_id_field = cast(
+        str, object_id_resp["properties"]["objectIdFieldName"]
+    ).lower()
 
     features = []
 
@@ -182,7 +188,10 @@ def get_layer(layer: FeatureServerLayer, crs: int, chunk_size=100) -> dict:
             params["objectIds"] = object_ids[i : i + chunk_size]
             chunk = query_layer(layer, params)
             progress.update(task, completed=i + chunk_size)
-            features += [_downcase_properties_keys(feat) for feat in chunk["features"]]
+            features += sorted(
+                (_downcase_properties_keys(feat) for feat in chunk["features"]),
+                key=lambda feat: feat["properties"][object_id_field],
+            )
 
     return {"type": "FeatureCollection", "crs": crs, "features": features}
 

--- a/dcpy/data/compare.py
+++ b/dcpy/data/compare.py
@@ -1,8 +1,85 @@
+import geopandas as gpd
+import numpy as np
 import pandas as pd
+import shapely
 
 from dcpy.data import models as comparison
 from dcpy.utils import postgres
 from dcpy.utils.logging import logger
+
+GEOMETRY_RTOL = 1e-12
+"""Relative tolerance for comparing coordinates.
+
+Roughly four orders of magnitude above float64 precision, and relative rather than
+absolute so the threshold stays meaningful whether the CRS is in feet or degrees.
+In EPSG:2263 it works out to about 1e-6 feet.
+"""
+
+
+def geometries_match(
+    left: gpd.GeoSeries, right: gpd.GeoSeries, *, rtol: float = GEOMETRY_RTOL
+) -> bool:
+    """
+    Whether two geometry series are equal, allowing coordinates to differ by `rtol`.
+
+    Structure must match exactly - null placement, geometry type, dimensionality, and
+    vertex count and order - so only last-bit float differences are absorbed. Sources
+    that reproject server-side (ArcGIS feature servers) are not bit-stable between
+    requests, and without a tolerance an unchanged layer reads as edited.
+    """
+    if len(left) != len(right):
+        return False
+
+    left_geoms, right_geoms = left.to_numpy(), right.to_numpy()
+    # A type id doesn't carry dimensionality: POINT and POINT Z are both 0, and each
+    # counts as one coordinate. Without has_z, a Z-only edit reads as unchanged.
+    for describe in (shapely.get_type_id, shapely.has_z, shapely.get_num_coordinates):
+        if not np.array_equal(describe(left_geoms), describe(right_geoms)):
+            return False
+
+    return bool(
+        np.allclose(
+            shapely.get_coordinates(left_geoms, include_z=True),
+            shapely.get_coordinates(right_geoms, include_z=True),
+            rtol=rtol,
+            atol=0.0,
+            # 2D geometries pad z with NaN, and has_z already matched
+            equal_nan=True,
+        )
+    )
+
+
+def dataframes_match(
+    left: pd.DataFrame, right: pd.DataFrame, *, rtol: float = GEOMETRY_RTOL
+) -> bool:
+    """
+    Whether two dataframes hold the same data, with `rtol` applied to geometry columns.
+
+    Non-geometry columns must be exactly equal.
+    """
+    if left.equals(right):
+        return True
+    if list(left.columns) != list(right.columns) or len(left) != len(right):
+        return False
+
+    def is_geometry(series: pd.Series) -> bool:
+        return isinstance(series.dtype, gpd.array.GeometryDtype)
+
+    geom_columns = [c for c in left.columns if is_geometry(left[c])]
+    if not geom_columns:
+        return False
+    # Same column names don't guarantee the same types. read_df hands back a plain
+    # DataFrame for parquet written without geo metadata.
+    if not all(is_geometry(right[c]) for c in geom_columns):
+        return False
+
+    left = left.reset_index(drop=True)
+    right = right.reset_index(drop=True)
+    other_columns = [c for c in left.columns if c not in geom_columns]
+    if not left[other_columns].equals(right[other_columns]):
+        return False
+
+    return all(geometries_match(left[c], right[c], rtol=rtol) for c in geom_columns)
 
 
 def compare_df_columns(left: pd.DataFrame, right: pd.DataFrame):

--- a/dcpy/lifecycle/ingest/validate.py
+++ b/dcpy/lifecycle/ingest/validate.py
@@ -5,6 +5,7 @@ import geopandas as gpd
 import pandas as pd
 from pydantic import ValidationError
 
+from dcpy.data import compare
 from dcpy.lifecycle.ingest import connectors, plan, transform
 from dcpy.lifecycle.ingest.models import (
     ProcessingStep,
@@ -183,7 +184,7 @@ def validate_data_against_existing_version(
             ]
             new = parquet.read_df(filepath)
             existing = parquet.read_df(existing_file)
-            if new.equals(existing):
+            if compare.dataframes_match(new, existing):
                 logger.info(
                     f"Dataset id='{ds}' version='{version}' already exists and matches newly processed data"
                 )

--- a/dcpy/lifecycle/scripts/ingest_or_library_archive.py
+++ b/dcpy/lifecycle/scripts/ingest_or_library_archive.py
@@ -20,9 +20,22 @@ def run(
     csv: bool = typer.Option(
         False, "-c", "--csv", help="Output csv locally as well as parquet"
     ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Overwrite the archived version instead of failing. Requires --version",
+    ),
 ):
     if INGEST_DEF_DIR is None:
         raise KeyError("Missing required env variable: 'TEMPLATE_DIR'")
+
+    # This entrypoint takes any dataset, and the recipes bucket isn't versioned, so
+    # naming the version is what keeps an overwrite from quietly eating whichever one
+    # happened to be derived.
+    if overwrite and not version:
+        raise ValueError(
+            "--overwrite requires an explicit --version, so replacing archived data is deliberate."
+        )
 
     if (INGEST_DEF_DIR / f"{dataset_id}.yml").exists():
         ingest(
@@ -32,8 +45,13 @@ def run(
             latest=latest,
             push=push_to_s3,
             output_csv=csv,
+            overwrite_okay=overwrite,
         )
     else:
+        if overwrite:
+            raise ValueError(
+                f"'{dataset_id}' is archived by dcpy.library, which has no overwrite option."
+            )
         from dcpy.library import cli as library_cli
 
         library_cli.archive(

--- a/dcpy/test/connectors/test_esri.py
+++ b/dcpy/test/connectors/test_esri.py
@@ -101,13 +101,16 @@ class TestResolveLayer(TestCase):
 
 
 def mock_query_layer(url: str, data: dict):
+    # ids and features come back from the server in arbitrary order
     features = [
-        {"objectId": 1, "properties": {"Property": "value"}},
-        {"objectId": 2, "properties": {"Property": "value"}},
-        {"objectId": 3, "properties": {"Property": "value"}},
+        {"objectId": 3, "properties": {"OBJECTID": 3, "Property": "value"}},
+        {"objectId": 1, "properties": {"OBJECTID": 1, "Property": "value"}},
+        {"objectId": 2, "properties": {"OBJECTID": 2, "Property": "value"}},
     ]
     if data.get("returnIdsOnly"):
-        resp: dict = {"properties": {"objectIds": [1, 2, 3]}}
+        resp: dict = {
+            "properties": {"objectIdFieldName": "OBJECTID", "objectIds": [3, 1, 2]}
+        }
     else:
         if data.get("objectIds"):
             query_features = [f for f in features if f["objectId"] in data["objectIds"]]
@@ -143,6 +146,13 @@ class TestGetLayer:
 
         # one call to get ids, three calls to get data
         assert post.call_count == 4
+
+    def test_get_layer_sorts_features_by_object_id(self, post: MagicMock):
+        for chunk_size in (1, 2, 100):
+            features = arcfs.get_layer(MULTIPLE_LAYER, crs=1, chunk_size=chunk_size)[
+                "features"
+            ]
+            assert [f["properties"]["objectid"] for f in features] == [1, 2, 3]
 
 
 @patch("requests.get", side_effect=mock_request_get)

--- a/dcpy/test/data/test_compare.py
+++ b/dcpy/test/data/test_compare.py
@@ -1,4 +1,6 @@
+import geopandas as gpd
 import pandas as pd
+import shapely
 
 from dcpy.data import compare
 from dcpy.data import models as comparison
@@ -158,3 +160,112 @@ class TestDataFrame:
 
         report = compare.get_df_keyed_report(self.basic, self.different_keys, keys)
         assert report == expected
+
+
+class TestGeometryTolerance:
+    """Coordinates should absorb float noise but nothing structural."""
+
+    # State Plane-ish magnitudes, where GEOMETRY_RTOL works out to ~1e-6 feet
+    square = shapely.Polygon([(1e6, 2e5), (1e6 + 10, 2e5), (1e6 + 10, 2e5 + 10)])
+    nudged = shapely.Polygon([(1e6 + 1e-7, 2e5), (1e6 + 10, 2e5), (1e6 + 10, 2e5 + 10)])
+    moved = shapely.Polygon([(1e6 + 1, 2e5), (1e6 + 10, 2e5), (1e6 + 10, 2e5 + 10)])
+    extra_vertex = shapely.Polygon(
+        [(1e6, 2e5), (1e6 + 5, 2e5), (1e6 + 10, 2e5), (1e6 + 10, 2e5 + 10)]
+    )
+
+    def _series(self, *geoms):
+        return gpd.GeoSeries(list(geoms))
+
+    def test_identical(self):
+        assert compare.geometries_match(
+            self._series(self.square), self._series(self.square)
+        )
+
+    def test_float_noise_tolerated(self):
+        assert compare.geometries_match(
+            self._series(self.square), self._series(self.nudged)
+        )
+
+    def test_real_move_caught(self):
+        assert not compare.geometries_match(
+            self._series(self.square), self._series(self.moved)
+        )
+
+    def test_added_vertex_caught(self):
+        assert not compare.geometries_match(
+            self._series(self.square), self._series(self.extra_vertex)
+        )
+
+    def test_null_placement_caught(self):
+        assert not compare.geometries_match(
+            self._series(self.square, None), self._series(None, self.square)
+        )
+
+    def test_geometry_type_caught(self):
+        assert not compare.geometries_match(
+            self._series(self.square), self._series(self.square.centroid)
+        )
+
+    def test_row_order_caught(self):
+        assert not compare.geometries_match(
+            self._series(self.square, self.moved), self._series(self.moved, self.square)
+        )
+
+    def test_two_dimensional_still_matches(self):
+        """z is padded with NaN, which must not read as a difference."""
+        assert compare.geometries_match(
+            self._series(shapely.Point(1e6, 2e5)), self._series(shapely.Point(1e6, 2e5))
+        )
+
+    def test_z_change_caught(self):
+        assert not compare.geometries_match(
+            self._series(shapely.Point(1e6, 2e5, 10)),
+            self._series(shapely.Point(1e6, 2e5, 9999)),
+        )
+
+    def test_flattening_to_two_dimensions_caught(self):
+        assert not compare.geometries_match(
+            self._series(shapely.Point(1e6, 2e5, 10)),
+            self._series(shapely.Point(1e6, 2e5)),
+        )
+
+    def test_z_float_noise_tolerated(self):
+        assert compare.geometries_match(
+            self._series(shapely.Point(1e6, 2e5, 1e5)),
+            self._series(shapely.Point(1e6, 2e5, 1e5 + 1e-8)),
+        )
+
+
+class TestDataFramesMatch:
+    square = TestGeometryTolerance.square
+    nudged = TestGeometryTolerance.nudged
+    moved = TestGeometryTolerance.moved
+
+    def _frame(self, geom, name="a"):
+        return gpd.GeoDataFrame({"name": [name], "geom": [geom]}, geometry="geom")
+
+    def test_float_noise_tolerated(self):
+        assert compare.dataframes_match(
+            self._frame(self.square), self._frame(self.nudged)
+        )
+
+    def test_real_move_caught(self):
+        assert not compare.dataframes_match(
+            self._frame(self.square), self._frame(self.moved)
+        )
+
+    def test_attribute_change_caught(self):
+        """Tolerance applies to geometry only - other columns stay exact."""
+        assert not compare.dataframes_match(
+            self._frame(self.square), self._frame(self.nudged, name="b")
+        )
+
+    def test_geometry_column_against_plain_column(self):
+        """Matching column names don't imply matching types."""
+        plain = pd.DataFrame({"name": ["a"], "geom": ["POINT (1 2)"]})
+        assert not compare.dataframes_match(self._frame(self.square), plain)
+
+    def test_non_geospatial_falls_back_to_exact(self):
+        left = pd.DataFrame({"a": [1.0]})
+        assert compare.dataframes_match(left, pd.DataFrame({"a": [1.0]}))
+        assert not compare.dataframes_match(left, pd.DataFrame({"a": [1.0 + 1e-15]}))

--- a/ingest_templates/usnps_parks.yml
+++ b/ingest_templates/usnps_parks.yml
@@ -32,7 +32,7 @@ ingestion:
     type: arcgis_feature_server
     server: nps
     dataset: NPS_Land_Resources_Division_Boundary_and_Tract_Data_Service
-    layer_name: nps_boundary
+    layer_name: NPS Boundary
   file_format:
     type: geojson
   processing_steps:


### PR DESCRIPTION
resolves #2528
[ingest runs on this branch](https://github.com/NYCPlanning/data-engineering/actions/workflows/ingest_single.yml?query=branch%3Adm-arcgis-fixes)

- **ArcGIS features archive in a stable order.** The server returns object ids and features unordered, so unchanged layers looked edited every week.
- **Geometry comparison takes a relative tolerance.** Server-side reprojection isn't bit-stable. Structure (type, vertex count, vertex order, null placement) still has to match exactly.
- **`usnps_parks` points at the renamed `NPS Boundary` layer.**
- **`ingest_single.yml` gets an overwrite option**, which requires an explicit version so replacing archived data is deliberate.

## Notes

None of the three failing datasets had real data changes. All match their archived versions once sorted, and only `nysdec_tidal_wetlands` needs the tolerance. On that data a single vertex moved 1e-5 ft is still caught.

The archives predate sorted order, so they need a one-time re-archive with the overwrite option before this merges.
