### PR TITLE
replace latest instead of adding to it

### DIFF
--- a/admin/ops/clear_library_files_from_latest.py
+++ b/admin/ops/clear_library_files_from_latest.py
@@ -14,16 +14,17 @@ Datasets fall into three cases, and only the first is safe to fix by clearing:
                  still exists in its own version folder, so clearing loses nothing.
 
   mixed_version  `latest/` holds an ingest config but `<version>/` is mixed too. Caused
-                 by `--overwrite`, which replaces only the files ingest writes. Clearing
-                 `latest/` would leave `<version>/` still resolving to the `.sql`, so
-                 these want a re-ingest at a fresh version instead.
+                 by `--overwrite`, which replaces only the files ingest writes. The
+                 library files move to `<version>_library/` so both folders come out
+                 clean. Note `--overwrite` already destroyed library's own config.json
+                 and parquet at these versions, so that folder ends up partial.
 
   needs_ingest   `latest/` still holds a library config, so the dataset has a template
                  but has never been archived through ingest. Rename `<version>` to
                  `<version>_library` and re-ingest; nothing to clear.
 
-Run with no arguments to report. Pass --apply to delete, which only ever touches files
-in the clear_latest group.
+Run with no arguments to report. Pass --apply to act on clear_latest and mixed_version;
+needs_ingest is left alone because it needs a rename plus a re-ingest.
 """
 
 import argparse
@@ -35,6 +36,7 @@ from dcpy.utils import s3
 from dcpy.utils.logging import logger
 
 BUCKET = "edm-recipes"
+ACL = "public-read"  # matches what these datasets are archived with
 REPO_ROOT = Path(__file__).parent.parent.parent
 INGEST_TEMPLATES = REPO_ROOT / "ingest_templates"
 
@@ -92,14 +94,30 @@ def main(apply: bool) -> None:
             print(f"  {dataset_id:38} {str(version):12} {', '.join(stale)}")
 
     to_clear = cases.get("clear_latest", [])
+    to_move = cases.get("mixed_version", [])
     if not apply:
         print(
-            f"\nreport only. --apply would delete {sum(len(s) for _, _, s in to_clear)} "
-            f"files across {len(to_clear)} datasets in clear_latest."
+            f"\nreport only. --apply would clear "
+            f"{sum(len(stale) for _, _, stale in to_clear)} files from latest/ across "
+            f"{len(to_clear)} datasets, and move library files into <version>_library/ "
+            f"for {len(to_move)} datasets."
         )
         return
 
     for dataset_id, _, stale in to_clear:
+        for filename in stale:
+            key = f"datasets/{dataset_id}/latest/{filename}"
+            logger.info(f"deleting {key}")
+            s3.delete(BUCKET, key)
+
+    for dataset_id, version, stale in to_move:
+        versioned = _folder_files(f"datasets/{dataset_id}/{version}")
+        for filename in (f for f in versioned if not _is_ingest_output(f)):
+            src = f"datasets/{dataset_id}/{version}/{filename}"
+            dest = f"datasets/{dataset_id}/{version}_library/{filename}"
+            logger.info(f"moving {src} -> {dest}")
+            s3.copy_file(BUCKET, src, dest, acl=ACL)
+            s3.delete(BUCKET, src)
         for filename in stale:
             key = f"datasets/{dataset_id}/latest/{filename}"
             logger.info(f"deleting {key}")

--- a/admin/ops/clear_library_files_from_latest.py
+++ b/admin/ops/clear_library_files_from_latest.py
@@ -36,7 +36,8 @@ from dcpy.utils import s3
 from dcpy.utils.logging import logger
 
 BUCKET = "edm-recipes"
-ACL = "public-read"  # matches what these datasets are archived with
+# matches what these datasets are archived with
+ARCHIVE_ACL: s3.ACL = "public-read"
 REPO_ROOT = Path(__file__).parent.parent.parent
 INGEST_TEMPLATES = REPO_ROOT / "ingest_templates"
 
@@ -51,6 +52,46 @@ def _is_ingest_output(filename: str) -> bool:
 
 def _folder_files(prefix: str) -> list[str]:
     return [f for f in s3.get_filenames(BUCKET, prefix) if f and not f.endswith("/")]
+
+
+def _versions(dataset_id: str) -> list[str]:
+    return [v.strip("/") for v in s3.get_subfolders(BUCKET, f"datasets/{dataset_id}/")]
+
+
+def _is_duplicated_elsewhere(dataset_id: str, filename: str, etag: str) -> bool:
+    """Is this `latest/` file byte-identical to one in a version folder?
+
+    `latest/` is a copy of some archive, so its files should exist under a version too.
+    Clearing one that doesn't would be the only way to actually lose data here.
+    """
+    for version in _versions(dataset_id):
+        if version == "latest":
+            continue
+        try:
+            other = s3.client().head_object(
+                Bucket=BUCKET, Key=f"datasets/{dataset_id}/{version}/{filename}"
+            )
+        except Exception:
+            continue
+        if other["ETag"] == etag:
+            return True
+    return False
+
+
+def unduplicated(dataset_id: str, stale: list[str]) -> list[str]:
+    """Stale files with no copy in any version folder. These are never cleared."""
+    orphans = []
+    for filename in stale:
+        try:
+            etag = s3.client().head_object(
+                Bucket=BUCKET, Key=f"datasets/{dataset_id}/latest/{filename}"
+            )["ETag"]
+        except Exception:
+            orphans.append(filename)
+            continue
+        if not _is_duplicated_elsewhere(dataset_id, filename, etag):
+            orphans.append(filename)
+    return orphans
 
 
 def classify(dataset_id: str) -> tuple[str, str | None, list[str]]:
@@ -96,6 +137,19 @@ def main(apply: bool) -> None:
     to_clear = cases.get("clear_latest", [])
     to_move = cases.get("mixed_version", [])
     if not apply:
+        orphaned = {
+            dataset_id: orphans
+            for dataset_id, _, stale in to_clear
+            if (orphans := unduplicated(dataset_id, stale))
+        }
+        if orphaned:
+            print(
+                f"\nno copy in any version folder, will not be cleared ({len(orphaned)})"
+            )
+            for dataset_id, orphans in orphaned.items():
+                print(f"  {dataset_id:38} {', '.join(orphans)}")
+        else:
+            print("\nevery clear_latest file has a copy in a version folder")
         print(
             f"\nreport only. --apply would clear "
             f"{sum(len(stale) for _, _, stale in to_clear)} files from latest/ across "
@@ -105,7 +159,14 @@ def main(apply: bool) -> None:
         return
 
     for dataset_id, _, stale in to_clear:
+        orphans = unduplicated(dataset_id, stale)
         for filename in stale:
+            if filename in orphans:
+                logger.warning(
+                    f"keeping datasets/{dataset_id}/latest/{filename}: no copy found "
+                    "in any version folder"
+                )
+                continue
             key = f"datasets/{dataset_id}/latest/{filename}"
             logger.info(f"deleting {key}")
             s3.delete(BUCKET, key)
@@ -116,7 +177,7 @@ def main(apply: bool) -> None:
             src = f"datasets/{dataset_id}/{version}/{filename}"
             dest = f"datasets/{dataset_id}/{version}_library/{filename}"
             logger.info(f"moving {src} -> {dest}")
-            s3.copy_file(BUCKET, src, dest, acl=ACL)
+            s3.copy_file(BUCKET, src, dest, acl=ARCHIVE_ACL)
             s3.delete(BUCKET, src)
         for filename in stale:
             key = f"datasets/{dataset_id}/latest/{filename}"

--- a/admin/ops/clear_library_files_from_latest.py
+++ b/admin/ops/clear_library_files_from_latest.py
@@ -1,0 +1,112 @@
+"""
+Reports, and optionally clears, library-era files left in ingest datasets' `latest/`
+folders in edm-recipes. See issue #2613.
+
+Ingest writes only `{id}.parquet` and `config.json`. Until #2618 it added those to
+`latest/` without clearing, so anything an earlier library archive left there survived.
+`RECIPE_FILE_TYPE_PREFERENCE` puts pg_dump ahead of parquet and matches on extension
+alone, so a leftover `.sql` beside a new parquet is silently preferred.
+
+Datasets fall into three cases, and only the first is safe to fix by clearing:
+
+  clear_latest   `latest/` holds an ingest config and the matching `<version>/` folder
+                 is clean. The stale files are copies of an older library archive that
+                 still exists in its own version folder, so clearing loses nothing.
+
+  mixed_version  `latest/` holds an ingest config but `<version>/` is mixed too. Caused
+                 by `--overwrite`, which replaces only the files ingest writes. Clearing
+                 `latest/` would leave `<version>/` still resolving to the `.sql`, so
+                 these want a re-ingest at a fresh version instead.
+
+  needs_ingest   `latest/` still holds a library config, so the dataset has a template
+                 but has never been archived through ingest. Rename `<version>` to
+                 `<version>_library` and re-ingest; nothing to clear.
+
+Run with no arguments to report. Pass --apply to delete, which only ever touches files
+in the clear_latest group.
+"""
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+from dcpy.utils import s3
+from dcpy.utils.logging import logger
+
+BUCKET = "edm-recipes"
+REPO_ROOT = Path(__file__).parent.parent.parent
+INGEST_TEMPLATES = REPO_ROOT / "ingest_templates"
+
+# what ingest itself writes; everything else in the folder came from somewhere earlier
+INGEST_WRITES = (".parquet",)
+CONFIG = "config.json"
+
+
+def _is_ingest_output(filename: str) -> bool:
+    return filename == CONFIG or filename.endswith(INGEST_WRITES)
+
+
+def _folder_files(prefix: str) -> list[str]:
+    return [f for f in s3.get_filenames(BUCKET, prefix) if f and not f.endswith("/")]
+
+
+def classify(dataset_id: str) -> tuple[str, str | None, list[str]]:
+    """Returns (case, version, stale filenames in latest/)."""
+    latest = _folder_files(f"datasets/{dataset_id}/latest")
+    if not latest:
+        return "no_archive", None, []
+    stale = sorted(f for f in latest if not _is_ingest_output(f))
+    if not stale:
+        return "already_clean", None, []
+    try:
+        raw = (
+            s3.client()
+            .get_object(Bucket=BUCKET, Key=f"datasets/{dataset_id}/latest/{CONFIG}")[
+                "Body"
+            ]
+            .read()
+        )
+        config = json.loads(raw)
+    except Exception:
+        return "unreadable_config", None, stale
+    if "id" not in config:  # library configs nest everything under "dataset"
+        return "needs_ingest", config.get("dataset", {}).get("version"), stale
+    version = config.get("version")
+    versioned = _folder_files(f"datasets/{dataset_id}/{version}")
+    if all(_is_ingest_output(f) for f in versioned):
+        return "clear_latest", version, stale
+    return "mixed_version", version, stale
+
+
+def main(apply: bool) -> None:
+    cases: dict[str, list] = defaultdict(list)
+    for path in sorted(INGEST_TEMPLATES.glob("*.yml")):
+        case, version, stale = classify(path.stem)
+        if case not in ("already_clean", "no_archive"):
+            cases[case].append((path.stem, version, stale))
+
+    for case in sorted(cases):
+        print(f"\n{case} ({len(cases[case])})")
+        for dataset_id, version, stale in cases[case]:
+            print(f"  {dataset_id:38} {str(version):12} {', '.join(stale)}")
+
+    to_clear = cases.get("clear_latest", [])
+    if not apply:
+        print(
+            f"\nreport only. --apply would delete {sum(len(s) for _, _, s in to_clear)} "
+            f"files across {len(to_clear)} datasets in clear_latest."
+        )
+        return
+
+    for dataset_id, _, stale in to_clear:
+        for filename in stale:
+            key = f"datasets/{dataset_id}/latest/{filename}"
+            logger.info(f"deleting {key}")
+            s3.delete(BUCKET, key)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="actually delete")
+    main(parser.parse_args().apply)

--- a/dcpy/connectors/ingest_datastore.py
+++ b/dcpy/connectors/ingest_datastore.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -57,17 +58,32 @@ class Connector(VersionedConnector, arbitrary_types_allowed=True):
             )
 
             if latest:
-                latest_folder_path = f"{key}/latest"
-                self.storage.push(
-                    f"{latest_folder_path}/{filepath.name}",
-                    filepath=filepath,
-                    acl=acl,
+                self.push_latest(
+                    key, filepath=filepath, config_path=config_path, acl=acl
                 )
-                self.storage.push(
-                    f"{latest_folder_path}/config.json",
-                    filepath=config_path,
-                    acl=acl,
-                )
+        return {}
+
+    def push_latest(
+        self,
+        key: str,
+        *,
+        filepath: Path,
+        config_path: Path,
+        acl: str | None = None,
+    ) -> dict:
+        """Point `latest` at one archive's files.
+
+        Pushed as a folder so it replaces whatever was there. Writing the files
+        individually leaves everything else in place, and a library-era .sql sitting
+        beside a new parquet wins file-type resolution, so consumers silently keep
+        reading the older archive.
+        """
+        with TemporaryDirectory() as tmp_dir:
+            latest_dir = Path(tmp_dir) / "latest"
+            latest_dir.mkdir()
+            shutil.copy(filepath, latest_dir / filepath.name)
+            shutil.copy(config_path, latest_dir / config_filename)
+            self.storage.push(f"{key}/latest", filepath=latest_dir, acl=acl)
         return {}
 
     def push_versioned(self, key: str, version: str, **kwargs) -> dict:

--- a/dcpy/lifecycle/ingest/run.py
+++ b/dcpy/lifecycle/ingest/run.py
@@ -240,6 +240,18 @@ def archive_transformed_datasets(
                 overwrite=overwrite_okay,
                 latest=latest,
             )
+        elif latest:
+            # --latest is its own request: point latest at this archive even when the
+            # versioned copy is already there and doesn't need rewriting.
+            logger.info(
+                f"Version already archived, pointing latest at {dataset.version}"
+            )
+            datastore.push_latest(
+                dataset.id,
+                filepath=dataset_folder / dataset.filename,
+                config_path=dataset_folder / INGESTED_DATASET_FILENAME,
+                acl=dataset.source.acl,
+            )
         else:
             logger.info("Skipping archival")
 

--- a/dcpy/test/connectors/test_ingest_datastore.py
+++ b/dcpy/test/connectors/test_ingest_datastore.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+from dcpy.connectors.hybrid_pathed_storage import PathedStorageConnector, StorageType
+from dcpy.connectors.ingest_datastore import Connector as IngestDatastoreConnector
+from dcpy.test.lifecycle.ingest.shared import DOWNSTREAM_DATASET_1, TEST_OUTPUT
+
+
+@pytest.fixture
+def connector(tmp_path):
+    return IngestDatastoreConnector(
+        storage=PathedStorageConnector.from_storage_kwargs(
+            conn_type="test_ingest_datastore.local",
+            storage_backend=StorageType.LOCAL,
+            local_dir=Path(tmp_path),
+            _validate_root_path=True,
+        )
+    )
+
+
+def test_push_latest_replaces_earlier_files(
+    connector: IngestDatastoreConnector, tmp_path: Path
+):
+    """`latest` mirrors one archive, so a prior archive's files must not survive.
+
+    A library-era `.sql` left beside the new parquet wins file-type resolution, which
+    silently points consumers at the older archive.
+    """
+    ds = DOWNSTREAM_DATASET_1
+    latest = tmp_path / ds.id / "latest"
+    latest.mkdir(parents=True)
+    (latest / f"{ds.id}.sql").write_text("-- archived by library")
+    (latest / "config.yml").write_text("dataset:\n  name: leftover\n")
+
+    connector.push_versioned(
+        key=ds.id, version=ds.version, config=ds, filepath=TEST_OUTPUT, latest=True
+    )
+
+    assert sorted(p.name for p in latest.iterdir()) == [
+        "config.json",
+        TEST_OUTPUT.name,
+    ], "latest should hold only what this archive wrote"
+
+
+def test_push_latest_is_independent_of_the_versioned_archive(
+    connector: IngestDatastoreConnector, tmp_path: Path
+):
+    """`latest` can be repointed without rewriting the versioned copy.
+
+    Ingest skips archival when a version is already present and unchanged, so
+    refreshing `latest` has to work on its own or the pointer goes stale.
+    """
+    ds = DOWNSTREAM_DATASET_1
+    latest = tmp_path / ds.id / "latest"
+    latest.mkdir(parents=True)
+    (latest / f"{ds.id}.sql").write_text("-- archived by library")
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}")
+    connector.push_latest(ds.id, filepath=TEST_OUTPUT, config_path=config_path)
+
+    assert sorted(p.name for p in latest.iterdir()) == ["config.json", TEST_OUTPUT.name]
+    assert not (tmp_path / ds.id / ds.version).exists(), (
+        "refreshing latest should not create the versioned archive"
+    )


### PR DESCRIPTION
part of #2613

`latest/` accumulates instead of being replaced. `_push` writes two files into it and leaves whatever else is there, so a library-era `.sql` ends up beside the new parquet and wins `RECIPE_FILE_TYPE_PREFERENCE`, which matches on extension alone. Consumers without an explicit `file_type` then silently keep reading the older archive. That bit three times in #2614. Pushing `latest/` as a folder replaces it wholesale, reusing the replace semantics `PathedStorageConnector.push` already has for directories.

`--latest` also needs to work on its own. Archival is skipped when a version already exists with unchanged data, and `latest` was only ever written inside that push, so re-running with `--latest` could leave the pointer on an older version and still report success.

Neither change helps a dataset that isn't re-ingested, so `admin/ops/clear_library_files_from_latest.py` handles the 81 existing folders. It reports by default and sorts them three ways:

- **clear_latest (45)** — `<version>/` is already clean, so only `latest/` needs clearing
- **mixed_version (6)** — `<version>/` is mixed too, so library files move to `<version>_library/` first
- **needs_ingest (30)** — never archived through ingest; needs a rename plus an ingest run, so `--apply` leaves these alone

Before deleting anything from `latest/` it checks each file has a byte-identical copy in a version folder, and skips any that doesn't. `latest/` is a copy of some archive, so that should always hold, but it's the one way this could actually lose data.

All 6 `mixed_version` datasets got that way from `--overwrite`, four of them during #2614. Worth knowing that flag is lossy rather than just messy: it replaces only the files ingest writes, so library's own `config.json` and `.parquet` are overwritten while its `.sql` and `.csv` survive.
