### PR TITLE
zap improvements

### DIFF
--- a/.github/workflows/zap_export.yml
+++ b/.github/workflows/zap_export.yml
@@ -78,9 +78,11 @@ jobs:
       #     service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}
       #     export_default_credentials: true
 
+      # --tb=short because the default traceback prints each frame's arguments, and
+      # get_metadata's argument is the request headers, bearer token included.
       - name: Check recode fields still exist in CRM
         if: ${{ matrix.open }}
-        run: python3 -m pytest tests/test_visible_projects.py -v
+        run: python3 -m pytest tests/test_visible_projects.py -v --tb=short
 
       - name: Get ${{ matrix.entity }}
         run: python3 -m src.runner ${{ matrix.entity }} $EDM_DATA_ZAP_SCHEMA

--- a/.github/workflows/zap_single_visible.yml
+++ b/.github/workflows/zap_single_visible.yml
@@ -60,8 +60,9 @@ jobs:
           echo "version=$DATE" >> "$GITHUB_OUTPUT"
 
       # Both datasets this workflow offers are open, so no matrix.open gate here.
+      # --tb=short keeps the bearer token out of the log; see zap_export.yml.
       - name: Check recode fields still exist in CRM
-        run: python3 -m pytest tests/test_visible_projects.py -v
+        run: python3 -m pytest tests/test_visible_projects.py -v --tb=short
 
       - name: Get ${{ github.event.inputs.dataset }}
         run: python3 -m src.runner ${{ github.event.inputs.dataset }} $EDM_DATA_ZAP_SCHEMA

--- a/.github/workflows/zap_single_visible.yml
+++ b/.github/workflows/zap_single_visible.yml
@@ -59,6 +59,10 @@ jobs:
           DATE=$(date +%Y%m%d)
           echo "version=$DATE" >> "$GITHUB_OUTPUT"
 
+      # Both datasets this workflow offers are open, so no matrix.open gate here.
+      - name: Check recode fields still exist in CRM
+        run: python3 -m pytest tests/test_visible_projects.py -v
+
       - name: Get ${{ github.event.inputs.dataset }}
         run: python3 -m src.runner ${{ github.event.inputs.dataset }} $EDM_DATA_ZAP_SCHEMA
 

--- a/products/zap-opendata/src/client.py
+++ b/products/zap-opendata/src/client.py
@@ -21,10 +21,12 @@ class Client:
     @cached_property
     def access_token(self) -> str:
         result = self.app.acquire_token_for_client(scopes=self.config["scope"])
-        if list(result.keys()) == ["error"]:
+        # msal returns `error` alongside error_description, error_codes and friends,
+        # so an exact key-list match never fires on a real failure.
+        if "error" in result:
             raise PermissionError(result)
         return result["access_token"]
 
     @cached_property
-    def request_header(self) -> str:
+    def request_header(self) -> dict:
         return {"Authorization": "Bearer " + self.access_token}

--- a/products/zap-opendata/src/visible_projects.py
+++ b/products/zap-opendata/src/visible_projects.py
@@ -263,5 +263,12 @@ def get_metadata(headers) -> list:
     metadata_values = []
     for link in [PICKLIST_METADATA_LINK, STATUS_METADATA_LINK]:
         res = requests.get(link, headers=headers)
+        if res.status_code != 200:
+            # Status, url and body only. `headers` holds the bearer token, which CI
+            # does not mask: it's derived from the 1Password secrets, not one of them.
+            raise RuntimeError(
+                f"CRM metadata request failed with {res.status_code} for {link}\n"
+                f"{res.text[:500]}"
+            )
         metadata_values.extend(res.json()["value"])
     return metadata_values

--- a/products/zap-opendata/src/visible_projects.py
+++ b/products/zap-opendata/src/visible_projects.py
@@ -4,11 +4,16 @@ import pandas as pd
 import requests
 from sqlalchemy import text
 
+from . import ZAP_DOMAIN
+
 OPEN_DATA = ["dcp_projects", "dcp_projectbbls"]
 
 
-PICKLIST_METADATA_LINK = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$select=LogicalName&$expand=OptionSet"
-STATUS_METADATA_LINK = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.StatusAttributeMetadata?$select=LogicalName&$expand=OptionSet"
+# Built from ZAP_DOMAIN so the metadata host can't drift from the host the bearer
+# token is scoped to. They were the same literal, but nothing kept them that way.
+_ENTITY_DEFINITIONS = f"{ZAP_DOMAIN}/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes"
+PICKLIST_METADATA_LINK = f"{_ENTITY_DEFINITIONS}/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$select=LogicalName&$expand=OptionSet"
+STATUS_METADATA_LINK = f"{_ENTITY_DEFINITIONS}/Microsoft.Dynamics.CRM.StatusAttributeMetadata?$select=LogicalName&$expand=OptionSet"
 RECODE_FIELDS = {
     "dcp_projects": [
         ("dcp_visibility", "dcp_visibility"),

--- a/products/zap-opendata/tests/test_client.py
+++ b/products/zap-opendata/tests/test_client.py
@@ -31,8 +31,26 @@ def test_request_header_carries_the_bearer_token(monkeypatch):
     assert client.request_header == {"Authorization": "Bearer abc123"}
 
 
-def test_access_token_raises_on_error_result(monkeypatch):
-    client = make_client(monkeypatch, {"error": "invalid_client"})
+# What msal actually hands back on a bad secret. The extra keys are the point: an
+# exact key-list match against ["error"] falls through this and dies on the
+# missing "access_token" instead.
+MSAL_ERROR_RESULT = {
+    "error": "invalid_client",
+    "error_description": "AADSTS7000215: Invalid client secret provided.",
+    "error_codes": [7000215],
+    "timestamp": "2026-09-05 12:00:00Z",
+    "trace_id": "00000000-0000-0000-0000-000000000000",
+    "correlation_id": "11111111-1111-1111-1111-111111111111",
+}
+
+
+@pytest.mark.parametrize(
+    "result",
+    [MSAL_ERROR_RESULT, {"error": "invalid_client"}],
+    ids=["realistic_payload", "error_key_only"],
+)
+def test_access_token_raises_on_error_result(monkeypatch, result):
+    client = make_client(monkeypatch, result)
 
     with pytest.raises(PermissionError):
         client.access_token

--- a/products/zap-opendata/tests/test_recode_id.py
+++ b/products/zap-opendata/tests/test_recode_id.py
@@ -1,9 +1,12 @@
+import json
 import logging
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
 import pytest
-from src.recode_id import ReuseTracker, convert_to_human_readable
+from src import recode_id as recode_id_module
+from src.recode_id import ReuseTracker, convert_to_human_readable, recode_id
 
 _logger = logging.getLogger("test_recode_id")
 
@@ -51,3 +54,140 @@ def test_convert_to_human_readable_raises_on_present_id_without_metadata():
             recode_tracker=ReuseTracker(),
             logger=_logger,
         )
+
+
+class StubResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self.status_code = status_code
+        self.payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self) -> dict:
+        return self.payload
+
+
+@pytest.fixture
+def stub_crm(monkeypatch, tmp_path):
+    """Stub CRM auth and HTTP for recode_id, and keep its .logs/ inside tmp_path."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        recode_id_module, "Client", lambda **kwargs: SimpleNamespace(request_header={})
+    )
+
+    def install(*responses: StubResponse) -> list[str]:
+        requested: list[str] = []
+
+        def fake_get(url, headers=None):
+            requested.append(url)
+            return responses[min(len(requested), len(responses)) - 1]
+
+        monkeypatch.setattr(recode_id_module.requests, "get", fake_get)
+        return requested
+
+    return install
+
+
+class TestRecodeId:
+    """The top-level recode loop, with the CRM stubbed.
+
+    Covers what convert_to_human_readable's own tests can't reach: the reuse cache,
+    the refresh-and-retry on a non-200, and the give-up path.
+    """
+
+    # Shaped like the $expand payload expand_url() asks for. The null contact matters:
+    # convert_to_human_readable pops metadata field names off the end, so primary
+    # applicant resolves through contact first and falls back to account.
+    expanded = {
+        "dcp_applicant_customer_account": {
+            "name": "624 Morris B, LLC",
+            "accountid": "acct-applicant",
+        },
+        "dcp_applicant_customer_contact": None,
+        "dcp_leadagencyforenvreview": {"name": "DCP", "accountid": "acct-agency"},
+        "dcp_CurrentMilestone": {
+            "dcp_name": "EAS - Project Completed",
+            "dcp_projectmilestoneid": "ms-current",
+        },
+        "dcp_currentenvironmentmilestone": {
+            "dcp_name": "EAS - Review Filed EAS",
+            "dcp_projectmilestoneid": "ms-env",
+        },
+    }
+
+    recoded_names = [
+        "624 Morris B, LLC",
+        "DCP",
+        "EAS - Project Completed",
+        "EAS - Review Filed EAS",
+    ]
+
+    def frame(self, *project_ids: str) -> pd.DataFrame:
+        return pd.DataFrame.from_records(
+            [
+                {
+                    "crm_project_id": project_id,
+                    "primary_applicant": "acct-applicant",
+                    "ceqr_leadagency": "acct-agency",
+                    "current_milestone": "ms-current",
+                    "current_envmilestone": "ms-env",
+                }
+                for project_id in project_ids
+            ]
+        )
+
+    def names(self, recoded: pd.DataFrame, row: int = 0) -> list:
+        return [recoded.loc[row, field] for field in recode_id_module.RECODE_ID_FIELDS]
+
+    def test_replaces_ids_with_names(self, stub_crm):
+        requested = stub_crm(StubResponse(self.expanded))
+
+        recoded = recode_id(self.frame("proj-1"))
+
+        assert self.names(recoded) == self.recoded_names
+        assert "proj-1" in requested[0]
+
+    def test_reuses_a_recode_across_rows(self, stub_crm):
+        """Second row hits the cache, so the CRM is queried once, not twice."""
+        requested = stub_crm(StubResponse(self.expanded))
+
+        recoded = recode_id(self.frame("proj-1", "proj-2"))
+
+        assert len(requested) == 1
+        assert self.names(recoded, row=0) == self.recoded_names
+        assert self.names(recoded, row=1) == self.recoded_names
+
+    def test_refreshes_auth_and_retries_after_non_200(self, stub_crm):
+        requested = stub_crm(
+            StubResponse({"error": "expired"}, status_code=401),
+            StubResponse(self.expanded),
+        )
+
+        recoded = recode_id(self.frame("proj-1"))
+
+        assert len(requested) == 2
+        assert self.names(recoded) == self.recoded_names
+
+    def test_gives_up_after_a_second_non_200(self, stub_crm):
+        """Row passes through with its raw ids rather than raising."""
+        requested = stub_crm(StubResponse({"error": "expired"}, status_code=401))
+
+        recoded = recode_id(self.frame("proj-1"))
+
+        assert len(requested) == 2
+        assert self.names(recoded) == [
+            "acct-applicant",
+            "acct-agency",
+            "ms-current",
+            "ms-env",
+        ]
+
+    def test_skips_rows_with_no_ids(self, stub_crm):
+        requested = stub_crm(StubResponse(self.expanded))
+        empty = self.frame("proj-1")
+        for field in recode_id_module.RECODE_ID_FIELDS:
+            empty[field] = np.nan
+
+        recoded = recode_id(empty)
+
+        assert requested == []
+        assert recoded.loc[0, "crm_project_id"] == "proj-1"

--- a/products/zap-opendata/tests/test_visible_projects.py
+++ b/products/zap-opendata/tests/test_visible_projects.py
@@ -26,8 +26,15 @@ def test_get_metadata(metadata_values):
 def test_recode_fields(fields_in_metadata, dataset_name):
     fields_to_lookup, _ = get_fields(dataset_name)
 
-    for field in fields_to_lookup:
-        assert field in fields_in_metadata
+    missing = [f for f in fields_to_lookup if f not in fields_in_metadata]
+
+    # Listing every field CRM does report is the point: a rename is usually fixed by
+    # spotting the new name in the list.
+    assert not missing, (
+        f"{dataset_name} recode fields missing from CRM metadata: {missing}\n\n"
+        f"CRM reports these {len(fields_in_metadata)} fields:\n"
+        + "\n".join(sorted(fields_in_metadata))
+    )
 
 
 @pytest.mark.skip(reason="in-progress")


### PR DESCRIPTION
Follow-up to #2604.

- **`Client.access_token` raises `PermissionError` on any msal error response.** The old `list(result.keys()) == ["error"]` never matched a real failure, which surfaced as `KeyError: 'access_token'` instead. The added test fails against the previous guard.
- **`recode_id()` has tests**, with the CRM stubbed: the reuse cache, the refresh-and-retry after a non-200, the give-up path, and rows with no ids.
- **The recode-field check reports what actually went wrong.** A throttled or failed CRM request now raises with the status code rather than a `KeyError` three lines later, and a renamed field lists every missing name alongside the fields CRM does report.
- **That check also runs in `zap_single_visible.yml`**, the workflow used to re-run one dataset after a failure.
- **The metadata URLs are built from `ZAP_DOMAIN`** rather than repeating the host as a literal, so the metadata host can't drift from the host the token is scoped to. Same value today, verified byte-identical.
- **Gate failures no longer print the bearer token.** pytest's default traceback prints each frame's arguments, and `get_metadata`'s argument is the request headers. `--tb=short` drops that and still names the missing field, the fields CRM reports, and the file and line.

Coverage of `src/recode_id.py` goes from 54% to 96%. Also corrects `request_header`'s return annotation, which said `str`.

## Notes

Error messages carry the status code, the URL and up to 500 chars of the response body, never the request headers. Actions does not mask the bearer token, which is derived from the 1Password secrets rather than being one of them, so a traceback that printed it would print it in full. Reproduced with a fake token: the default traceback logs it, `--tb=short` does not.


